### PR TITLE
fix: read Sofya snippets from description, and fail loudly when none parse

### DIFF
--- a/src/kindly_web_search_mcp_server/search/sofya.py
+++ b/src/kindly_web_search_mcp_server/search/sofya.py
@@ -41,7 +41,7 @@ async def search_sofya(
     Sofya endpoint:
     - POST https://sofya.co/v1/search
     - Header: Authorization: Bearer <SOFYA_API_KEY>
-    - JSON: {"query": "<query>", "max_results": <num_results>, "search_depth": "snippets"}
+    - JSON: {"query": "<query>", "max_results": <clamped to 1..20>, "search_depth": "snippets"}
 
     `snippets` costs 1 credit and returns SERP text without fetching pages, while
     `basic` costs 3 and returns extracted page content. The cheap depth is correct
@@ -94,14 +94,22 @@ async def search_sofya(
             continue
         title = item.get("title")
         link = item.get("url")
-        # `content` holds extracted page text and is only populated when Sofya
-        # fetched the page. At `snippets` depth it does not, and the SERP text
-        # arrives in `description` instead, so fall back rather than drop the hit.
-        snippet = item.get("content") or item.get("description") or ""
         if not isinstance(title, str) or not isinstance(link, str):
             continue
-        if not isinstance(snippet, str):
-            snippet = ""
+
+        # `content` holds extracted page text and is populated only when Sofya
+        # fetched the page. At `snippets` depth it does not, and the SERP text
+        # arrives in `description` instead. Take the first field that actually
+        # carries text: testing truthiness alone would latch onto a non-string
+        # `content` and never reach `description`.
+        snippet = next(
+            (
+                value
+                for value in (item.get("content"), item.get("description"))
+                if isinstance(value, str) and value
+            ),
+            "",
+        )
 
         # `page_content` is populated later by the MCP tool (best-effort).
         results.append(WebSearchResult(title=title, link=link, snippet=snippet, page_content=""))
@@ -113,8 +121,8 @@ async def search_sofya(
     # and would hide the mismatch, so surface it instead.
     if raw_results and not results:
         raise SofyaError(
-            f"Sofya returned {len(raw_results)} result(s) but none had a usable "
-            "`title` and `url`; the response schema may have changed."
+            f"Sofya returned {len(raw_results)} result(s) but none could be parsed; "
+            "each needs a string `title` and `url`. The response schema may have changed."
         )
 
     return results

--- a/src/kindly_web_search_mcp_server/search/sofya.py
+++ b/src/kindly_web_search_mcp_server/search/sofya.py
@@ -8,6 +8,10 @@ import httpx
 from ..models import WebSearchResult
 
 
+# The API documents `max_results` as accepting 1-20.
+MAX_RESULTS = 20
+
+
 class SofyaError(RuntimeError):
     pass
 
@@ -39,6 +43,11 @@ async def search_sofya(
     - Header: Authorization: Bearer <SOFYA_API_KEY>
     - JSON: {"query": "<query>", "max_results": <num_results>, "search_depth": "snippets"}
 
+    `snippets` costs 1 credit and returns SERP text without fetching pages, while
+    `basic` costs 3 and returns extracted page content. The cheap depth is correct
+    here because this server resolves `page_content` itself with its own browser,
+    so paying Sofya to fetch the same pages would be wasted.
+
     Docs: https://sofya.co/docs
     """
     if not query.strip():
@@ -51,7 +60,9 @@ async def search_sofya(
     url = "https://sofya.co/v1/search"
     payload = {
         "query": query,
-        "max_results": int(num_results),
+        # The API documents max_results as 1-20 and rejects anything outside that
+        # with a 400, so clamp rather than forward a caller's larger request.
+        "max_results": max(1, min(int(num_results), MAX_RESULTS)),
         "search_depth": "snippets",
     }
     headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
@@ -83,13 +94,27 @@ async def search_sofya(
             continue
         title = item.get("title")
         link = item.get("url")
-        snippet = item.get("content")
-        if not isinstance(title, str) or not isinstance(link, str) or not isinstance(snippet, str):
+        # `content` holds extracted page text and is only populated when Sofya
+        # fetched the page. At `snippets` depth it does not, and the SERP text
+        # arrives in `description` instead, so fall back rather than drop the hit.
+        snippet = item.get("content") or item.get("description") or ""
+        if not isinstance(title, str) or not isinstance(link, str):
             continue
+        if not isinstance(snippet, str):
+            snippet = ""
 
         # `page_content` is populated later by the MCP tool (best-effort).
         results.append(WebSearchResult(title=title, link=link, snippet=snippet, page_content=""))
         if len(results) >= num_results:
             break
+
+    # Discarding every result means the response did not match the shape expected
+    # here. Returning an empty list would be indistinguishable from "no matches"
+    # and would hide the mismatch, so surface it instead.
+    if raw_results and not results:
+        raise SofyaError(
+            f"Sofya returned {len(raw_results)} result(s) but none had a usable "
+            "`title` and `url`; the response schema may have changed."
+        )
 
     return results

--- a/tests/test_sofya_unit.py
+++ b/tests/test_sofya_unit.py
@@ -138,6 +138,46 @@ class TestSofyaSnippetSource(unittest.TestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].snippet, "SERP snippet text")
 
+    def test_uses_description_when_content_is_an_empty_string(self) -> None:
+        """Treat a blank `content` as absent rather than as the snippet"""
+        results = self._search(
+            {
+                "results": [
+                    {
+                        "title": "Result",
+                        "url": "https://example.org",
+                        "content": "",
+                        "description": "SERP snippet text",
+                    }
+                ]
+            }
+        )
+
+        self.assertEqual(results[0].snippet, "SERP snippet text")
+
+    def test_uses_description_when_content_is_not_a_string(self) -> None:
+        """Fall through to `description` when `content` is a non-string value
+
+        A truthiness-only fallback latches onto the non-string and never reaches
+        `description`, silently returning an empty snippet.
+        """
+        for odd_content in ({"nested": "object"}, 123, ["list"]):
+            with self.subTest(content=odd_content):
+                results = self._search(
+                    {
+                        "results": [
+                            {
+                                "title": "Result",
+                                "url": "https://example.org",
+                                "content": odd_content,
+                                "description": "SERP snippet text",
+                            }
+                        ]
+                    }
+                )
+
+                self.assertEqual(results[0].snippet, "SERP snippet text")
+
     def test_prefers_content_when_both_are_present(self) -> None:
         """Keep extracted page text when the API did fetch the page"""
         results = self._search(
@@ -165,13 +205,25 @@ class TestSofyaSnippetSource(unittest.TestCase):
         self.assertEqual(results[0].snippet, "")
 
     def test_raises_when_no_returned_result_is_usable(self) -> None:
-        """Fail loudly instead of returning nothing when the schema does not match"""
+        """Fail loudly instead of returning nothing when the schema does not match
+
+        Covers both ways a result is discarded: an entry that is not an object,
+        and an object without a usable string ``title`` and ``url``.
+        """
         from kindly_web_search_mcp_server.search.sofya import SofyaError
 
         with self.assertRaises(SofyaError) as caught:
-            self._search({"results": [{"headline": "x"}, {"headline": "y"}]})
+            self._search(
+                {
+                    "results": [
+                        {"headline": "no title or url"},
+                        "not an object",
+                        {"title": "Result", "url": 123},
+                    ]
+                }
+            )
 
-        self.assertIn("2", str(caught.exception))
+        self.assertIn("3", str(caught.exception))
 
     def test_returns_empty_when_the_api_found_nothing(self) -> None:
         """Return no results, without error, when the query genuinely matched nothing"""

--- a/tests/test_sofya_unit.py
+++ b/tests/test_sofya_unit.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import json
 import os
 import sys
 import unittest
 from pathlib import Path
+from typing import Any
 
 import anyio
 import httpx
@@ -45,6 +47,149 @@ class TestSofyaParsing(unittest.TestCase):
             self.assertTrue(results[0].snippet)
 
         anyio.run(run)
+
+
+class TestSofyaSnippetSource(unittest.TestCase):
+    """Cover which response field supplies the snippet, and the empty-result path.
+
+    Sofya returns extracted page text in ``content`` only when it fetched the page.
+    This client requests ``search_depth="snippets"``, which explicitly does not
+    fetch pages, so the SERP text arrives in ``description`` instead. Reading only
+    ``content`` therefore risks discarding every result.
+    """
+
+    def setUp(self) -> None:
+        """Set a dummy API key and restore the previous value afterwards"""
+        previous = os.environ.get("SOFYA_API_KEY")
+        os.environ["SOFYA_API_KEY"] = "sofya_test"
+
+        def restore() -> None:
+            if previous is None:
+                os.environ.pop("SOFYA_API_KEY", None)
+            else:
+                os.environ["SOFYA_API_KEY"] = previous
+
+        self.addCleanup(restore)
+
+    def _search(
+        self,
+        payload: dict[str, Any],
+        *,
+        num_results: int = 3,
+        sent: dict[str, Any] | None = None,
+    ) -> Any:
+        """Run ``search_sofya`` against a mocked response.
+
+        Args:
+            payload: JSON body the mocked Sofya API returns.
+            num_results: Value forwarded to ``search_sofya``.
+            sent: When given, receives the decoded request body.
+
+        Returns:
+            The parsed results.
+        """
+
+        async def run() -> Any:
+            from kindly_web_search_mcp_server.search.sofya import search_sofya
+
+            def handler(request: httpx.Request) -> httpx.Response:
+                if sent is not None:
+                    sent.update(json.loads(request.content))
+                return httpx.Response(200, json=payload)
+
+            async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+                return await search_sofya("q", num_results=num_results, http_client=client)
+
+        return anyio.run(run)
+
+    def test_uses_description_when_content_is_absent(self) -> None:
+        """Read the SERP snippet, which is what `snippets` depth actually returns"""
+        results = self._search(
+            {
+                "results": [
+                    {
+                        "title": "Result",
+                        "url": "https://example.org",
+                        "description": "SERP snippet text",
+                        "fetched": False,
+                    }
+                ]
+            }
+        )
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].snippet, "SERP snippet text")
+
+    def test_uses_description_when_content_is_null(self) -> None:
+        """Treat an explicit null `content` the same as an absent one"""
+        results = self._search(
+            {
+                "results": [
+                    {
+                        "title": "Result",
+                        "url": "https://example.org",
+                        "content": None,
+                        "description": "SERP snippet text",
+                    }
+                ]
+            }
+        )
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].snippet, "SERP snippet text")
+
+    def test_prefers_content_when_both_are_present(self) -> None:
+        """Keep extracted page text when the API did fetch the page"""
+        results = self._search(
+            {
+                "results": [
+                    {
+                        "title": "Result",
+                        "url": "https://example.org",
+                        "content": "Extracted page content",
+                        "description": "SERP snippet text",
+                    }
+                ]
+            }
+        )
+
+        self.assertEqual(results[0].snippet, "Extracted page content")
+
+    def test_keeps_result_that_has_no_snippet_text(self) -> None:
+        """Keep a usable link even with no snippet, since page_content is fetched later"""
+        results = self._search(
+            {"results": [{"title": "Result", "url": "https://example.org"}]}
+        )
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].snippet, "")
+
+    def test_raises_when_no_returned_result_is_usable(self) -> None:
+        """Fail loudly instead of returning nothing when the schema does not match"""
+        from kindly_web_search_mcp_server.search.sofya import SofyaError
+
+        with self.assertRaises(SofyaError) as caught:
+            self._search({"results": [{"headline": "x"}, {"headline": "y"}]})
+
+        self.assertIn("2", str(caught.exception))
+
+    def test_returns_empty_when_the_api_found_nothing(self) -> None:
+        """Return no results, without error, when the query genuinely matched nothing"""
+        self.assertEqual(self._search({"results": []}), [])
+
+    def test_clamps_max_results_to_the_documented_maximum(self) -> None:
+        """Clamp `max_results` to 20, the documented ceiling, instead of sending 400"""
+        sent: dict[str, Any] = {}
+        self._search({"results": []}, num_results=50, sent=sent)
+
+        self.assertEqual(sent["max_results"], 20)
+
+    def test_requests_snippet_depth(self) -> None:
+        """Request the cheap depth, since page content is resolved by this server"""
+        sent: dict[str, Any] = {}
+        self._search({"results": []}, sent=sent)
+
+        self.assertEqual(sent["search_depth"], "snippets")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #42.

## What I could establish without a key

#42 asked whether Sofya populates `content` at `search_depth="snippets"`. I still don't have a `SOFYA_API_KEY`, so that specific question remains unanswered — but I found enough to make it not matter.

From [Sofya's docs](https://sofya.co/docs):

- `content` — "Extracted page content"; `description` — "SERP snippet"
- `snippets` (1 credit) — "SERP snippets only. Fastest." Explicitly does **not** fetch pages
- each result carries `fetched`, "true if page was fetched, false if snippet only"

That `fetched` flag exists precisely to mark the distinction, which is strong circumstantial evidence that `content` is not populated when no page was fetched.

I then read [Agno's `SofyaTools`](https://raw.githubusercontent.com/agno-agi/agno/main/libs/agno/agno/tools/sofya.py), a working third-party integration. Two things stood out:

- it reads **only `content`** — and **defaults to `search_depth="basic"`**, the depth where `content` is guaranteed
- it clamps `max_results` with `max(1, min(max_results, 20))`

So the reference integration sidesteps the question by never using the cheap depth. **No existing integration exercises the `snippets` + `content` combination this client used** — which is exactly why the bug was plausible and why nobody had hit it.

## The fix

Rather than guess which field wins, handle both:

- Snippet text falls back `content` → `description` → `""`. A result with a usable `title` and `url` is kept even with no snippet text, since this server resolves `page_content` itself with its own browser — the link is the valuable part.
- **Discarding every returned result now raises `SofyaError`** instead of returning `[]`. That was the real defect: an empty list is indistinguishable from "no matches", so a schema mismatch looked like a normal empty search. An empty `results` array still returns `[]`, because that genuinely is no matches.

The second point is what actually closes the issue. Whatever Sofya returns, the client is now either correct or loud — never silently empty.

Also clamps `max_results` to the documented 1–20 instead of forwarding a larger value and taking a 400, matching what Agno does.

The `snippets` depth is kept deliberately, and the reason is now recorded in the docstring: this server does its own page extraction, so paying 3× for Sofya to fetch the same pages would be wasted.

## Tests

Eight new cases, written before the fix — five failed against the old implementation:

| Case | Covers |
|---|---|
| `content` absent | the suspected `snippets` shape |
| `content` null | explicit null, not just missing |
| both present | `content` still wins at `basic` depth |
| neither present | result kept with empty snippet |
| nothing usable | raises rather than returning `[]` |
| `results: []` | returns `[]` without error |
| `num_results=50` | clamped to 20 |
| depth | still requests `snippets` |

They also fix an env leak: the existing test set `SOFYA_API_KEY` globally with no cleanup, so the new class restores the prior value via `addCleanup`.

## Verification

- Full suite: **108 passed, 11 failed, 3 skipped**. The 11 are the known pre-existing browser/subprocess failures — unchanged.
- `ruff check` clean.
- `ruff format` **not** run: both files already fail `ruff format --check` on `main` (there's no ruff config, so the repo isn't format-clean). Reformatting would have buried this change in unrelated churn. Verified against `origin/main` rather than assumed.

## Honest caveat

This makes the client behave correctly under either API shape; it is not a confirmation of which shape Sofya actually returns. If you get a key, one live call still tells you whether `content` or `description` carries the text at `snippets` depth — but nothing breaks either way now, so it's no longer blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
