### PR TITLE
feat: add KINDLY_CHROME_PROXY env var for headless Chromium proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,3 +72,11 @@ KINDLY_NODRIVER_PORT_RANGE=
 # - Default: disabled in the worker for reliability
 # - Set to 1 to re-enable sandbox (more secure, may break in containers)
 KINDLY_NODRIVER_SANDBOX=0
+
+# Chromium proxy for universal HTML loading
+# Passed directly as --proxy-server to Chromium. Supports http://, socks5://, etc.
+# Useful when the headless browser needs to route traffic through a proxy to reach the internet.
+# Examples:
+#   KINDLY_CHROME_PROXY=socks5://127.0.0.1:1080
+#   KINDLY_CHROME_PROXY=http://proxy.example.com:8080
+KINDLY_CHROME_PROXY=

--- a/.env.example
+++ b/.env.example
@@ -80,3 +80,12 @@ KINDLY_NODRIVER_SANDBOX=0
 #   KINDLY_CHROME_PROXY=socks5://127.0.0.1:1080
 #   KINDLY_CHROME_PROXY=http://proxy.example.com:8080
 KINDLY_CHROME_PROXY=
+#
+# Proxy bypass list (comma-separated). Hosts matching these patterns bypass the proxy.
+# Uses Chromium's --proxy-bypass-list syntax:
+#   - Exact host: localhost, 127.0.0.1
+#   - Wildcard: *.example.com, .local
+#   - Suffix match: [::1] (IPv6 loopback)
+# Example:
+#   KINDLY_CHROME_PROXY_BYPASS=localhost,127.0.0.1,*.internal
+KINDLY_CHROME_PROXY_BYPASS=

--- a/README.md
+++ b/README.md
@@ -595,6 +595,25 @@ Windows (PowerShell):
 $env:KINDLY_BROWSER_EXECUTABLE_PATH="C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"
 ```
 
+## Chromium proxy (optional)
+
+Set `KINDLY_CHROME_PROXY` to route all headless Chromium traffic (used for `page_content` extraction) through a proxy server. The value is passed directly as Chromium's `--proxy-server` flag.
+
+Supported schemes: `http://`, `https://`, `socks5://`, `socks4://`.
+
+```bash
+export KINDLY_CHROME_PROXY="socks5://127.0.0.1:1080"
+```
+
+When running in Docker, use `host.docker.internal` instead of `127.0.0.1` to reach the host:
+```bash
+docker run ... -e KINDLY_CHROME_PROXY="socks5://host.docker.internal:1080" ...
+```
+
+This only affects Chromium-based `page_content` extraction. Search API calls (Serper, Tavily, SearXNG) use `httpx` and respect standard `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` environment variables instead.
+
+Note: Chromium's `--proxy-server` does not support embedded credentials (e.g. `socks5://user:pass@host:port` will not work). If your proxy requires authentication, set up a local credential-less proxy forwarder (e.g. SSH tunnel, `gost`, `socat`) and point `KINDLY_CHROME_PROXY` to the local endpoint.
+
 ## Remote / Docker deployment (separate machine)
 
 Whether you can run the MCP server on a different PC depends on your MCP client:
@@ -613,6 +632,7 @@ Run the server (port `8000`):
 docker run --rm -p 8000:8000 \
   -e SERPER_API_KEY="..." \
   -e GITHUB_TOKEN="..." \
+  -e KINDLY_CHROME_PROXY="socks5://host.docker.internal:1080" \
   kindly-web-search-mcp-server \
   --http --host 0.0.0.0 --port 8000
 ```
@@ -622,6 +642,7 @@ docker run --rm -p 8000:8000 \
 docker run --rm -p 8000:8000 \
   -e TAVILY_API_KEY="..." \
   -e GITHUB_TOKEN="..." \
+  -e KINDLY_CHROME_PROXY="socks5://host.docker.internal:1080" \
   kindly-web-search-mcp-server \
   --http --host 0.0.0.0 --port 8000
 ```

--- a/README.md
+++ b/README.md
@@ -614,6 +614,20 @@ This only affects Chromium-based `page_content` extraction. Search API calls (Se
 
 Note: Chromium's `--proxy-server` does not support embedded credentials (e.g. `socks5://user:pass@host:port` will not work). If your proxy requires authentication, set up a local credential-less proxy forwarder (e.g. SSH tunnel, `gost`, `socat`) and point `KINDLY_CHROME_PROXY` to the local endpoint.
 
+### Proxy bypass list
+
+Set `KINDLY_CHROME_PROXY_BYPASS` to exclude specific hosts from the proxy. The value is passed directly as Chromium's `--proxy-bypass-list` flag (comma-separated). Syntax:
+
+- Exact host: `localhost`, `127.0.0.1`
+- Wildcard suffix: `*.example.com`, `.local`
+- IPv6: `[::1]`
+
+```bash
+export KINDLY_CHROME_PROXY_BYPASS="localhost,127.0.0.1,*.internal"
+```
+
+When unset, Chromium uses its default bypass list (which includes `localhost` and `127.0.0.1`).
+
 ## Remote / Docker deployment (separate machine)
 
 Whether you can run the MCP server on a different PC depends on your MCP client:

--- a/src/kindly_web_search_mcp_server/scrape/nodriver_worker.py
+++ b/src/kindly_web_search_mcp_server/scrape/nodriver_worker.py
@@ -478,6 +478,10 @@ def _resolve_chrome_proxy() -> str:
     return raw
 
 
+def _resolve_chrome_proxy_bypass() -> str:
+    return (os.environ.get("KINDLY_CHROME_PROXY_BYPASS") or "").strip()
+
+
 def _build_chromium_launch_args(
     *,
     base_browser_args: list[str],
@@ -506,6 +510,9 @@ def _build_chromium_launch_args(
     proxy = _resolve_chrome_proxy()
     if proxy:
         args.append(f"--proxy-server={proxy}")
+    bypass = _resolve_chrome_proxy_bypass()
+    if bypass:
+        args.append(f"--proxy-bypass-list={bypass}")
 
     # Append the base args last to preserve existing behavior (and allow overrides),
     # while avoiding duplicates that can confuse Chromium.

--- a/src/kindly_web_search_mcp_server/scrape/nodriver_worker.py
+++ b/src/kindly_web_search_mcp_server/scrape/nodriver_worker.py
@@ -473,6 +473,11 @@ def _resolve_snap_backoff_multiplier() -> float:
     return max(1.0, min(value, 20.0))
 
 
+def _resolve_chrome_proxy() -> str:
+    raw = (os.environ.get("KINDLY_CHROME_PROXY") or "").strip()
+    return raw
+
+
 def _build_chromium_launch_args(
     *,
     base_browser_args: list[str],
@@ -497,6 +502,10 @@ def _build_chromium_launch_args(
         f"--user-agent={user_agent}",
         *([] if sandbox_enabled else ["--no-sandbox"]),
     ]
+
+    proxy = _resolve_chrome_proxy()
+    if proxy:
+        args.append(f"--proxy-server={proxy}")
 
     # Append the base args last to preserve existing behavior (and allow overrides),
     # while avoiding duplicates that can confuse Chromium.


### PR DESCRIPTION
## Summary

- Add `KINDLY_CHROME_PROXY` environment variable to route all headless Chromium traffic through a proxy server
- The value is passed directly as Chromium's `--proxy-server` flag, supporting `http://`, `socks5://`, `socks4://`, and other schemes
- Update README with new "Chromium proxy" section, Docker deployment examples, and credential limitation note
- Update `.env.example` with the new variable

## Motivation

When running the MCP server in environments that require a proxy to access the internet (e.g. corporate networks, Docker containers behind a SOCKS5 proxy), the headless Chromium used for `page_content` extraction has no way to configure proxy settings. Browser extensions like SwitchyOmega cannot be loaded in headless mode, and Chromium creates a fresh temporary profile on each launch.

## Changes

- `src/kindly_web_search_mcp_server/scrape/nodriver_worker.py`: add `_resolve_chrome_proxy()` helper, inject `--proxy-server` into `_build_chromium_launch_args`
- `README.md`: new "Chromium proxy" section with usage, Docker examples, and credential auth note; updated Docker deployment examples
- `.env.example`: add `KINDLY_CHROME_PROXY` entry with comments

## Test plan

- [x] Built Docker image with patch, configured with `KINDLY_CHROME_PROXY=socks5://host.docker.internal:1081`
- [x] SearXNG search works via `SEARXNG_BASE_URL`
- [x] `get_content("https://httpbin.org/ip")` returns the proxy's exit IP, confirming `--proxy-server` is effective

🤖 Generated with [Claude Code](https://claude.com/claude-code)