### PR TITLE
feat: add SerpBase (Google) search provider

### DIFF
--- a/src/kindly_web_search_mcp_server/search/__init__.py
+++ b/src/kindly_web_search_mcp_server/search/__init__.py
@@ -1,4 +1,4 @@
-"""Search providers (Serper → Tavily → SearXNG)."""
+"""Search providers (Serper → SerpBase → Tavily → SearXNG)."""
 from __future__ import annotations
 
 import os
@@ -9,6 +9,7 @@ import httpx
 from ..models import WebSearchResult
 from ..utils.diagnostics import Diagnostics
 from .searxng import search_searxng
+from .serpbase import search_serpbase
 from .serper import search_serper
 from .tavily import search_tavily
 
@@ -19,6 +20,10 @@ class WebSearchProviderError(RuntimeError):
 
 def _has_serper_key() -> bool:
     return bool(os.environ.get("SERPER_API_KEY", "").strip())
+
+
+def _has_serpbase_key() -> bool:
+    return bool(os.environ.get("SERPBASE_API_KEY", "").strip())
 
 
 def _has_tavily_key() -> bool:
@@ -37,25 +42,30 @@ async def search_web(
     diagnostics: Diagnostics | None = None,
 ) -> list[WebSearchResult]:
     """
-    Search the web using Serper, Tavily, or SearXNG.
+    Search the web using Serper, SerpBase, Tavily, or SearXNG.
 
     Selection (strict order, no cross-provider fallback):
     - If SERPER_API_KEY is set: use Serper.
+    - Else if SERPBASE_API_KEY is set: use SerpBase.
     - Else if TAVILY_API_KEY is set: use Tavily.
     - Else if SEARXNG_BASE_URL is set: use SearXNG.
     """
     has_serper = _has_serper_key()
+    has_serpbase = _has_serpbase_key()
     has_tavily = _has_tavily_key()
     has_searxng = _has_searxng_config()
-    if not has_serper and not has_tavily and not has_searxng:
+    if not has_serper and not has_serpbase and not has_tavily and not has_searxng:
         raise WebSearchProviderError(
-            "No web search provider is configured. Set SERPER_API_KEY, TAVILY_API_KEY, or SEARXNG_BASE_URL."
+            "No web search provider is configured. Set SERPER_API_KEY, SERPBASE_API_KEY, TAVILY_API_KEY, or SEARXNG_BASE_URL."
         )
 
     provider: Callable[..., Awaitable[list[WebSearchResult]]]
     if has_serper:
         provider = search_serper
         provider_name = "serper"
+    elif has_serpbase:
+        provider = search_serpbase
+        provider_name = "serpbase"
     elif has_tavily:
         provider = search_tavily
         provider_name = "tavily"
@@ -72,6 +82,7 @@ async def search_web(
                 "num_results": num_results,
                 "provider": provider_name,
                 "has_serper_key": has_serper,
+                "has_serpbase_key": has_serpbase,
                 "has_tavily_key": has_tavily,
                 "has_searxng_config": has_searxng,
             },

--- a/src/kindly_web_search_mcp_server/search/serpbase.py
+++ b/src/kindly_web_search_mcp_server/search/serpbase.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+from ..models import WebSearchResult
+
+
+class SerpbaseError(RuntimeError):
+    pass
+
+
+class SerpbaseConfigError(SerpbaseError):
+    pass
+
+
+def _get_serpbase_api_key() -> str:
+    api_key = os.environ.get("SERPBASE_API_KEY", "").strip()
+    if not api_key:
+        raise SerpbaseConfigError(
+            "SERPBASE_API_KEY is not set. Configure it as an environment variable in your IDE/run configuration."
+        )
+    return api_key
+
+
+async def search_serpbase(
+    query: str,
+    *,
+    num_results: int,
+    http_client: httpx.AsyncClient | None = None,
+) -> list[WebSearchResult]:
+    """Query SerpBase and return parsed Google organic results.
+
+    SerpBase endpoint:
+    - GET https://api.serpbase.dev/google/search
+    - Params: q, num, api_key
+    - Returns JSON with ``organic_results`` array (title, link, snippet, position).
+
+    Docs: https://serpbase.dev/docs
+    """
+    if not query.strip():
+        return []
+
+    if num_results < 1:
+        return []
+
+    api_key = _get_serpbase_api_key()
+    url = "https://api.serpbase.dev/google/search"
+    params = {"q": query, "num": int(num_results), "api_key": api_key}
+
+    async def _do_request(client: httpx.AsyncClient) -> dict[str, Any]:
+        resp = await client.get(url, params=params)
+        resp.raise_for_status()
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            raise SerpbaseError("SerpBase response was not valid JSON.") from exc
+        if not isinstance(data, dict):
+            raise SerpbaseError("SerpBase response was not a JSON object.")
+        return data
+
+    if http_client is None:
+        async with httpx.AsyncClient(timeout=30) as client:
+            data = await _do_request(client)
+    else:
+        data = await _do_request(http_client)
+
+    organic = data.get("organic_results", [])
+    if not isinstance(organic, list):
+        return []
+
+    results: list[WebSearchResult] = []
+    for item in organic:
+        if not isinstance(item, dict):
+            continue
+
+        title = item.get("title")
+        link = item.get("link")
+        snippet = item.get("snippet")
+        if not isinstance(title, str) or not isinstance(link, str) or not isinstance(snippet, str):
+            continue
+
+        # ``page_content`` is populated later by the MCP tool (best-effort).
+        results.append(WebSearchResult(title=title, link=link, snippet=snippet, page_content=""))
+        if len(results) >= num_results:
+            break
+
+    return results

--- a/src/kindly_web_search_mcp_server/settings.py
+++ b/src/kindly_web_search_mcp_server/settings.py
@@ -12,6 +12,7 @@ class Settings:
     """
 
     serper_api_key: str = os.environ.get("SERPER_API_KEY", "")
+    serpbase_api_key: str = os.environ.get("SERPBASE_API_KEY", "")
 
 
 settings = Settings()


### PR DESCRIPTION
## Summary
Add SerpBase as a Google search provider — returns structured Google results via REST API with zero scraping maintenance.

## Background
The project currently supports Serper, Tavily, and SearXNG — all excellent providers, but none offer a straightforward Google Search Results API with a generous free tier. SerpBase fills this gap: it's a simple REST API that returns Google organic results (title, link, snippet) in clean JSON. The feature was proposed in #31.

## Changes
- **New**: `src/kindly_web_search_mcp_server/search/serpbase.py` — REST API-based Google search provider using `api.serpbase.dev`. Uses GET with query params, parses `organic_results` into `WebSearchResult` objects.
- **Updated**: `src/kindly_web_search_mcp_server/search/__init__.py` — import, `_has_serpbase_key()` check, and dispatch for `SERPBASE_API_KEY`. Provider chain: Serper → SerpBase → Tavily → SearXNG.
- **Updated**: `src/kindly_web_search_mcp_server/settings.py` — added `serpbase_api_key` field.

## Design decisions
| Decision | Rationale |
|----------|-----------|
| API key via `SERPBASE_API_KEY` env var | Follows existing convention (SERPER_API_KEY, TAVILY_API_KEY) |
| Placed after Serper in priority chain | Serper is the established default; SerpBase is an accessible alternative |
| GET + query params | Matches SerpBase API design; simpler than JSON POST body |
| Uses existing `httpx` dependency | No new packages — follows project's "keep it lightweight" philosophy |
| Same error/parsing pattern as Serper | Consistent with existing provider implementations |

## Testing
- When `SERPBASE_API_KEY` is set (and higher-priority keys are unset): routes to SerpBase, returns `WebSearchResult` list from Google organic results
- When `SERPBASE_API_KEY` is unset: provider is skipped, falls through to next configured provider
- Existing tests pass without modification — SerpBase is only selected when its env var is explicitly set

## Related
- Closes #31