### PR TITLE
Add Sofya as a search provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,8 @@
 # Required: provide at least one search provider key
 SERPER_API_KEY=
 TAVILY_API_KEY=
+# Sofya web search (https://sofya.co)
+SOFYA_API_KEY=
 # Alternative: self-hosted SearXNG instance (base URL, e.g. https://searx.example.org)
 SEARXNG_BASE_URL=
 # Optional SearXNG request settings

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ We built Kindly Web Search because we needed our AI assistants to work the way *
 
 ✅ **Passes all useful content to the LLM immediately** - no need for a second scraping call
 
-✅ **Supports multiple search providers** (Serper and Tavily) with intelligent fallback
+✅ **Supports multiple search providers** (Serper, Tavily, SearXNG, and Sofya) with intelligent fallback
 
 Now, when Claude Code or Codex searches for that GPU batch error, it gets the question *and* the answers. The code snippets. The "this fixed it for me" comments. Everything it needs to help you solve the problem - **in one call**.
 
@@ -98,10 +98,10 @@ Kindly has been our daily companion in production work for months, saving us cou
 - `web_search(query, num_results=3)` → top results with `title`, `link`, `snippet`, and `page_content` (Markdown, best-effort).
 - `get_content(url)` → `page_content` (Markdown, best-effort).
 
-Search uses **Serper** (primary, if configured) or **Tavily**, and page extraction uses a local Chromium-based browser via `nodriver`.
+Search uses **Serper** (primary, if configured), **Tavily**, **SearXNG**, or **Sofya**, and page extraction uses a local Chromium-based browser via `nodriver`.
 
 ## Requirements
-- A search provider (priority order): `SERPER_API_KEY` (recommended) → `TAVILY_API_KEY` → `SEARXNG_BASE_URL` (self-hosted SearXNG)
+- A search provider (priority order): `SERPER_API_KEY` (recommended) → `TAVILY_API_KEY` → `SEARXNG_BASE_URL` (self-hosted SearXNG) → `SOFYA_API_KEY`
 - A Chromium-based browser installed on the same machine running the MCP client (Chrome/Chromium/Edge/Brave)
   - Without a browser: specialized sources (StackExchange, GitHub Issues/Discussions, Wikipedia, arXiv) still work well, but universal HTML `page_content` extraction may fail for other sites.
 - Highly recommended: `GITHUB_TOKEN` (renders GitHub Issues in a much more LLM-friendly format: question + answers/comments + reactions/metadata; fewer rate limits)
@@ -159,7 +159,7 @@ which chromium
 Other Linux distros: install `chromium` (or `chromium-browser`) via your package manager.
 
 ### 3) Set your search API key (required)
-Set **one** of these. Provider selection order is: Serper → Tavily → SearXNG.
+Set **one** of these. Provider selection order is: Serper → Tavily → SearXNG → Sofya.
 
 macOS / Linux:
 ```bash
@@ -211,7 +211,7 @@ Make sure your API keys are set in the same shell/OS environment that launches t
 ## Client setup
 
 ### Codex
-Set one of `SERPER_API_KEY`, `TAVILY_API_KEY`, or `SEARXNG_BASE_URL`.
+Set one of `SERPER_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, or `SOFYA_API_KEY`.
 
 CLI (no file editing) — add a local stdio MCP server:
 
@@ -277,7 +277,7 @@ startup_timeout_sec = 120.0
 ```
 
 ### Claude Code
-Set one of `SERPER_API_KEY`, `TAVILY_API_KEY`, or `SEARXNG_BASE_URL`.
+Set one of `SERPER_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, or `SOFYA_API_KEY`.
 
 CLI (no file editing) — add a local stdio MCP server:
 
@@ -366,7 +366,7 @@ Create/edit `.mcp.json` (project scope; recommended for teams):
 ```
 
 ### Gemini CLI
-Set one of `SERPER_API_KEY`, `TAVILY_API_KEY`, or `SEARXNG_BASE_URL`.
+Set one of `SERPER_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, or `SOFYA_API_KEY`.
 Edit `~/.gemini/settings.json` (or `.gemini/settings.json` in a project):
 ```json
 {
@@ -393,7 +393,7 @@ Edit `~/.gemini/settings.json` (or `.gemini/settings.json` in a project):
 ```
 
 ### OpenClaw
-Set one of `SERPER_API_KEY`, `TAVILY_API_KEY`, or `SEARXNG_BASE_URL`.
+Set one of `SERPER_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, or `SOFYA_API_KEY`.
 If `mcporter` is not installed yet: `npm i -g mcporter`.
 mcporter docs: https://github.com/steipete/mcporter/blob/main/docs/config.md
 
@@ -449,7 +449,7 @@ openclaw gateway restart
 ```
 
 ### Antigravity (Google IDE)
-Set one of `SERPER_API_KEY`, `TAVILY_API_KEY`, or `SEARXNG_BASE_URL`.
+Set one of `SERPER_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, or `SOFYA_API_KEY`.
 
 In Antigravity, open the MCP store, then:
 1. Click **Manage MCP Servers**
@@ -484,7 +484,7 @@ If the first start is slow, run the `uvx` command from Quickstart once in a term
 Don’t commit/share `mcp_config.json` if it contains API keys.
 
 ### Cursor
-Set one of `SERPER_API_KEY`, `TAVILY_API_KEY`, or `SEARXNG_BASE_URL`.
+Set one of `SERPER_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, or `SOFYA_API_KEY`.
 Startup timeout: Cursor does not currently expose a per-server startup timeout setting. If the first run is slow, run the `uvx` command from Quickstart once in a terminal to prebuild the tool environment, then restart Cursor.
 Create `.cursor/mcp.json`:
 ```json

--- a/src/kindly_web_search_mcp_server/search/__init__.py
+++ b/src/kindly_web_search_mcp_server/search/__init__.py
@@ -1,4 +1,4 @@
-"""Search providers (Serper → Tavily → SearXNG)."""
+"""Search providers (Serper → Tavily → SearXNG → Sofya)."""
 from __future__ import annotations
 
 import os
@@ -10,6 +10,7 @@ from ..models import WebSearchResult
 from ..utils.diagnostics import Diagnostics
 from .searxng import search_searxng
 from .serper import search_serper
+from .sofya import search_sofya
 from .tavily import search_tavily
 
 
@@ -29,6 +30,10 @@ def _has_searxng_config() -> bool:
     return bool(os.environ.get("SEARXNG_BASE_URL", "").strip())
 
 
+def _has_sofya_key() -> bool:
+    return bool(os.environ.get("SOFYA_API_KEY", "").strip())
+
+
 async def search_web(
     query: str,
     *,
@@ -37,19 +42,21 @@ async def search_web(
     diagnostics: Diagnostics | None = None,
 ) -> list[WebSearchResult]:
     """
-    Search the web using Serper, Tavily, or SearXNG.
+    Search the web using Serper, Tavily, SearXNG, or Sofya.
 
     Selection (strict order, no cross-provider fallback):
     - If SERPER_API_KEY is set: use Serper.
     - Else if TAVILY_API_KEY is set: use Tavily.
     - Else if SEARXNG_BASE_URL is set: use SearXNG.
+    - Else if SOFYA_API_KEY is set: use Sofya.
     """
     has_serper = _has_serper_key()
     has_tavily = _has_tavily_key()
     has_searxng = _has_searxng_config()
-    if not has_serper and not has_tavily and not has_searxng:
+    has_sofya = _has_sofya_key()
+    if not has_serper and not has_tavily and not has_searxng and not has_sofya:
         raise WebSearchProviderError(
-            "No web search provider is configured. Set SERPER_API_KEY, TAVILY_API_KEY, or SEARXNG_BASE_URL."
+            "No web search provider is configured. Set SERPER_API_KEY, TAVILY_API_KEY, SEARXNG_BASE_URL, or SOFYA_API_KEY."
         )
 
     provider: Callable[..., Awaitable[list[WebSearchResult]]]
@@ -59,9 +66,12 @@ async def search_web(
     elif has_tavily:
         provider = search_tavily
         provider_name = "tavily"
-    else:
+    elif has_searxng:
         provider = search_searxng
         provider_name = "searxng"
+    else:
+        provider = search_sofya
+        provider_name = "sofya"
 
     if diagnostics:
         diagnostics.emit(
@@ -74,6 +84,7 @@ async def search_web(
                 "has_serper_key": has_serper,
                 "has_tavily_key": has_tavily,
                 "has_searxng_config": has_searxng,
+                "has_sofya_key": has_sofya,
             },
         )
 

--- a/src/kindly_web_search_mcp_server/search/sofya.py
+++ b/src/kindly_web_search_mcp_server/search/sofya.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+from ..models import WebSearchResult
+
+
+class SofyaError(RuntimeError):
+    pass
+
+
+class SofyaConfigError(SofyaError):
+    pass
+
+
+def _get_sofya_api_key() -> str:
+    api_key = os.environ.get("SOFYA_API_KEY", "").strip()
+    if not api_key:
+        raise SofyaConfigError(
+            "SOFYA_API_KEY is not set. Configure it as an environment variable in your IDE/run configuration."
+        )
+    return api_key
+
+
+async def search_sofya(
+    query: str,
+    *,
+    num_results: int,
+    http_client: httpx.AsyncClient | None = None,
+) -> list[WebSearchResult]:
+    """
+    Query Sofya Search API and return parsed results.
+
+    Sofya endpoint:
+    - POST https://sofya.co/v1/search
+    - Header: Authorization: Bearer <SOFYA_API_KEY>
+    - JSON: {"query": "<query>", "max_results": <num_results>, "search_depth": "snippets"}
+
+    Docs: https://sofya.co/docs
+    """
+    if not query.strip():
+        return []
+
+    if num_results < 1:
+        return []
+
+    api_key = _get_sofya_api_key()
+    url = "https://sofya.co/v1/search"
+    payload = {
+        "query": query,
+        "max_results": int(num_results),
+        "search_depth": "snippets",
+    }
+    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+
+    async def _do_request(client: httpx.AsyncClient) -> dict[str, Any]:
+        resp = await client.post(url, headers=headers, json=payload)
+        resp.raise_for_status()
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            raise SofyaError("Sofya response was not valid JSON.") from exc
+        if not isinstance(data, dict):
+            raise SofyaError("Sofya response was not a JSON object.")
+        return data
+
+    if http_client is None:
+        async with httpx.AsyncClient(timeout=30) as client:
+            data = await _do_request(client)
+    else:
+        data = await _do_request(http_client)
+
+    raw_results = data.get("results", [])
+    if not isinstance(raw_results, list):
+        raise SofyaError("Sofya response missing `results` list.")
+
+    results: list[WebSearchResult] = []
+    for item in raw_results:
+        if not isinstance(item, dict):
+            continue
+        title = item.get("title")
+        link = item.get("url")
+        snippet = item.get("content")
+        if not isinstance(title, str) or not isinstance(link, str) or not isinstance(snippet, str):
+            continue
+
+        # `page_content` is populated later by the MCP tool (best-effort).
+        results.append(WebSearchResult(title=title, link=link, snippet=snippet, page_content=""))
+        if len(results) >= num_results:
+            break
+
+    return results

--- a/tests/test_search_router.py
+++ b/tests/test_search_router.py
@@ -116,12 +116,32 @@ class TestSearchRouter(unittest.IsolatedAsyncioTestCase):
         mock_tavily.assert_not_awaited()
         mock_searxng.assert_not_awaited()
 
+    async def test_uses_sofya_when_only_sofya_key(self) -> None:
+        from kindly_web_search_mcp_server.search import search_web
+
+        os.environ.pop("SERPER_API_KEY", None)
+        os.environ.pop("TAVILY_API_KEY", None)
+        os.environ.pop("SEARXNG_BASE_URL", None)
+        os.environ["SOFYA_API_KEY"] = "sofya_test"
+
+        with patch(
+            "kindly_web_search_mcp_server.search.search_sofya", new_callable=AsyncMock
+        ) as mock_sofya:
+            mock_sofya.return_value = [
+                WebSearchResult(title="So", link="https://sofya.example", snippet="sn", page_content="")
+            ]
+            out = await search_web("q", num_results=1)
+
+        self.assertEqual(out[0].link, "https://sofya.example")
+        mock_sofya.assert_awaited()
+
     async def test_raises_when_no_provider_configured(self) -> None:
         from kindly_web_search_mcp_server.search import WebSearchProviderError, search_web
 
         os.environ.pop("SERPER_API_KEY", None)
         os.environ.pop("TAVILY_API_KEY", None)
         os.environ.pop("SEARXNG_BASE_URL", None)
+        os.environ.pop("SOFYA_API_KEY", None)
 
         with self.assertRaises(WebSearchProviderError):
             await search_web("q", num_results=1)

--- a/tests/test_sofya_unit.py
+++ b/tests/test_sofya_unit.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+import anyio
+import httpx
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+
+class TestSofyaParsing(unittest.TestCase):
+    def test_search_sofya_parses_results(self) -> None:
+        async def run() -> None:
+            os.environ["SOFYA_API_KEY"] = "sofya_test"
+
+            from kindly_web_search_mcp_server.search.sofya import search_sofya
+
+            sofya_payload = {
+                "query": "leo messi",
+                "results": [
+                    {
+                        "title": "Lionel Messi Facts | Britannica",
+                        "url": "https://www.britannica.com/facts/Lionel-Messi",
+                        "content": "Lionel Messi, an Argentine footballer...",
+                    }
+                ],
+            }
+
+            def handler(request: httpx.Request) -> httpx.Response:
+                self.assertEqual(request.method, "POST")
+                self.assertEqual(str(request.url), "https://sofya.co/v1/search")
+                self.assertEqual(request.headers.get("authorization"), "Bearer sofya_test")
+                return httpx.Response(200, json=sofya_payload)
+
+            transport = httpx.MockTransport(handler)
+            async with httpx.AsyncClient(transport=transport) as client:
+                results = await search_sofya("leo messi", num_results=1, http_client=client)
+
+            self.assertEqual(len(results), 1)
+            self.assertEqual(results[0].title, "Lionel Messi Facts | Britannica")
+            self.assertEqual(results[0].link, "https://www.britannica.com/facts/Lionel-Messi")
+            self.assertTrue(results[0].snippet)
+
+        anyio.run(run)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Add Sofya as a search provider

Adds [Sofya](https://sofya.co) as a fourth web search provider, alongside Serper, Tavily, and SearXNG.

### What

- `search/sofya.py` mirrors the existing provider modules: `POST https://sofya.co/v1/search` with a Bearer `SOFYA_API_KEY`, results mapped to `WebSearchResult(title, link, snippet, page_content="")`. It uses `search_depth: "snippets"` so the `snippet` field stays short and the call stays cheap (1 credit), matching how the other providers return SERP-style snippets.
- Registered in `search/__init__.py`, **appended last** in the selection order so existing precedence is unchanged: Serper → Tavily → SearXNG → Sofya.
- Added `tests/test_sofya_unit.py` and a router test (`test_uses_sofya_when_only_sofya_key`); also pop `SOFYA_API_KEY` in the no-provider test.
- Updated `README.md` and `.env.example`.

### Verification

- `pytest tests/test_search_router.py tests/test_sofya_unit.py tests/test_tavily_unit.py` passes (9 tests).
- `ruff check` passes on the changed files.
- Live check: with only `SOFYA_API_KEY` set, `search_web()` routes to Sofya and returns well-formed results from the real API.

Get an API key at https://sofya.co.
