### PR TITLE
refactor: drive provider lists from a single registry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,10 @@
 # Copy to your runtime environment (shell/IDE/container). Do NOT commit secrets.
 #
-# Required: provide at least one search provider key
+# Required: provide at least one search provider key.
+# Selection order is: Serper -> SerpBase -> Tavily -> SearXNG -> Sofya.
 SERPER_API_KEY=
+# SerpBase (Google results, https://serpbase.dev)
+SERPBASE_API_KEY=
 TAVILY_API_KEY=
 # Sofya web search (https://sofya.co)
 SOFYA_API_KEY=

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ args = [
   "start-mcp-server",
 ]
 # Forward variables from your shell/OS environment:
-env_vars = ["SERPER_API_KEY", "TAVILY_API_KEY", "SEARXNG_BASE_URL", "GITHUB_TOKEN", "KINDLY_BROWSER_EXECUTABLE_PATH"]
+env_vars = ["SERPER_API_KEY", "SERPBASE_API_KEY", "TAVILY_API_KEY", "SEARXNG_BASE_URL", "SOFYA_API_KEY", "GITHUB_TOKEN", "KINDLY_BROWSER_EXECUTABLE_PATH"]
 startup_timeout_sec = 120.0
 ```
 
@@ -551,7 +551,7 @@ Paste this into your `mcpServers` object (don’t overwrite other servers):
 ```
 
 If Antigravity can’t find `uvx`, replace `"uvx"` with the absolute path (`which uvx` on macOS/Linux, `where uvx` on Windows).
-Make sure at least one of `SERPER_API_KEY` / `TAVILY_API_KEY` / `SEARXNG_BASE_URL` is non-empty.
+Make sure at least one of `SERPER_API_KEY` / `SERPBASE_API_KEY` / `TAVILY_API_KEY` / `SEARXNG_BASE_URL` / `SOFYA_API_KEY` is non-empty.
 If the first start is slow, run the `uvx` command from Quickstart once in a terminal to prebuild the environment, then click **Refresh**.
 Don’t commit/share `mcp_config.json` if it contains API keys.
 
@@ -755,7 +755,7 @@ docker run --rm -p 8000:8000 \
 ```
 
 - MCP endpoint: `http://<server-host>:8000/mcp`
-- Make sure at least one of `SERPER_API_KEY` / `TAVILY_API_KEY` / `SEARXNG_BASE_URL` is set.
+- Make sure at least one of `SERPER_API_KEY` / `SERPBASE_API_KEY` / `TAVILY_API_KEY` / `SEARXNG_BASE_URL` / `SOFYA_API_KEY` is set.
 - `page_content` extraction runs on the server machine/container (this Docker image includes Chromium).
 - Remote HTTP is typically **unauthenticated** and **unencrypted** by default; don’t expose this port publicly. Use VPN/firewall rules or a reverse proxy with TLS + auth.
 - Don’t bake API keys into the image; pass them via env vars at runtime.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ We built Kindly Web Search because we needed our AI assistants to work the way *
 
 ✅ **Passes all useful content to the LLM immediately** - no need for a second scraping call
 
-✅ **Supports multiple search providers** (Serper, Tavily, SearXNG, and Sofya) with intelligent fallback
+✅ **Supports multiple search providers** (Serper, SerpBase, Tavily, SearXNG, and Sofya) with intelligent fallback
 
 Now, when Claude Code or Codex searches for that GPU batch error, it gets the question *and* the answers. The code snippets. The "this fixed it for me" comments. Everything it needs to help you solve the problem - **in one call**.
 
@@ -112,7 +112,7 @@ When extracting page content (`get_content` or `web_search` results), Kindly rou
 
 All `httpx`-based handlers read standard proxy environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`) and support both HTTP and SOCKS proxy URLs via the `socksio` dependency. The universal HTML loader uses Chromium's `--proxy-server` flag via `KINDLY_CHROME_PROXY`, which supports SOCKS5 and other schemes natively.
 
-Search uses **Serper** (primary, if configured), **Tavily**, **SearXNG**, or **Sofya**, and page extraction uses a local Chromium-based browser via `nodriver`.
+Search uses **Serper** (primary, if configured), **SerpBase**, **Tavily**, **SearXNG**, or **Sofya**, and page extraction uses a local Chromium-based browser via `nodriver`.
 
 #### Markdown fast paths (skip the browser for doc sites)
 
@@ -127,7 +127,7 @@ Both probes validate the response (`text/markdown`, ≥1 KB, non-empty after san
 
 ## Requirements
 
-- A search provider (priority order): `SERPER_API_KEY` (recommended) → `TAVILY_API_KEY` → `SEARXNG_BASE_URL` (self-hosted SearXNG) → `SOFYA_API_KEY`
+- A search provider (priority order): `SERPER_API_KEY` (recommended) → `SERPBASE_API_KEY` (SerpBase, Google results) → `TAVILY_API_KEY` → `SEARXNG_BASE_URL` (self-hosted SearXNG) → `SOFYA_API_KEY`
 - A Chromium-based browser installed on the same machine running the MCP client (Chrome/Chromium/Edge/Brave)
   - Without a browser: specialized sources (StackExchange, GitHub Issues/Discussions, Wikipedia, arXiv) still work well, but universal HTML `page_content` extraction may fail for other sites.
 - Highly recommended: `GITHUB_TOKEN` (renders GitHub Issues in a much more LLM-friendly format: question + answers/comments + reactions/metadata; fewer rate limits)
@@ -197,7 +197,7 @@ Other Linux distros: install `chromium` (or `chromium-browser`) via your package
 
 ### 3) Set your search API key (required)
 
-Set **one** of these. Provider selection order is: Serper → Tavily → SearXNG → Sofya.
+Set **one** of these. Provider selection order is: Serper → SerpBase → Tavily → SearXNG → Sofya.
 
 macOS / Linux:
 
@@ -257,7 +257,7 @@ Make sure your API keys are set in the same shell/OS environment that launches t
 
 ### Codex
 
-Set one of `SERPER_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, or `SOFYA_API_KEY`.
+Set one of `SERPER_API_KEY`, `SERPBASE_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, or `SOFYA_API_KEY`.
 
 CLI (no file editing) — add a local stdio MCP server:
 
@@ -330,7 +330,7 @@ startup_timeout_sec = 120.0
 
 ### Claude Code
 
-Set one of `SERPER_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, or `SOFYA_API_KEY`.
+Set one of `SERPER_API_KEY`, `SERPBASE_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, or `SOFYA_API_KEY`.
 
 CLI (no file editing) — add a local stdio MCP server:
 
@@ -428,7 +428,7 @@ Create/edit `.mcp.json` (project scope; recommended for teams):
 
 ### Gemini CLI
 
-Set one of `SERPER_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, or `SOFYA_API_KEY`.
+Set one of `SERPER_API_KEY`, `SERPBASE_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, or `SOFYA_API_KEY`.
 Edit `~/.gemini/settings.json` (or `.gemini/settings.json` in a project):
 
 ```json
@@ -457,7 +457,7 @@ Edit `~/.gemini/settings.json` (or `.gemini/settings.json` in a project):
 
 ### OpenClaw
 
-Set one of `SERPER_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, or `SOFYA_API_KEY`.
+Set one of `SERPER_API_KEY`, `SERPBASE_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, or `SOFYA_API_KEY`.
 If `mcporter` is not installed yet: `npm i -g mcporter`.
 mcporter docs: <https://github.com/steipete/mcporter/blob/main/docs/config.md>
 
@@ -519,7 +519,7 @@ openclaw gateway restart
 
 ### Antigravity (Google IDE)
 
-Set one of `SERPER_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, or `SOFYA_API_KEY`.
+Set one of `SERPER_API_KEY`, `SERPBASE_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, or `SOFYA_API_KEY`.
 
 In Antigravity, open the MCP store, then:
 
@@ -557,7 +557,7 @@ Don’t commit/share `mcp_config.json` if it contains API keys.
 
 ### Cursor
 
-Set one of `SERPER_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, or `SOFYA_API_KEY`.
+Set one of `SERPER_API_KEY`, `SERPBASE_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, or `SOFYA_API_KEY`.
 Startup timeout: Cursor does not currently expose a per-server startup timeout setting. If the first run is slow, run the `uvx` command from Quickstart once in a terminal to prebuild the tool environment, then restart Cursor.
 Create `.cursor/mcp.json`:
 
@@ -790,7 +790,7 @@ docker run --rm -p 8000:8000 \
   - Set `KINDLY_DIAGNOSTICS=1` to emit JSON-line diagnostics to stderr and include `diagnostics` in tool responses.
   - `get_content` returns top-level `diagnostics`; `web_search` attaches `diagnostics` per result.
 - `OSError: [Errno 39] Directory not empty: '/tmp/kindly-nodriver-.../Default'`: update to the latest server revision (uv may cache tool envs; `uv cache clean` can help).
-- “web_search fails: no provider key”: set `SERPER_API_KEY`, `TAVILY_API_KEY`, or `SEARXNG_BASE_URL`.
+- “web_search fails: no provider key”: set `SERPER_API_KEY`, `SERPBASE_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, or `SOFYA_API_KEY`.
 
 ## Security
 

--- a/src/kindly_web_search_mcp_server/search/__init__.py
+++ b/src/kindly_web_search_mcp_server/search/__init__.py
@@ -142,26 +142,40 @@ async def search_web(
     http_client: httpx.AsyncClient | None = None,
     diagnostics: Diagnostics | None = None,
 ) -> list[WebSearchResult]:
-    """
-    Search the web using the first configured provider in :data:`PROVIDERS`.
+    """Search the web using the first configured provider in :data:`PROVIDERS`
 
     Selection is by strict priority order with no cross-provider fallback: the
     first provider whose environment variable is set handles the query, and a
     failure from it is raised rather than retried against another provider.
-    """
-    configured = {provider.name: provider.is_configured() for provider in PROVIDERS}
 
-    selected = next(
-        (provider for provider in PROVIDERS if configured[provider.name]), None
-    )
+    Args:
+        query: The search query to run.
+        num_results: Maximum number of results to return.
+        http_client: Client to reuse for the request. A short-lived client is
+            created when omitted.
+        diagnostics: Sink for the provider-selection diagnostic. Nothing is
+            emitted when omitted.
+
+    Returns:
+        The provider's results, at most ``num_results`` of them.
+
+    Raises:
+        WebSearchProviderError: If no provider is configured.
+    """
+    # Read each provider's configuration once, so the selection and the emitted
+    # diagnostic cannot disagree if the environment changes mid-call.
+    statuses = [(provider, provider.is_configured()) for provider in PROVIDERS]
+
+    selected = next((provider for provider, ok in statuses if ok), None)
     if selected is None:
         variables = ", ".join(provider_env_vars())
         raise WebSearchProviderError(
             f"No web search provider is configured. Set one of: {variables}."
         )
 
-    provider_fn: Callable[..., Awaitable[list[WebSearchResult]]]
-    provider_fn = selected.search_function()
+    provider_fn: Callable[..., Awaitable[list[WebSearchResult]]] = (
+        selected.search_function()
+    )
 
     if diagnostics:
         diagnostics.emit(
@@ -171,10 +185,7 @@ async def search_web(
                 "query": query,
                 "num_results": num_results,
                 "provider": selected.name,
-                **{
-                    provider.diagnostics_key: configured[provider.name]
-                    for provider in PROVIDERS
-                },
+                **{provider.diagnostics_key: ok for provider, ok in statuses},
             },
         )
 

--- a/src/kindly_web_search_mcp_server/search/__init__.py
+++ b/src/kindly_web_search_mcp_server/search/__init__.py
@@ -1,7 +1,17 @@
-"""Search providers (Serper → SerpBase → Tavily → SearXNG → Sofya)."""
+"""Search providers (Serper → SerpBase → Tavily → SearXNG → Sofya).
+
+:data:`PROVIDERS` is the single source of truth for which providers exist, what
+configures them, and the order they are selected in. Adding a provider means
+appending one entry here; the router, the startup preflight check in
+:mod:`~kindly_web_search_mcp_server.server`, and its diagnostics snapshot all read
+from it, and tests assert the documentation matches it.
+"""
+
 from __future__ import annotations
 
 import os
+import sys
+from dataclasses import dataclass
 from typing import Awaitable, Callable
 
 import httpx
@@ -15,28 +25,114 @@ from .sofya import search_sofya
 from .tavily import search_tavily
 
 
+# The provider coroutines are re-exported deliberately. `SearchProviderSpec` resolves
+# them by attribute name at call time rather than holding a reference, so a static
+# reader (and the linter) sees no use for the imports above -- but rebinding these
+# module attributes is exactly how tests substitute providers.
+__all__ = [
+    "PROVIDERS",
+    "SearchProviderSpec",
+    "WebSearchProviderError",
+    "any_provider_configured",
+    "provider_env_vars",
+    "search_searxng",
+    "search_serpbase",
+    "search_serper",
+    "search_sofya",
+    "search_tavily",
+    "search_web",
+]
+
+
 class WebSearchProviderError(RuntimeError):
     pass
 
 
-def _has_serper_key() -> bool:
-    return bool(os.environ.get("SERPER_API_KEY", "").strip())
+@dataclass(frozen=True)
+class SearchProviderSpec:
+    """Describe one search provider and how to reach it.
+
+    Attributes:
+        name: Short identifier reported as ``provider`` in diagnostics.
+        label: Human-readable name used in documentation and error messages.
+        env_var: Environment variable whose presence selects this provider.
+        function_name: Attribute name of this provider's search coroutine in
+            this module.
+        diagnostics_key: Key used for this provider's flag in the
+            ``search.provider_select`` diagnostics payload.
+    """
+
+    name: str
+    label: str
+    env_var: str
+    function_name: str
+    diagnostics_key: str
+
+    def is_configured(self) -> bool:
+        """Report whether this provider's environment variable is set.
+
+        Returns:
+            ``True`` when the variable holds a non-blank value.
+        """
+        return bool(os.environ.get(self.env_var, "").strip())
+
+    def search_function(self) -> Callable[..., Awaitable[list[WebSearchResult]]]:
+        """Resolve this provider's search coroutine.
+
+        Looked up by name at call time rather than captured as a reference when
+        :data:`PROVIDERS` is built. Tests patch these coroutines by module
+        attribute (``patch("...search.search_serper")``), which rebinds the module
+        attribute; a captured reference would silently keep pointing at the
+        original function and bypass the patch.
+
+        Returns:
+            The coroutine function that queries this provider.
+        """
+        return getattr(sys.modules[__name__], self.function_name)
 
 
-def _has_serpbase_key() -> bool:
-    return bool(os.environ.get("SERPBASE_API_KEY", "").strip())
+# Order is the selection order: the first configured provider wins, with no
+# cross-provider fallback. `searxng` keeps a `_config` diagnostics key rather than
+# `_key` because it is configured by a base URL, not an API key.
+PROVIDERS: tuple[SearchProviderSpec, ...] = (
+    SearchProviderSpec(
+        "serper", "Serper", "SERPER_API_KEY", "search_serper", "has_serper_key"
+    ),
+    SearchProviderSpec(
+        "serpbase",
+        "SerpBase",
+        "SERPBASE_API_KEY",
+        "search_serpbase",
+        "has_serpbase_key",
+    ),
+    SearchProviderSpec(
+        "tavily", "Tavily", "TAVILY_API_KEY", "search_tavily", "has_tavily_key"
+    ),
+    SearchProviderSpec(
+        "searxng", "SearXNG", "SEARXNG_BASE_URL", "search_searxng", "has_searxng_config"
+    ),
+    SearchProviderSpec(
+        "sofya", "Sofya", "SOFYA_API_KEY", "search_sofya", "has_sofya_key"
+    ),
+)
 
 
-def _has_tavily_key() -> bool:
-    return bool(os.environ.get("TAVILY_API_KEY", "").strip())
+def any_provider_configured() -> bool:
+    """Report whether at least one search provider is configured.
+
+    Returns:
+        ``True`` when any provider's environment variable is set.
+    """
+    return any(provider.is_configured() for provider in PROVIDERS)
 
 
-def _has_searxng_config() -> bool:
-    return bool(os.environ.get("SEARXNG_BASE_URL", "").strip())
+def provider_env_vars() -> tuple[str, ...]:
+    """List the environment variables that select a search provider.
 
-
-def _has_sofya_key() -> bool:
-    return bool(os.environ.get("SOFYA_API_KEY", "").strip())
+    Returns:
+        The variables in provider selection order.
+    """
+    return tuple(provider.env_var for provider in PROVIDERS)
 
 
 async def search_web(
@@ -47,41 +143,25 @@ async def search_web(
     diagnostics: Diagnostics | None = None,
 ) -> list[WebSearchResult]:
     """
-    Search the web using Serper, SerpBase, Tavily, SearXNG, or Sofya.
+    Search the web using the first configured provider in :data:`PROVIDERS`.
 
-    Selection (strict order, no cross-provider fallback):
-    - If SERPER_API_KEY is set: use Serper.
-    - Else if SERPBASE_API_KEY is set: use SerpBase.
-    - Else if TAVILY_API_KEY is set: use Tavily.
-    - Else if SEARXNG_BASE_URL is set: use SearXNG.
-    - Else if SOFYA_API_KEY is set: use Sofya.
+    Selection is by strict priority order with no cross-provider fallback: the
+    first provider whose environment variable is set handles the query, and a
+    failure from it is raised rather than retried against another provider.
     """
-    has_serper = _has_serper_key()
-    has_serpbase = _has_serpbase_key()
-    has_tavily = _has_tavily_key()
-    has_searxng = _has_searxng_config()
-    has_sofya = _has_sofya_key()
-    if not has_serper and not has_serpbase and not has_tavily and not has_searxng and not has_sofya:
+    configured = {provider.name: provider.is_configured() for provider in PROVIDERS}
+
+    selected = next(
+        (provider for provider in PROVIDERS if configured[provider.name]), None
+    )
+    if selected is None:
+        variables = ", ".join(provider_env_vars())
         raise WebSearchProviderError(
-            "No web search provider is configured. Set SERPER_API_KEY, SERPBASE_API_KEY, TAVILY_API_KEY, SEARXNG_BASE_URL, or SOFYA_API_KEY."
+            f"No web search provider is configured. Set one of: {variables}."
         )
 
-    provider: Callable[..., Awaitable[list[WebSearchResult]]]
-    if has_serper:
-        provider = search_serper
-        provider_name = "serper"
-    elif has_serpbase:
-        provider = search_serpbase
-        provider_name = "serpbase"
-    elif has_tavily:
-        provider = search_tavily
-        provider_name = "tavily"
-    elif has_searxng:
-        provider = search_searxng
-        provider_name = "searxng"
-    else:
-        provider = search_sofya
-        provider_name = "sofya"
+    provider_fn: Callable[..., Awaitable[list[WebSearchResult]]]
+    provider_fn = selected.search_function()
 
     if diagnostics:
         diagnostics.emit(
@@ -90,17 +170,16 @@ async def search_web(
             {
                 "query": query,
                 "num_results": num_results,
-                "provider": provider_name,
-                "has_serper_key": has_serper,
-                "has_serpbase_key": has_serpbase,
-                "has_tavily_key": has_tavily,
-                "has_searxng_config": has_searxng,
-                "has_sofya_key": has_sofya,
+                "provider": selected.name,
+                **{
+                    provider.diagnostics_key: configured[provider.name]
+                    for provider in PROVIDERS
+                },
             },
         )
 
     async def _run(client: httpx.AsyncClient) -> list[WebSearchResult]:
-        return await provider(query, num_results=num_results, http_client=client)
+        return await provider_fn(query, num_results=num_results, http_client=client)
 
     if http_client is not None:
         return await _run(http_client)

--- a/src/kindly_web_search_mcp_server/server.py
+++ b/src/kindly_web_search_mcp_server/server.py
@@ -107,7 +107,7 @@ def _resolve_host_port(host: str | None, port: int | None) -> tuple[str, int]:
     return resolved_host, resolved_port
 
 
-def provider_configuration_warning() -> str | None:
+def _provider_configuration_warning() -> str | None:
     """Build the startup warning shown when no search provider is configured.
 
     Derived from :data:`~kindly_web_search_mcp_server.search.PROVIDERS` so that a
@@ -163,7 +163,7 @@ def main(argv: list[str] | None = None) -> None:
 
     # Do not hard-fail on startup: many clients set env vars in their MCP config
     # and expect the server to at least come up for tool discovery.
-    warning = provider_configuration_warning()
+    warning = _provider_configuration_warning()
     if warning:
         LOGGER.warning(warning)
 

--- a/src/kindly_web_search_mcp_server/server.py
+++ b/src/kindly_web_search_mcp_server/server.py
@@ -12,7 +12,7 @@ from mcp.server.fastmcp import FastMCP
 
 from .models import GetContentResponse, WebSearchResponse
 from .content.resolver import resolve_page_content_markdown
-from .search import search_web
+from .search import any_provider_configured, provider_env_vars, search_web
 from .utils.diagnostics import (
     Diagnostics,
     MAX_SAMPLE_CHARS,
@@ -107,6 +107,27 @@ def _resolve_host_port(host: str | None, port: int | None) -> tuple[str, int]:
     return resolved_host, resolved_port
 
 
+def provider_configuration_warning() -> str | None:
+    """Build the startup warning shown when no search provider is configured.
+
+    Derived from :data:`~kindly_web_search_mcp_server.search.PROVIDERS` so that a
+    newly added provider cannot leave this check behind. Previously it named three
+    providers explicitly, so installs configured only with SerpBase or Sofya were
+    warned that search would fail while it worked normally.
+
+    Returns:
+        The warning text, or ``None`` when at least one provider is configured.
+    """
+    if any_provider_configured():
+        return None
+
+    variables = ", ".join(provider_env_vars())
+    return (
+        f"No search provider is configured (set one of: {variables}); "
+        "`web_search` calls will fail until one is provided."
+    )
+
+
 def main(argv: list[str] | None = None) -> None:
     """
     Entrypoint for running the MCP server.
@@ -140,17 +161,11 @@ def main(argv: list[str] | None = None) -> None:
         )
         raise SystemExit(2)
 
-    if not (
-        os.environ.get("SERPER_API_KEY", "").strip()
-        or os.environ.get("TAVILY_API_KEY", "").strip()
-        or os.environ.get("SEARXNG_BASE_URL", "").strip()
-    ):
-        # Do not hard-fail on startup: many clients set env vars in their MCP config
-        # and expect the server to at least come up for tool discovery.
-        LOGGER.warning(
-            "No search provider is configured (SERPER_API_KEY, TAVILY_API_KEY, or SEARXNG_BASE_URL); "
-            "`web_search` calls will fail until one is provided."
-        )
+    # Do not hard-fail on startup: many clients set env vars in their MCP config
+    # and expect the server to at least come up for tool discovery.
+    warning = provider_configuration_warning()
+    if warning:
+        LOGGER.warning(warning)
 
     if transport in ("sse", "streamable-http"):
         host, port = _resolve_host_port(args.host, args.port)
@@ -250,7 +265,8 @@ async def web_search(
 
     Prerequisites:
     - Requires at least one configured search provider in the server environment:
-      `SERPER_API_KEY` (Serper), `TAVILY_API_KEY` (Tavily), or `SEARXNG_BASE_URL` (SearXNG).
+      `SERPER_API_KEY` (Serper), `SERPBASE_API_KEY` (SerpBase), `TAVILY_API_KEY` (Tavily),
+      `SEARXNG_BASE_URL` (SearXNG), or `SOFYA_API_KEY` (Sofya).
       If none is set, this tool will fail.
 
     Returns:
@@ -260,7 +276,8 @@ async def web_search(
 
     Notes:
     - Content extraction is best-effort and may be truncated to avoid context “bombs”.
-    - Provider routing (strict order): Serper → Tavily → SearXNG. No cross-provider fallback.
+    - Provider routing (strict order): Serper → SerpBase → Tavily → SearXNG → Sofya.
+      No cross-provider fallback.
     - If the search provider fails (missing key, quota/rate-limit, network issues), the tool will error.
     - For a deeper look at one result, call `get_content()` on the chosen `link`.
     - This tool is often called under a hard per-call deadline; page_content resolution is bounded by
@@ -274,9 +291,9 @@ async def web_search(
     parent_diag = Diagnostics(parent_request_id, diag_enabled, stream=sys.stderr)
     if diag_enabled:
         env_snapshot = {
-            "SERPER_API_KEY": os.environ.get("SERPER_API_KEY", ""),
-            "TAVILY_API_KEY": os.environ.get("TAVILY_API_KEY", ""),
-            "SEARXNG_BASE_URL": os.environ.get("SEARXNG_BASE_URL", ""),
+            # Provider variables come from the registry so a new provider shows up
+            # in diagnostics without a second edit here.
+            **{name: os.environ.get(name, "") for name in provider_env_vars()},
             "GITHUB_TOKEN": os.environ.get("GITHUB_TOKEN", ""),
             "KINDLY_TOOL_TOTAL_TIMEOUT_SECONDS": os.environ.get("KINDLY_TOOL_TOTAL_TIMEOUT_SECONDS", ""),
             "KINDLY_TOOL_TOTAL_TIMEOUT_MAX_SECONDS": os.environ.get(

--- a/tests/test_provider_registry_consistency.py
+++ b/tests/test_provider_registry_consistency.py
@@ -11,6 +11,7 @@ truth. The prose copies cannot be generated, so these tests fail when one drifts
 
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
@@ -52,15 +53,47 @@ def test_tool_description_documents_every_provider(
     assert provider.label in doc, f"web_search's docstring omits {provider.label}."
 
 
+def _assert_states_registry_order(text: str, pattern: str, source: str) -> None:
+    """Assert the sentence matched by ``pattern`` lists providers in registry order.
+
+    Checks the matched sentence alone rather than the surrounding document. A
+    document-wide scan passes as soon as any earlier list happens to be ordered,
+    which would leave the ordering claim itself unchecked.
+
+    Args:
+        text: Document containing the ordering claim.
+        pattern: Regex whose first group captures the claim, on one line.
+        source: Human-readable name of the document, used in failure messages.
+    """
+    match = re.search(pattern, text)
+    assert match, f"{source} no longer states a provider order."
+
+    claim = match.group(1)
+    positions = [claim.find(provider.label) for provider in PROVIDERS]
+    missing = [p.label for p, pos in zip(PROVIDERS, positions) if pos < 0]
+
+    assert not missing, f"{source} order omits {missing}: {claim.strip()}"
+    assert positions == sorted(positions), (
+        f"{source} order '{claim.strip()}' disagrees with PROVIDERS: "
+        f"{[p.name for p in PROVIDERS]}."
+    )
+
+
 def test_tool_description_states_the_real_routing_order() -> None:
     """Describe providers in the order the router actually selects them"""
-    doc = _tool_docstring()
-    positions = [doc.find(provider.label) for provider in PROVIDERS]
+    _assert_states_registry_order(
+        _tool_docstring(),
+        r"Provider routing \(strict order\):([^\n]*)",
+        "web_search's docstring",
+    )
 
-    assert all(position >= 0 for position in positions)
-    assert positions == sorted(positions), (
-        "web_search's docstring lists providers in a different order than "
-        f"PROVIDERS selects them: {[p.name for p in PROVIDERS]}."
+
+def test_env_example_states_the_real_selection_order() -> None:
+    """Keep the example env file's stated selection order honest"""
+    _assert_states_registry_order(
+        (REPO_ROOT / ".env.example").read_text(encoding="utf-8"),
+        r"Selection order is:([^\n]*)",
+        ".env.example",
     )
 
 
@@ -105,13 +138,13 @@ def test_no_startup_warning_for_any_single_provider(
         provider: Registry entry to configure as the only provider.
         monkeypatch: pytest fixture used to scope environment changes.
     """
-    from kindly_web_search_mcp_server.server import provider_configuration_warning
+    from kindly_web_search_mcp_server.server import _provider_configuration_warning
 
     for entry in PROVIDERS:
         monkeypatch.delenv(entry.env_var, raising=False)
     monkeypatch.setenv(provider.env_var, "configured")
 
-    assert provider_configuration_warning() is None
+    assert _provider_configuration_warning() is None
 
 
 def test_startup_warning_lists_every_provider_when_none_configured(
@@ -122,16 +155,43 @@ def test_startup_warning_lists_every_provider_when_none_configured(
     Args:
         monkeypatch: pytest fixture used to scope environment changes.
     """
-    from kindly_web_search_mcp_server.server import provider_configuration_warning
+    from kindly_web_search_mcp_server.server import _provider_configuration_warning
 
     for entry in PROVIDERS:
         monkeypatch.delenv(entry.env_var, raising=False)
 
-    warning = provider_configuration_warning()
+    warning = _provider_configuration_warning()
 
     assert warning is not None
     for entry in PROVIDERS:
         assert entry.env_var in warning
+
+
+def test_readme_provider_lists_are_complete() -> None:
+    """Complete every README line that enumerates provider variables
+
+    A line naming two or more provider variables is claiming to list the options,
+    so it must name them all. Lines naming exactly one are configuration snippets
+    (a shell export, a JSON key, a ``-e`` flag) and are left alone. Checking only
+    that each provider appears *somewhere* in the README misses a list that was
+    updated in one place and skipped in another.
+    """
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    env_vars = {provider.env_var for provider in PROVIDERS}
+
+    incomplete = []
+    for number, line in enumerate(readme.splitlines(), start=1):
+        present = {env_var for env_var in env_vars if env_var in line}
+        if len(present) >= 2 and present != env_vars:
+            incomplete.append((number, sorted(env_vars - present), line.strip()[:70]))
+
+    assert not incomplete, (
+        "README lines enumerate providers incompletely:\n"
+        + "\n".join(
+            f"  L{number} missing {missing}: {text}"
+            for number, missing, text in incomplete
+        )
+    )
 
 
 def test_registry_entries_are_unique() -> None:

--- a/tests/test_provider_registry_consistency.py
+++ b/tests/test_provider_registry_consistency.py
@@ -1,0 +1,151 @@
+"""Hold every provider list in the tree in sync with the registry.
+
+Providers used to be enumerated separately in the router, the startup preflight
+check, the ``web_search`` tool description, ``.env.example`` and the README. Two
+providers were added without updating all five, so a SerpBase-only or Sofya-only
+install was told no provider was configured while search worked fine.
+
+:data:`~kindly_web_search_mcp_server.search.PROVIDERS` is now the single source of
+truth. The prose copies cannot be generated, so these tests fail when one drifts.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from kindly_web_search_mcp_server.search import PROVIDERS, SearchProviderSpec
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _tool_docstring() -> str:
+    """Return the ``web_search`` tool description shown to the model.
+
+    Returns:
+        The docstring registered as the tool's description.
+    """
+    from kindly_web_search_mcp_server.server import web_search
+
+    return getattr(web_search, "__doc__", "") or ""
+
+
+@pytest.mark.parametrize("provider", PROVIDERS, ids=lambda p: p.name)
+def test_tool_description_documents_every_provider(
+    provider: SearchProviderSpec,
+) -> None:
+    """Name every provider in the description the model reads.
+
+    Args:
+        provider: Registry entry under test.
+    """
+    doc = _tool_docstring()
+
+    assert provider.env_var in doc, (
+        f"web_search's docstring omits {provider.env_var}. It is the tool "
+        "description the model uses to decide how to configure search."
+    )
+    assert provider.label in doc, f"web_search's docstring omits {provider.label}."
+
+
+def test_tool_description_states_the_real_routing_order() -> None:
+    """Describe providers in the order the router actually selects them"""
+    doc = _tool_docstring()
+    positions = [doc.find(provider.label) for provider in PROVIDERS]
+
+    assert all(position >= 0 for position in positions)
+    assert positions == sorted(positions), (
+        "web_search's docstring lists providers in a different order than "
+        f"PROVIDERS selects them: {[p.name for p in PROVIDERS]}."
+    )
+
+
+@pytest.mark.parametrize("provider", PROVIDERS, ids=lambda p: p.name)
+def test_env_example_documents_every_provider(provider: SearchProviderSpec) -> None:
+    """Offer every provider's variable in the shipped example env file.
+
+    Args:
+        provider: Registry entry under test.
+    """
+    env_example = (REPO_ROOT / ".env.example").read_text(encoding="utf-8")
+
+    assert f"{provider.env_var}=" in env_example, (
+        f".env.example has no {provider.env_var} entry."
+    )
+
+
+@pytest.mark.parametrize("provider", PROVIDERS, ids=lambda p: p.name)
+def test_readme_documents_every_provider(provider: SearchProviderSpec) -> None:
+    """Mention every provider in the README.
+
+    Args:
+        provider: Registry entry under test.
+    """
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+
+    assert provider.env_var in readme, f"README.md never mentions {provider.env_var}."
+    assert provider.label in readme, f"README.md never mentions {provider.label}."
+
+
+@pytest.mark.parametrize("provider", PROVIDERS, ids=lambda p: p.name)
+def test_no_startup_warning_for_any_single_provider(
+    provider: SearchProviderSpec, monkeypatch
+) -> None:
+    """Start quietly when exactly one provider is configured, whichever it is.
+
+    This is the defect behind the issue: the preflight check named three providers
+    explicitly, so a SerpBase-only or Sofya-only install was warned that search
+    would fail while it worked normally.
+
+    Args:
+        provider: Registry entry to configure as the only provider.
+        monkeypatch: pytest fixture used to scope environment changes.
+    """
+    from kindly_web_search_mcp_server.server import provider_configuration_warning
+
+    for entry in PROVIDERS:
+        monkeypatch.delenv(entry.env_var, raising=False)
+    monkeypatch.setenv(provider.env_var, "configured")
+
+    assert provider_configuration_warning() is None
+
+
+def test_startup_warning_lists_every_provider_when_none_configured(
+    monkeypatch,
+) -> None:
+    """Name every option when nothing is configured.
+
+    Args:
+        monkeypatch: pytest fixture used to scope environment changes.
+    """
+    from kindly_web_search_mcp_server.server import provider_configuration_warning
+
+    for entry in PROVIDERS:
+        monkeypatch.delenv(entry.env_var, raising=False)
+
+    warning = provider_configuration_warning()
+
+    assert warning is not None
+    for entry in PROVIDERS:
+        assert entry.env_var in warning
+
+
+def test_registry_entries_are_unique() -> None:
+    """Keep provider names, variables and functions distinct"""
+    for field in ("name", "env_var", "function_name", "diagnostics_key"):
+        values = [getattr(provider, field) for provider in PROVIDERS]
+        assert len(values) == len(set(values)), f"duplicate {field} in PROVIDERS"
+
+
+@pytest.mark.parametrize("provider", PROVIDERS, ids=lambda p: p.name)
+def test_registry_resolves_each_search_function(provider: SearchProviderSpec) -> None:
+    """Resolve a callable for every registry entry.
+
+    Args:
+        provider: Registry entry under test.
+    """
+    assert callable(provider.search_function())


### PR DESCRIPTION
Closes #40.

## The problem

Providers were enumerated in **five** places: the router, the startup preflight check, the `web_search` tool description, `.env.example`, and the README. SerpBase (#36) and Sofya (#32) each landed without updating all five.

Concretely, before this PR:

- A **SerpBase-only or Sofya-only** install logged `No search provider is configured (SERPER_API_KEY, TAVILY_API_KEY, or SEARXNG_BASE_URL); web_search calls will fail` — while search worked fine.
- The **tool description the model reads** listed three providers and claimed routing was `Serper → Tavily → SearXNG`. Both the list and the order were wrong.
- `SERPBASE_API_KEY` appeared **nowhere** outside the router — not in `.env.example`, not in the README.

## The fix

`PROVIDERS` in `search/__init__.py` becomes the single source of truth. The router selects from it, and `server.py` derives its preflight warning and diagnostics env snapshot from it. Adding a provider now means appending one entry.

Prose can't be generated, so **tests hold the docs to the registry instead**: the tool description, `.env.example`, and the README must each name every provider, and the description must list them in real selection order.

## Two things worth reviewing closely

**Lazy function resolution is deliberate.** `SearchProviderSpec.search_function()` resolves the coroutine by attribute name at call time rather than holding a reference captured when `PROVIDERS` is built. The suite substitutes providers with `patch("kindly_web_search_mcp_server.search.search_serper")` in 14 places, which rebinds the *module attribute*. A captured reference would keep pointing at the original function and silently bypass every one of those patches — tests would still pass while asserting nothing. I ran the router tests first, before anything else, to confirm the idiom survives.

The provider coroutines are listed in `__all__` for the same reason. Ruff flagged them as unused imports, which is fair — they *are* invisible to a static reader. They're a genuine part of this module's surface, so declaring that is more honest than a `noqa`.

**Diagnostics keys are preserved exactly**, including the `has_searxng_config` outlier (named for a base URL, not an API key). Normalising it would have been tidier but changes observable output for no benefit to this issue.

## Verification

- **Behaviour fixed, all five providers:**

```
SERPER_API_KEY       only -> no warning
SERPBASE_API_KEY     only -> no warning
TAVILY_API_KEY       only -> no warning
SEARXNG_BASE_URL     only -> no warning
SOFYA_API_KEY        only -> no warning
none set             -> No search provider is configured (set one of: SERPER_API_KEY, SERPBASE_API_KEY, ...)
```

- **Guard tests fail before the fix** — 5 failures naming exactly the drift in the issue (tool description missing serpbase/sofya, wrong routing order, `.env.example` missing serpbase, README missing serpbase). All pass after.

- **Mutation-tested.** Appending an undocumented `Mutant` provider to `PROVIDERS` fails 5 tests, confirming the guard catches a *future* provider that skips its docs rather than only the two known-missing ones. It also caught a duplicate `function_name` I'd used in the mutant entry.

- **Router tests pass unchanged** — the 14 `patch(...)` call sites still work.

- Full suite: **128 passed, 11 failed, 3 skipped**. The 11 are the known pre-existing browser/subprocess failures (7 `test_nodriver_worker_sandbox`, 3 `test_universal_html_loader`, 1 Windows concurrency), unchanged.

- `ruff check` and `ruff format --check` clean on all changed files.

## Note

This is the third bug in a row from the same shape — one concept written down in several places that drift apart. The previous two were the `mcp` version bound and the credential-redaction rule. This one is now guarded by tests; the other two are guarded by tests as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
