### PR TITLE
fix: pin mcp below 2.0 to restore server startup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,14 @@ description = "MCP server: Serper web search + robust content retrieval."
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "mcp",
+    # `<2`: the MCP SDK dropped `mcp.server.fastmcp` in 2.0.0, and `server.py` imports
+    # `FastMCP` from it. The documented install path (`uvx --from git+https://...`)
+    # re-resolves from PyPI on every start and ignores `uv.lock`, so leaving this
+    # unbounded broke every user the moment 2.0.0 shipped. Lift this bound only
+    # alongside a port to the 2.x `MCPServer` API.
+    # `>=1.25`: oldest release verified against this server; stops a constrained
+    # resolve from silently selecting an older, untested API.
+    "mcp>=1.25,<2",
     "pydantic",
     "httpx[socks]",
     "beautifulsoup4",
@@ -20,7 +27,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "ruff"]
+# `packaging` is declared rather than inherited from pytest: the dependency-bound
+# guard in `tests/test_dependency_constraints.py` imports it directly, and relying
+# on a transitive dep is the same failure mode that guard exists to prevent.
+dev = ["pytest", "ruff", "packaging"]
 # Optional extras for improved PDF-to-Markdown conversion on supported Python versions.
 # These pull in `onnxruntime` transitively (via `pymupdf-layout`), which may not have wheels
 # for the newest CPython releases (e.g., cp314). Keeping them optional avoids install

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -1,0 +1,81 @@
+"""Guard the dependency bounds declared in ``pyproject.toml``.
+
+The documented install path is ``uvx --from git+https://...``, which re-resolves
+dependencies from PyPI on every start and ignores ``uv.lock``. The bounds that
+reach users therefore live in ``pyproject.toml``, not in the lock file, so they
+are asserted here.
+
+The rest of the suite covers the other half of this contract: six test modules
+import ``kindly_web_search_mcp_server.server``, so an SDK that no longer provides
+``mcp.server.fastmcp`` fails the suite. Those imports prove the *resolved* version
+works; the assertions here constrain what may be resolved in the first place.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+PYPROJECT_PATH = Path(__file__).resolve().parents[1] / "pyproject.toml"
+
+# The MCP SDK removed ``mcp.server.fastmcp`` in 2.0.0. The later versions are
+# listed deliberately: a too-narrow pin such as ``!=2.0.0`` excludes exactly the
+# one release while leaving 2.1.0 and 3.0.0 installable, which would reintroduce
+# the outage while still satisfying a check that only tried 2.0.0.
+REJECTED_MCP_VERSIONS = ("2.0.0", "2.1.0", "3.0.0")
+
+# Matches the lower bound declared in ``pyproject.toml``. Raising that floor
+# should update this too; the pairing is what makes an accidental
+# over-tightening visible instead of silent.
+SUPPORTED_MCP_VERSION = "1.25.0"
+
+
+def _read_mcp_requirement() -> Requirement:
+    """Extract the ``mcp`` requirement declared in ``pyproject.toml``
+
+    Returns:
+        The parsed requirement for the MCP Python SDK.
+
+    Raises:
+        AssertionError: If no ``mcp`` entry is declared.
+    """
+    with PYPROJECT_PATH.open("rb") as handle:
+        pyproject = tomllib.load(handle)
+
+    for entry in pyproject["project"]["dependencies"]:
+        requirement = Requirement(entry)
+        if requirement.name.lower() == "mcp":
+            return requirement
+
+    raise AssertionError("pyproject.toml declares no 'mcp' dependency")
+
+
+@pytest.fixture(scope="module")
+def mcp_requirement() -> Requirement:
+    """Return the ``mcp`` requirement declared in ``pyproject.toml``"""
+    return _read_mcp_requirement()
+
+
+@pytest.mark.parametrize("version", REJECTED_MCP_VERSIONS)
+def test_mcp_requirement_rejects_versions_without_fastmcp(
+    mcp_requirement: Requirement, version: str
+) -> None:
+    """Reject every MCP SDK release that dropped ``mcp.server.fastmcp``"""
+    assert not mcp_requirement.specifier.contains(Version(version)), (
+        f"pyproject.toml allows mcp {version}, which has no 'mcp.server.fastmcp' "
+        f"and breaks server.py at import time. Declared specifier: '{mcp_requirement}'."
+    )
+
+
+def test_mcp_requirement_still_allows_supported_version(
+    mcp_requirement: Requirement,
+) -> None:
+    """Keep the supported MCP SDK version installable"""
+    assert mcp_requirement.specifier.contains(Version(SUPPORTED_MCP_VERSION)), (
+        f"pyproject.toml no longer allows the supported mcp {SUPPORTED_MCP_VERSION}. "
+        f"Declared specifier: '{mcp_requirement}'."
+    )


### PR DESCRIPTION
## Problem

The server fails to start for every user. MCP clients report a `-32000` handshake failure; the underlying crash is:

```
File ".../kindly_web_search_mcp_server/server.py", line 11, in <module>
    from mcp.server.fastmcp import FastMCP
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

The MCP Python SDK released **2.0.0**, which removed `mcp.server.fastmcp` entirely — `FastMCP` no longer exists anywhere in the package (replaced by `mcp.server.mcpserver.MCPServer`). `server.py:11` imports from the removed module, so the process dies before it can answer `initialize`.

`pyproject.toml` declared the dependency as bare `"mcp"` with no upper bound. The documented install path, `uvx --from git+https://...`, re-resolves dependencies from PyPI on **every** start and does not consult `uv.lock` (which pins 1.25.0) — that file only applies to `uv sync` / `uv run` inside the project. So the break reached every user the moment 2.0.0 shipped, regardless of the lock file.

## Changes

- **`pyproject.toml`** — pin `mcp>=1.25,<2`, with a comment recording why each bound exists and what must happen before the cap is lifted (a port to the 2.x `MCPServer` API).
- **`tests/test_dependency_constraints.py`** (new) — guard test that parses `pyproject.toml` and asserts the declared `mcp` bound rejects 2.x. It checks `2.1.0` and `3.0.0` in addition to `2.0.0`, because a too-narrow pin such as `!=2.0.0` would exclude exactly the one release while leaving later majors installable, silently reopening the outage.
- **`pyproject.toml` dev extra** — declare `packaging`. The guard test imports it directly but was relying on it arriving transitively via pytest, which is the same failure mode the guard exists to prevent.

This guards the dependency *declaration*. The other half of the contract was already covered: six test modules import `kindly_web_search_mcp_server.server`, so an SDK that cannot provide `FastMCP` fails the suite.

No env vars added or changed.

## Reproduction

Before this change, against `main`:

```bash
echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"probe","version":"1.0"}}}' \
  | SERPER_API_KEY=dummy uvx --refresh \
      --from git+https://github.com/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server \
      kindly-web-search-mcp-server start-mcp-server
```

→ `ModuleNotFoundError: No module named 'mcp.server.fastmcp'`

## Verification

- **Guard test fails before the fix**, with the unbounded `"mcp"` in place: *"pyproject.toml allows mcp 2.0.0, which has no 'mcp.server.fastmcp' … Declared specifier: 'mcp'"*. Passes after.
- **Mutation-tested.** Temporarily setting the pin to `mcp>=1.25,!=2.0.0` makes the guard fail on 2.1.0 and 3.0.0, confirming it catches a narrowed pin rather than just the literal 2.0.0 case.
- **End-to-end `uvx` install** from this branch with `--refresh` (forcing a clean rebuild and re-resolve) returns a valid `initialize` response and resolves mcp 1.29.0.
- **`ruff check` and `ruff format --check`** clean on the new file.
- **Full suite: 89 passed, 11 failed, 3 skipped.** The 11 failures are pre-existing and unrelated — browser/subprocess tests in `test_nodriver_worker_sandbox.py`, `test_universal_html_loader.py`, and one Windows concurrency test in `test_server.py`, mostly `'_FakeProc' object has no attribute 'stdout'`. Confirmed by stashing this change and re-running that subset against the original `pyproject.toml`: identical 11 failures.

## Notes for reviewers

- The `>=1.25` floor is the oldest release verified against this server, not a measured minimum — the true floor is likely lower. Over-constraining it costs nothing for a standalone app, and the comment says so plainly rather than implying a precise bound.
- Version left at `0.1.8`. There is no release automation in the repo and `uvx` installs from git HEAD, so the fix reaches users without a bump — happy to add one if you'd prefer.
- **Out of scope, worth a follow-up:** the other seven runtime dependencies (`pydantic`, `httpx`, `beautifulsoup4`, `markdownify`, `trafilatura`, `nodriver`, `PyMuPDF`) are all unbounded and carry the same latent risk. There are also two pre-existing `ruff` errors in `src/kindly_web_search_mcp_server/scrape/extract.py` (`F401` unused `Callable`, `E731` lambda assignment), untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
