### PR TITLE
doc: add Google Chrome path example for macOS (cherry-pick from @wolke1007)

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,6 +659,12 @@ Create `.vscode/mcp.json`:
 
 Set `KINDLY_BROWSER_EXECUTABLE_PATH` to your browser binary.
 
+macOS (Google Chrome):
+
+```bash
+export KINDLY_BROWSER_EXECUTABLE_PATH="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+```
+
 macOS (Homebrew Chromium):
 
 ```bash


### PR DESCRIPTION
Cherry-picks [`17f9e08`](https://github.com/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server/commit/17f9e08f162633b34e9124197737ba2301bbabac) by @wolke1007 from `wolke1007/kindly-web-search-mcp-server`. There was no PR attached to it, so this brings it across on its own. Authorship is preserved.

## What it does

Adds a macOS Google Chrome example to the **Browser path (only if auto-detection fails)** section of the README, alongside the existing Homebrew Chromium and Linux examples.

## Why it's correct

I verified the commit's premise against the code. `_resolve_browser_executable_path` in `src/kindly_web_search_mcp_server/scrape/nodriver_worker.py:292-311` falls back to:

```python
for name in ("chromium", "google-chrome", "google-chrome-stable", "chrome", "chromium-browser"):
    resolved = shutil.which(name)
```

`shutil.which` searches `PATH` only. A standard macOS Google Chrome install lives at `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`, which is not on `PATH` — so auto-detection does miss it, exactly as the commit describes. The documented workaround is the right one.

## One adaptation

`README.md` was reformatted on main after this commit was written (blank lines added around headings and fences). The cherry-pick applied cleanly but left the new block without the blank line between its label and its code fence, which every neighbouring block now has. I added it so the section is internally consistent. That is the only change from the original commit, and it is noted in the commit message.

## Scope note

`wolke1007/kindly-web-search-mcp-server` is 8 commits ahead of main, and the rest are **not** included here deliberately — they range from doc tweaks to substantial refactors, including `refactor: remove SearXNG support, delete dead code`, which would remove a provider main still supports. Only this doc commit was requested and only this one is taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
