### PR TITLE
fix: redact proxy credentials in worker launch-args diagnostics

### DIFF
--- a/src/kindly_web_search_mcp_server/scrape/nodriver_worker.py
+++ b/src/kindly_web_search_mcp_server/scrape/nodriver_worker.py
@@ -19,6 +19,12 @@ import tempfile
 import time
 from typing import TextIO
 
+# The only package import in this module. This worker is otherwise stdlib-only
+# because it runs as a `python -m` subprocess, but `utils.diagnostics` is itself
+# stdlib-only behind empty package `__init__` files, so the import is free. Sharing
+# the redaction keeps one definition of what a credential looks like.
+from ..utils.diagnostics import redact_url_credentials
+
 
 class _NullTextIO(io.TextIOBase):
     """
@@ -1038,7 +1044,10 @@ async def _fetch_html(
                         {
                             "attempt": attempt + 1,
                             "user_data_dir": resolved_user_data_dir,
-                            "args": chromium_args,
+                            # `--proxy-server` carries KINDLY_CHROME_PROXY verbatim, which
+                            # may embed credentials. Redact the emitted copy only; Chromium
+                            # still receives the real `chromium_args` below.
+                            "args": [redact_url_credentials(arg) for arg in chromium_args],
                         },
                     )
                     chrome_proc = await _launch_chromium(resolved_browser_executable_path, chromium_args)

--- a/src/kindly_web_search_mcp_server/utils/diagnostics.py
+++ b/src/kindly_web_search_mcp_server/utils/diagnostics.py
@@ -13,12 +13,16 @@ _TRUTHY = {"1", "true", "yes", "on"}
 _MASK_HINTS = ("KEY", "TOKEN", "SECRET", "PASSWORD", "BEARER")
 
 # Credentials in a URL's userinfo component, e.g. `http://user:pass@proxy:8080`.
-# The name-based hints above cannot catch these: the snapshots in
-# `scrape/universal_html.py` include HTTP_PROXY/HTTPS_PROXY, whose names carry no
-# secret marker while their values routinely do. Matches the whole userinfo rather
-# than just `user:pass`, so the password-less `http://user@proxy` form is covered
-# too; `@` in an authority always delimits userinfo, so this cannot match a host.
-_URL_USERINFO_RE = re.compile(r"://[^/@\s]*@")
+# The name-based hints above cannot catch these: proxy variables and CLI flags carry
+# no secret marker in their names while their values routinely do.
+#
+# The character class admits `@` so the match runs to the *last* `@` before the path,
+# which covers passwords containing an unescaped `@` (`http://user:pa@ss@host`). A
+# stricter class stopping at the first `@` leaves the remainder of such a password
+# exposed. The trade-off is that a pathological value may over-redact, which fails
+# closed. `/` and whitespace still bound the match, so an `@` in a path is untouched.
+_URL_USERINFO_RE = re.compile(r"://[^/\s]*@")
+_REDACTED_USERINFO = "://***@"
 
 MAX_SAMPLE_CHARS = 2000
 MAX_STDERR_CHARS = 4000
@@ -35,7 +39,40 @@ def new_request_id() -> str:
     return str(uuid.uuid4())
 
 
+def redact_url_credentials(text: str) -> str:
+    """Strip credentials from any URL userinfo component in ``text``
+
+    Removes the ``user:pass@`` portion of a URL while leaving the scheme, host,
+    and port readable, so diagnostics emitted to stderr stay useful for debugging
+    proxy routing without disclosing secrets. Values containing no credentialed
+    URL are returned unchanged.
+
+    Args:
+        text: Arbitrary text that may embed one or more URLs, such as an
+            environment variable value or a command-line argument.
+
+    Returns:
+        The text with every URL userinfo component replaced by ``***``.
+    """
+    return _URL_USERINFO_RE.sub(_REDACTED_USERINFO, text)
+
+
 def mask_env_values(env: Mapping[str, str]) -> dict[str, str]:
+    """Mask secrets in an environment snapshot bound for diagnostics output
+
+    Applies two complementary rules. Variables whose *name* signals a secret are
+    replaced wholesale with their length, since no part of the value is safe to
+    show. Every other value keeps its content but has any URL credentials removed,
+    because variables such as ``HTTP_PROXY`` carry no secret marker in their name
+    yet routinely embed ``user:pass@`` in their value.
+
+    Args:
+        env: The environment snapshot to mask. ``None`` values are treated as
+            empty strings.
+
+    Returns:
+        A new mapping with the same keys and masked values.
+    """
     masked: dict[str, str] = {}
     for key, value in env.items():
         raw = "" if value is None else str(value)
@@ -44,7 +81,7 @@ def mask_env_values(env: Mapping[str, str]) -> dict[str, str]:
         else:
             # Redact only the userinfo rather than the whole value: these snapshots
             # exist to debug proxy routing, so the host and port must stay readable.
-            masked[key] = _URL_USERINFO_RE.sub("://***@", raw)
+            masked[key] = redact_url_credentials(raw)
     return masked
 
 

--- a/tests/test_diagnostics_masking.py
+++ b/tests/test_diagnostics_masking.py
@@ -62,6 +62,21 @@ def test_redacts_password_less_userinfo() -> None:
     assert masked["HTTP_PROXY"] == "http://***@proxy.corp:8080"
 
 
+def test_redacts_password_containing_unescaped_at_sign() -> None:
+    """Redact through to the last `@`, so no tail of the password survives"""
+    masked = mask_env_values({"HTTP_PROXY": "http://user:pa@ss@proxy.corp:8080"})
+
+    assert masked["HTTP_PROXY"] == "http://***@proxy.corp:8080"
+    assert "ss" not in masked["HTTP_PROXY"].replace("proxy.corp", "")
+
+
+def test_redacts_each_url_in_a_multi_url_value() -> None:
+    """Handle values holding more than one credentialed URL"""
+    masked = mask_env_values({"X": "http://a:b@one.example,https://c:d@two.example"})
+
+    assert masked["X"] == "http://***@one.example,https://***@two.example"
+
+
 def test_redacts_credentials_in_any_url_valued_variable() -> None:
     """Apply userinfo redaction regardless of the variable's name"""
     masked = mask_env_values({"SEARXNG_BASE_URL": "https://u:p@searx.example.org"})

--- a/tests/test_worker_launch_args_redaction.py
+++ b/tests/test_worker_launch_args_redaction.py
@@ -1,0 +1,76 @@
+"""Cover credential redaction in the nodriver worker's launch-args diagnostics.
+
+The worker emits ``worker.launch_args`` with the full Chromium command line. That
+list includes ``--proxy-server`` built from ``KINDLY_CHROME_PROXY``, which may embed
+credentials, so the emitted copy must be redacted while Chromium still receives the
+real arguments.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from kindly_web_search_mcp_server.scrape.nodriver_worker import (
+    _build_chromium_launch_args,
+)
+from kindly_web_search_mcp_server.utils.diagnostics import redact_url_credentials
+
+PROXY_WITH_CREDENTIALS = "http://alice:s3cr3t@proxy.corp:8080"
+
+
+def _launch_args(monkeypatch, proxy: str) -> list[str]:
+    """Build Chromium launch args with ``KINDLY_CHROME_PROXY`` set to ``proxy``.
+
+    Args:
+        monkeypatch: pytest fixture used to scope the environment change.
+        proxy: Value to expose as ``KINDLY_CHROME_PROXY``.
+
+    Returns:
+        The generated Chromium command-line arguments.
+    """
+    monkeypatch.setenv("KINDLY_CHROME_PROXY", proxy)
+    return _build_chromium_launch_args(
+        base_browser_args=[],
+        user_data_dir="/tmp/profile",
+        user_agent="UA",
+        host="127.0.0.1",
+        port=9222,
+        sandbox_enabled=False,
+    )
+
+
+def test_chromium_receives_the_real_proxy_credentials(monkeypatch) -> None:
+    """Keep credentials intact in the args actually passed to Chromium"""
+    args = _launch_args(monkeypatch, PROXY_WITH_CREDENTIALS)
+
+    assert f"--proxy-server={PROXY_WITH_CREDENTIALS}" in args
+
+
+def test_emitted_launch_args_hide_proxy_credentials(monkeypatch) -> None:
+    """Redact credentials from the copy emitted to diagnostics"""
+    args = _launch_args(monkeypatch, PROXY_WITH_CREDENTIALS)
+
+    emitted = [redact_url_credentials(arg) for arg in args]
+
+    assert "--proxy-server=http://***@proxy.corp:8080" in emitted
+    assert not any("s3cr3t" in arg for arg in emitted)
+    assert not any("alice" in arg for arg in emitted)
+
+
+def test_emitted_launch_args_keep_proxy_host_visible(monkeypatch) -> None:
+    """Preserve the proxy host and port so the diagnostic stays useful"""
+    args = _launch_args(monkeypatch, PROXY_WITH_CREDENTIALS)
+
+    emitted = [redact_url_credentials(arg) for arg in args]
+
+    assert any("proxy.corp:8080" in arg for arg in emitted)
+
+
+def test_credential_free_args_are_unchanged(monkeypatch) -> None:
+    """Leave ordinary arguments untouched"""
+    args = _launch_args(monkeypatch, "http://proxy.corp:8080")
+
+    assert [redact_url_credentials(arg) for arg in args] == args


### PR DESCRIPTION
Follow-up to #45. Reviewing that PR critically turned up that it fixed only half the leak.

## The half I missed

#45 fixed `mask_env_values`. But `scrape/nodriver_worker.py:1035` emits a second, independent diagnostic carrying the same class of secret — `worker.launch_args`, which emits the full Chromium command line:

```
worker.launch_args -> ["--proxy-server=http://alice:s3cr3t@proxy.corp:8080", ...]
```

That argument is built from `KINDLY_CHROME_PROXY` at `nodriver_worker.py:554` and never passed through any masking. It's a *different* variable from the ones #45 covered — `KINDLY_CHROME_PROXY` appears in no env snapshot anywhere, so it leaked purely as a command-line argument and `mask_env_values` could never have caught it.

Reproduced before the fix:

```
emitted via worker.launch_args -> ['--proxy-server=http://alice:s3cr3t@proxy.corp:8080']
CREDENTIAL LEAKED: True
```

The fix redacts the emitted copy only. Chromium still receives the real `chromium_args`, so proxy authentication keeps working — there's a test asserting both halves of that.

## A partial-redaction bug in #45's pattern

The old pattern `://[^/@\s]*@` stopped at the first `@`, so a password containing an unescaped `@` was only partly redacted:

```
http://user:pa@ss@proxy.corp:8080  ->  http://***@ss@proxy.corp:8080
```

Widened to `://[^/\s]*@`, which matches to the last `@` before the path. This fails closed: a pathological value may over-redact, which is the safe direction for a secret, versus the old behaviour that failed open and leaked. `/` and whitespace still bound the match, so an `@` in a URL path is untouched — still tested.

## Structure and docs

Extracted `redact_url_credentials` so both call sites share one definition of what a credential looks like. The alternative was letting the worker grow its own copy of the regex, which is precisely the duplication #45 removed when it deleted `scripts/_env_loader.py` — repeating it here would have been self-defeating.

This is the only package import in `nodriver_worker.py`, which is otherwise stdlib-only. I checked that this is safe rather than assuming: `utils/diagnostics.py` is stdlib-only and every package `__init__.py` in the chain is empty, so the import costs nothing, and `python -m kindly_web_search_mcp_server.scrape.nodriver_worker --help` still works.

Also added docstrings to `mask_env_values` and the new helper. The former had none, while now carrying two distinct masking strategies — worth explaining why name-based and value-based masking coexist.

## Verification

- **Both paths confirmed closed end to end.** Env snapshot and `worker.launch_args` both redact; `chromium_args` still carries the real credential.
- Full suite: **100 passed, 11 failed, 3 skipped.** The 11 are the known pre-existing browser/subprocess failures (7 `test_nodriver_worker_sandbox`, 3 `test_universal_html_loader`, 1 Windows concurrency) — unchanged.
- Worker still launches as a `python -m` subprocess.
- `ruff check` and `ruff format --check` clean on all four files.

New `tests/test_worker_launch_args_redaction.py` covers: Chromium receives real credentials; the emitted copy does not; the proxy host stays visible; credential-free args are untouched. Two cases added to `test_diagnostics_masking.py` for the unescaped-`@` password and multi-URL values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
