### PR TITLE
HTTP transport handling improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,4 @@ RUN useradd -m -u 10001 app \
     && chown -R app:app /app
 USER app
 
-# Default to stdio (for `docker run -i ...`). Override with `--http` for HTTP mode.
 ENTRYPOINT ["mcp-web-search"]
-CMD ["--stdio"]

--- a/README.md
+++ b/README.md
@@ -760,6 +760,41 @@ docker run --rm -p 8000:8000 \
 - Remote HTTP is typically **unauthenticated** and **unencrypted** by default; don’t expose this port publicly. Use VPN/firewall rules or a reverse proxy with TLS + auth.
 - Don’t bake API keys into the image; pass them via env vars at runtime.
 
+### Host and origin allowlists (`421` and `403` errors)
+
+The HTTP transports enforce DNS rebinding protection. Out of the box only loopback is
+accepted — `127.0.0.1`, `localhost` and `[::1]` — which covers `docker run -p 8000:8000`
+reached as `http://localhost:8000/mcp`, but not much else. Reach the server under any
+other name (a Compose service name, a LAN address, a reverse-proxy hostname) and you get:
+
+- `421 Invalid Host header` — the `Host` header isn’t in the allowlist.
+- `403 Invalid Origin header` — a browser-based client sent an `Origin` that isn’t.
+
+Widen the allowlist with two comma-separated variables:
+
+| Variable | Matches against | Example |
+|---|---|---|
+| `FASTMCP_ALLOWED_HOSTS` | the `Host` header | `kindly-web-search-mcp:*,localhost:*,127.0.0.1:*` |
+| `FASTMCP_ALLOWED_ORIGINS` | the `Origin` header (browser clients) | `http://localhost:*,https://app.example` |
+
+Syntax notes:
+
+- An entry is either an **exact** value or a `name:*` **port wildcard**. A bare `*` matches
+  nothing — `FASTMCP_ALLOWED_HOSTS=*` rejects every request.
+- `kindly-web-search-mcp:*` matches `kindly-web-search-mcp:8000` but **not** a portless
+  `Host: kindly-web-search-mcp`. List both if your client may omit the port.
+- Setting a variable **replaces** the loopback defaults for that header rather than adding
+  to them. Keep `localhost:*` and `127.0.0.1:*` in the list if you still want local access.
+- The two default independently. Setting only `FASTMCP_ALLOWED_HOSTS` keeps the loopback
+  origins, so browser clients on `http://localhost:<port>` keep working.
+- CORS is derived from `FASTMCP_ALLOWED_ORIGINS`, so an origin that passes preflight is
+  always one the server will also accept on the real request.
+
+Neither variable is a way to turn the protection off, and that is deliberate: this server
+is unauthenticated, and `get_content` will fetch any URL it is given from wherever it runs.
+An open allowlist lets any web page you happen to visit drive it against your own network
+and read the response. List the hosts you actually use.
+
 ### Docker-compose
 
 Add a subsection to `services:` in your `docker-compose.yml`. Setup variables as described above.
@@ -778,9 +813,14 @@ Add a subsection to `services:` in your `docker-compose.yml`. Setup variables as
       - FASTMCP_HOST=0.0.0.0
       - FASTMCP_PORT=8000
       - FASTMCP_TRANSPORT=http
+      # Other containers reach this one by its service name, which is not loopback.
+      # Without this you get `421 Invalid Host header`. See the section above.
+      - FASTMCP_ALLOWED_HOSTS=kindly-web-search-mcp:*,localhost:*,127.0.0.1:*
 ```
 
 `FASTMCP_TRANSPORT` can be `streamable-http` (or simply `http`) for Streamable HTTP, `sse` for SSE.
+It is read by every entry point, including `kindly-web-search-mcp-server start-mcp-server`.
+An unrecognised value logs a warning and falls back to stdio.
 
 Run with:
 
@@ -789,6 +829,11 @@ docker compose up -d
 ```
 
 Container will be built at the first run. To rebuild it, append `--build` to the command above.
+
+> **Warning:** `ports: - "8000:8000"` publishes the server on **all** host interfaces. As with
+> `docker run` above, remote HTTP here is **unauthenticated** and **unencrypted** — don’t expose
+> this port publicly. Bind it to loopback (`"127.0.0.1:8000:8000"`), keep it on an internal
+> Compose network, or put a reverse proxy with TLS + auth in front.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -760,6 +760,36 @@ docker run --rm -p 8000:8000 \
 - Remote HTTP is typically **unauthenticated** and **unencrypted** by default; don’t expose this port publicly. Use VPN/firewall rules or a reverse proxy with TLS + auth.
 - Don’t bake API keys into the image; pass them via env vars at runtime.
 
+### Docker-compose
+
+Add a subsection to `services:` in your `docker-compose.yml`. Setup variables as described above.
+
+```yaml
+  kindly-web-search-mcp:
+    build:
+      context: https://github.com/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server.git#main
+    container_name: kindly-web-search-mcp
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+    environment:
+      - SEARXNG_BASE_URL=...
+      - GITHUB_TOKEN=${KINDLY_GITHUB_TOKEN:-}
+      - FASTMCP_HOST=0.0.0.0
+      - FASTMCP_PORT=8000
+      - FASTMCP_TRANSPORT=http
+```
+
+`FASTMCP_TRANSPORT` can be `streamable-http` (or simply `http`) for Streamable HTTP, `sse` for SSE.
+
+Run with:
+
+```bash
+docker compose up -d
+```
+
+Container will be built at the first run. To rebuild it, append `--build` to the command above.
+
 ## Troubleshooting
 
 - “No Chromium-based browser executable found”: install Chrome/Chromium/Edge and set `KINDLY_BROWSER_EXECUTABLE_PATH` if needed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,11 @@ dependencies = [
     # `>=1.25`: oldest release verified against this server; stops a constrained
     # resolve from silently selecting an older, untested API.
     "mcp>=1.25,<2",
+    # `server.py` imports both directly to wrap the ASGI app in CORS middleware and
+    # serve it. They arrive transitively via `mcp` today, which is exactly the kind of
+    # undeclared dependency `tests/test_dependency_constraints.py` exists to catch.
+    "starlette",
+    "uvicorn",
     "pydantic",
     "httpx[socks]",
     "beautifulsoup4",

--- a/src/kindly_web_search_mcp_server/cli.py
+++ b/src/kindly_web_search_mcp_server/cli.py
@@ -39,6 +39,16 @@ def _has_transport_flag(argv: list[str]) -> bool:
     return any(arg.split("=", 1)[0] in transport_flags for arg in argv)
 
 
+def _transport_env_set() -> bool:
+    """Report whether ``FASTMCP_TRANSPORT`` selects a transport.
+
+    Returns:
+        ``True`` when the variable holds a non-blank value, in which case the server
+        resolves the transport itself and this wrapper must not inject ``--stdio``.
+    """
+    return bool((os.environ.get("FASTMCP_TRANSPORT") or "").strip())
+
+
 def main(argv: list[str] | None = None) -> None:
     from .server import main as server_main
 
@@ -48,7 +58,10 @@ def main(argv: list[str] | None = None) -> None:
     if forwarded_args[:1] == ["--"]:
         forwarded_args = forwarded_args[1:]
 
-    if not _has_transport_flag(forwarded_args):
+    # `--stdio` is injected only when nothing else says otherwise. Injecting it
+    # unconditionally made this entry point the one place FASTMCP_TRANSPORT was
+    # ignored, so a Compose file setting it still came up in stdio and exited.
+    if not _has_transport_flag(forwarded_args) and not _transport_env_set():
         forwarded_args = ["--stdio", *forwarded_args]
 
     previous_context = os.environ.get("KINDLY_MCP_CONTEXT")

--- a/src/kindly_web_search_mcp_server/server.py
+++ b/src/kindly_web_search_mcp_server/server.py
@@ -101,9 +101,12 @@ def _build_arg_parser() -> argparse.ArgumentParser:
 
 
 def _resolve_transport(raw: str | None) -> Transport:
-    if raw in ("stdio", "sse", "streamable-http"):
-        return raw
-    return os.environ.get("FASTMCP_TRANSPORT", "stdio")
+    resolved_transport = raw or os.environ.get("FASTMCP_TRANSPORT", "stdio")
+    if resolved_transport == "http":
+        return "streamable-http"
+    if resolved_transport in ("stdio", "sse", "streamable-http"):
+        return resolved_transport
+    return "stdio"
 
 
 def _resolve_host_port(host: str | None, port: int | None) -> tuple[str, int]:

--- a/src/kindly_web_search_mcp_server/server.py
+++ b/src/kindly_web_search_mcp_server/server.py
@@ -4,6 +4,7 @@ import argparse
 import asyncio
 import logging
 import os
+import re
 import sys
 import time
 from typing import Literal
@@ -29,8 +30,90 @@ from .utils.logging import configure_logging
 configure_logging()
 LOGGER = logging.getLogger(__name__)
 
-allowed_hosts = [h.strip() for h in os.getenv("FASTMCP_ALLOWED_HOSTS", "").split(",") if h.strip()]
-allowed_origins = [o.strip() for o in os.getenv("FASTMCP_ALLOWED_ORIGINS", "").split(",") if o.strip()]
+# Mirrors the loopback allowlist FastMCP installs for itself when it is handed no
+# `transport_security`. It is repeated here rather than left to the SDK because the SDK
+# applies it only when the *constructor* `host` is a loopback address, while this server
+# resolves its bind address later from `FASTMCP_HOST`/`--host`. Stating it explicitly
+# keeps the protection identical whatever we end up binding to.
+LOCALHOST_ALLOWED_HOSTS = ("127.0.0.1:*", "localhost:*", "[::1]:*")
+LOCALHOST_ALLOWED_ORIGINS = ("http://127.0.0.1:*", "http://localhost:*", "http://[::1]:*")
+
+
+def _split_env_list(raw: str | None) -> list[str]:
+    """Split a comma-separated environment variable into its entries.
+
+    Args:
+        raw: The raw environment value, or ``None`` when the variable is unset.
+
+    Returns:
+        The non-empty, whitespace-trimmed entries, in declaration order.
+    """
+    return [item.strip() for item in (raw or "").split(",") if item.strip()]
+
+
+def _resolve_transport_security(
+    allowed_hosts: list[str],
+    allowed_origins: list[str],
+) -> tuple[TransportSecuritySettings, list[str]]:
+    """Resolve DNS-rebinding settings and the CORS origins that must match them.
+
+    DNS rebinding protection stays on unconditionally, and an unset allowlist falls back
+    to loopback rather than to "allow everything". The difference matters because this
+    server is unauthenticated and ``get_content`` fetches whatever URL the caller names:
+    an empty allowlist combined with a permissive CORS policy lets any web page the
+    operator visits drive the server against their own LAN and read the response.
+
+    The two lists default independently. Setting only ``FASTMCP_ALLOWED_HOSTS`` — the
+    natural reaction to a ``421 Invalid Host header`` behind Docker Compose — therefore
+    keeps loopback origins working instead of rejecting every browser request with
+    ``403 Invalid Origin header``.
+
+    Args:
+        allowed_hosts: Host patterns from ``FASTMCP_ALLOWED_HOSTS``; empty when unset.
+        allowed_origins: Origin patterns from ``FASTMCP_ALLOWED_ORIGINS``; empty when unset.
+
+    Returns:
+        A tuple of the :class:`~mcp.server.transport_security.TransportSecuritySettings`
+        for :class:`~mcp.server.fastmcp.FastMCP` and the origin list the CORS middleware
+        must advertise. The second element is always the settings' own origin list, so
+        the two surfaces cannot disagree.
+    """
+    hosts = allowed_hosts or list(LOCALHOST_ALLOWED_HOSTS)
+    origins = allowed_origins or list(LOCALHOST_ALLOWED_ORIGINS)
+    settings = TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=hosts,
+        allowed_origins=origins,
+    )
+    return settings, origins
+
+
+def _cors_origin_regex(origins: list[str]) -> str:
+    """Translate transport-security origin patterns into a CORS origin regex.
+
+    Starlette's ``CORSMiddleware`` matches origins by exact string, so the SDK's
+    ``host:*`` port wildcard would quietly match nothing if passed to it verbatim.
+    Compiling both surfaces from one list is what stops CORS from approving a preflight
+    for an origin the transport-security middleware then rejects with a 403.
+
+    Args:
+        origins: Origin patterns, each either an exact origin or one ending in ``:*``.
+
+    Returns:
+        A regular expression matching exactly the supplied patterns.
+    """
+    alternatives = [
+        re.escape(origin[:-1]) + r"\d+" if origin.endswith(":*") else re.escape(origin)
+        for origin in origins
+    ]
+    return "|".join(alternatives)
+
+
+ALLOWED_HOSTS = _split_env_list(os.getenv("FASTMCP_ALLOWED_HOSTS"))
+ALLOWED_ORIGINS = _split_env_list(os.getenv("FASTMCP_ALLOWED_ORIGINS"))
+TRANSPORT_SECURITY, CORS_ALLOW_ORIGINS = _resolve_transport_security(
+    ALLOWED_HOSTS, ALLOWED_ORIGINS
+)
 
 mcp = FastMCP(
     "kindly-web-search",
@@ -38,11 +121,7 @@ mcp = FastMCP(
         "Web search via Serper (default), Tavily, or a self-hosted SearXNG instance with best-effort "
         "scraping/extraction of result pages into Markdown for LLM consumption."
     ),
-    transport_security=TransportSecuritySettings(
-        enable_dns_rebinding_protection=bool(allowed_hosts or allowed_origins),
-        allowed_hosts=allowed_hosts,
-        allowed_origins=allowed_origins,
-    ),
+    transport_security=TRANSPORT_SECURITY,
 )
 
 Transport = Literal["stdio", "sse", "streamable-http"]
@@ -57,8 +136,8 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     transport_group = parser.add_mutually_exclusive_group()
     transport_group.add_argument(
         "--transport",
-        choices=("stdio", "sse", "streamable-http"),
-        help="Transport to use (default: stdio).",
+        choices=("stdio", "sse", "streamable-http", "http"),
+        help="Transport to use (default: stdio). `http` is an alias for `streamable-http`.",
     )
     transport_group.add_argument(
         "--stdio",
@@ -103,11 +182,31 @@ def _build_arg_parser() -> argparse.ArgumentParser:
 
 
 def _resolve_transport(raw: str | None) -> Transport:
-    resolved_transport = raw or os.environ.get("FASTMCP_TRANSPORT", "stdio")
+    """Resolve the transport from the CLI flag, then ``FASTMCP_TRANSPORT``.
+
+    The CLI flag wins, so an explicit invocation is never overridden by ambient
+    environment. An unrecognised value logs a warning before falling back: in a Compose
+    file a typo would otherwise bring the container up in stdio, which exits immediately
+    with nothing to explain why.
+
+    Args:
+        raw: The value of the CLI transport flag, or ``None`` when it was not given.
+
+    Returns:
+        The resolved transport, with ``http`` normalised to ``streamable-http``.
+    """
+    resolved_transport = (raw or os.environ.get("FASTMCP_TRANSPORT") or "").strip()
+    if not resolved_transport:
+        return "stdio"
     if resolved_transport == "http":
         return "streamable-http"
     if resolved_transport in ("stdio", "sse", "streamable-http"):
         return resolved_transport
+    LOGGER.warning(
+        "Unrecognised transport %r; falling back to stdio. "
+        "Valid values: stdio, sse, streamable-http (or http).",
+        resolved_transport,
+    )
     return "stdio"
 
 
@@ -190,16 +289,20 @@ def main(argv: list[str] | None = None) -> None:
             if hasattr(mcp, "settings") and hasattr(mcp.settings, key):
                 setattr(mcp.settings, key, value)
 
+        # Branch on the resolved transport, not on `hasattr`: `streamable_http_app`
+        # exists on every supported SDK version, so probing for it always selected
+        # Streamable HTTP, making `--sse` serve /mcp while /sse returned 404. Passing
+        # `args.mount_path` here is also what keeps `--mount-path` from being a no-op.
         asgi_app = (
-            mcp.streamable_http_app()
-            if hasattr(mcp, "streamable_http_app")
-            else mcp.sse_app()
+            mcp.sse_app(args.mount_path)
+            if transport == "sse"
+            else mcp.streamable_http_app()
         )
 
         # NB: allow_credentials=True will require explicit methods & headers
         app = CORSMiddleware(
             asgi_app,
-            allow_origins=allowed_origins if allowed_origins else ["*"],
+            allow_origin_regex=_cors_origin_regex(CORS_ALLOW_ORIGINS),
             allow_credentials=False,
             allow_methods=["*"],
             allow_headers=["*"],

--- a/src/kindly_web_search_mcp_server/server.py
+++ b/src/kindly_web_search_mcp_server/server.py
@@ -9,6 +9,7 @@ import time
 from typing import Literal
 
 from mcp.server.fastmcp import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
 
 from .models import GetContentResponse, WebSearchResponse
 from .content.resolver import resolve_page_content_markdown
@@ -26,11 +27,19 @@ from .utils.logging import configure_logging
 configure_logging()
 LOGGER = logging.getLogger(__name__)
 
+allowed_hosts = [h.strip() for h in os.getenv("FASTMCP_ALLOWED_HOSTS", "").split(",") if h.strip()]
+allowed_origins = [o.strip() for o in os.getenv("FASTMCP_ALLOWED_ORIGINS", "").split(",") if o.strip()]
+
 mcp = FastMCP(
     "kindly-web-search",
     instructions=(
         "Web search via Serper (default), Tavily, or a self-hosted SearXNG instance with best-effort "
         "scraping/extraction of result pages into Markdown for LLM consumption."
+    ),
+    transport_security=TransportSecuritySettings(
+        enable_dns_rebinding_protection=bool(allowed_hosts or allowed_origins),
+        allowed_hosts=allowed_hosts,
+        allowed_origins=allowed_origins,
     ),
 )
 
@@ -94,7 +103,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
 def _resolve_transport(raw: str | None) -> Transport:
     if raw in ("stdio", "sse", "streamable-http"):
         return raw
-    return "stdio"
+    return os.environ.get("FASTMCP_TRANSPORT", "stdio")
 
 
 def _resolve_host_port(host: str | None, port: int | None) -> tuple[str, int]:

--- a/src/kindly_web_search_mcp_server/server.py
+++ b/src/kindly_web_search_mcp_server/server.py
@@ -10,6 +10,8 @@ from typing import Literal
 
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
+import uvicorn
+from starlette.middleware.cors import CORSMiddleware
 
 from .models import GetContentResponse, WebSearchResponse
 from .content.resolver import resolve_page_content_markdown
@@ -188,11 +190,28 @@ def main(argv: list[str] | None = None) -> None:
             if hasattr(mcp, "settings") and hasattr(mcp.settings, key):
                 setattr(mcp.settings, key, value)
 
-    try:
-        mcp.run(transport=transport, mount_path=args.mount_path)
-    except TypeError:
-        # Backward-compat: older MCP SDKs may not accept `mount_path`.
-        mcp.run(transport=transport)
+        asgi_app = (
+            mcp.streamable_http_app()
+            if hasattr(mcp, "streamable_http_app")
+            else mcp.sse_app()
+        )
+
+        # NB: allow_credentials=True will require explicit methods & headers
+        app = CORSMiddleware(
+            asgi_app,
+            allow_origins=allowed_origins if allowed_origins else ["*"],
+            allow_credentials=False,
+            allow_methods=["*"],
+            allow_headers=["*"],
+            expose_headers=["mcp-session-id", "mcp-protocol-version"],
+        )
+        uvicorn.run(app, host=host, port=port)
+    else:
+        try:
+            mcp.run(transport=transport, mount_path=args.mount_path)
+        except TypeError:
+            # Backward-compat: older MCP SDKs may not accept `mount_path`.
+            mcp.run(transport=transport)
 
 
 

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -34,6 +34,37 @@ REJECTED_MCP_VERSIONS = ("2.0.0", "2.1.0", "3.0.0")
 SUPPORTED_MCP_VERSION = "1.25.0"
 
 
+# Imported directly at the top of ``server.py`` (``import uvicorn``,
+# ``from starlette.middleware.cors import CORSMiddleware``). Both are satisfied
+# transitively through ``mcp`` today, so nothing fails until the SDK drops one of them
+# — at which point the documented ``uvx --from git+https://...`` install breaks at
+# import for every user. Declaring them turns that into a resolver error instead.
+DIRECTLY_IMPORTED_DEPENDENCIES = ("starlette", "uvicorn")
+
+
+def _declared_dependency_names() -> set[str]:
+    """Collect the distribution names declared in ``[project].dependencies``
+
+    Returns:
+        The lowercased names of every declared runtime dependency.
+    """
+    with PYPROJECT_PATH.open("rb") as handle:
+        pyproject = tomllib.load(handle)
+
+    return {
+        Requirement(entry).name.lower() for entry in pyproject["project"]["dependencies"]
+    }
+
+
+@pytest.mark.parametrize("name", DIRECTLY_IMPORTED_DEPENDENCIES)
+def test_directly_imported_packages_are_declared(name: str) -> None:
+    """Declare every package ``server.py`` imports without going through ``mcp``"""
+    assert name in _declared_dependency_names(), (
+        f"pyproject.toml does not declare '{name}', which server.py imports directly. "
+        "It currently resolves transitively via 'mcp'; that is not a guarantee."
+    )
+
+
 def _read_mcp_requirement() -> Requirement:
     """Extract the ``mcp`` requirement declared in ``pyproject.toml``
 

--- a/tests/test_server_transport.py
+++ b/tests/test_server_transport.py
@@ -1,0 +1,242 @@
+"""Cover transport selection and transport security for the HTTP/SSE entry points.
+
+These are the behaviours that have no other guard: ``main`` never returns for a live
+server, so the ASGI app is captured by patching :func:`uvicorn.run` and inspected
+instead of being served. The origin tests check the CORS policy against the SDK's own
+validator rather than against a hand-written expectation, because the defect being
+guarded is the two disagreeing, not either one in isolation.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+import pytest
+from mcp.server.transport_security import TransportSecurityMiddleware
+
+from kindly_web_search_mcp_server.server import (
+    LOCALHOST_ALLOWED_HOSTS,
+    LOCALHOST_ALLOWED_ORIGINS,
+    _cors_origin_regex,
+    _resolve_transport,
+    _resolve_transport_security,
+    _split_env_list,
+)
+
+
+# --- transport resolution -----------------------------------------------------------
+
+
+def test_transport_defaults_to_stdio_when_nothing_is_set(monkeypatch) -> None:
+    """Fall back to stdio when neither the flag nor the environment selects one"""
+    monkeypatch.delenv("FASTMCP_TRANSPORT", raising=False)
+    assert _resolve_transport(None) == "stdio"
+
+
+@pytest.mark.parametrize(
+    ("env_value", "expected"),
+    [
+        ("stdio", "stdio"),
+        ("sse", "sse"),
+        ("streamable-http", "streamable-http"),
+        ("http", "streamable-http"),
+        ("  http  ", "streamable-http"),
+    ],
+)
+def test_transport_env_var_is_honoured(monkeypatch, env_value: str, expected: str) -> None:
+    """Honour ``FASTMCP_TRANSPORT``, normalising the ``http`` alias"""
+    monkeypatch.setenv("FASTMCP_TRANSPORT", env_value)
+    assert _resolve_transport(None) == expected
+
+
+def test_cli_flag_wins_over_env_var(monkeypatch) -> None:
+    """Prefer the explicit CLI flag over ambient environment"""
+    monkeypatch.setenv("FASTMCP_TRANSPORT", "streamable-http")
+    assert _resolve_transport("sse") == "sse"
+
+
+def test_blank_env_var_is_treated_as_unset(monkeypatch, caplog) -> None:
+    """Treat a blank ``FASTMCP_TRANSPORT`` as unset, without warning"""
+    monkeypatch.setenv("FASTMCP_TRANSPORT", "   ")
+    with caplog.at_level(logging.WARNING):
+        assert _resolve_transport(None) == "stdio"
+    assert caplog.records == []
+
+
+def test_invalid_env_var_falls_back_to_stdio_with_a_warning(monkeypatch, caplog) -> None:
+    """Warn before falling back, so a Compose typo is not silent"""
+    monkeypatch.setenv("FASTMCP_TRANSPORT", "htpp")
+    with caplog.at_level(logging.WARNING):
+        assert _resolve_transport(None) == "stdio"
+    assert any("htpp" in record.getMessage() for record in caplog.records)
+
+
+def test_http_is_accepted_by_the_transport_flag() -> None:
+    """Accept ``--transport http`` because the env var accepts ``http``"""
+    from kindly_web_search_mcp_server.server import _build_arg_parser
+
+    args = _build_arg_parser().parse_args(["--transport", "http"])
+    assert _resolve_transport(args.transport) == "streamable-http"
+
+
+# --- transport security defaults ----------------------------------------------------
+
+
+def test_split_env_list_trims_and_drops_blanks() -> None:
+    """Trim entries and drop the empties a trailing comma leaves behind"""
+    assert _split_env_list(" a:* , ,b:8000 ") == ["a:*", "b:8000"]
+    assert _split_env_list(None) == []
+    assert _split_env_list("") == []
+
+
+def test_unconfigured_server_keeps_loopback_protection() -> None:
+    """Keep DNS rebinding protection on when no allowlist is configured
+
+    This is the regression that matters most: an empty allowlist previously turned
+    protection off entirely for every user who had not set the variables.
+    """
+    settings, cors_origins = _resolve_transport_security([], [])
+
+    assert settings.enable_dns_rebinding_protection is True
+    assert settings.allowed_hosts == list(LOCALHOST_ALLOWED_HOSTS)
+    assert settings.allowed_origins == list(LOCALHOST_ALLOWED_ORIGINS)
+    assert cors_origins == list(LOCALHOST_ALLOWED_ORIGINS)
+
+
+def test_configuring_hosts_alone_keeps_loopback_origins() -> None:
+    """Leave origins working when only ``FASTMCP_ALLOWED_HOSTS`` is set
+
+    Setting the hosts alone is the natural reaction to a 421 behind Compose. It must
+    not leave an empty origin allowlist, which rejects every browser request with 403.
+    """
+    settings, cors_origins = _resolve_transport_security(["kindly-web-search-mcp:*"], [])
+
+    assert settings.allowed_hosts == ["kindly-web-search-mcp:*"]
+    assert settings.allowed_origins == list(LOCALHOST_ALLOWED_ORIGINS)
+    assert cors_origins == list(LOCALHOST_ALLOWED_ORIGINS)
+
+
+def test_configured_origins_are_used_verbatim() -> None:
+    """Use the configured origins for both the SDK and the CORS policy"""
+    settings, cors_origins = _resolve_transport_security([], ["https://app.example"])
+
+    assert settings.allowed_origins == ["https://app.example"]
+    assert cors_origins == settings.allowed_origins
+
+
+# --- CORS / transport-security agreement --------------------------------------------
+
+SAMPLE_ORIGINS = (
+    "http://localhost:3000",
+    "http://127.0.0.1:8000",
+    "http://[::1]:8000",
+    "https://evil.example",
+    "http://localhost.evil.example",
+    "https://localhost:3000",
+)
+
+
+@pytest.mark.parametrize("origin", SAMPLE_ORIGINS)
+def test_cors_regex_agrees_with_the_sdk_origin_validator(origin: str) -> None:
+    """Match exactly what the SDK's transport-security middleware accepts
+
+    A green preflight followed by a 403 on the real request is the failure this pins
+    down, so the two policies are compared directly rather than to a fixed expectation.
+    """
+    settings, cors_origins = _resolve_transport_security([], [])
+    middleware = TransportSecurityMiddleware(settings)
+
+    cors_allows = re.compile(_cors_origin_regex(cors_origins)).fullmatch(origin) is not None
+
+    assert cors_allows == middleware._validate_origin(origin)
+
+
+def test_cors_regex_rejects_a_foreign_origin() -> None:
+    """Reject an arbitrary web page outright, rather than answering it with ``*``"""
+    _, cors_origins = _resolve_transport_security([], [])
+    pattern = re.compile(_cors_origin_regex(cors_origins))
+
+    assert pattern.fullmatch("https://evil.example") is None
+    assert pattern.fullmatch("http://localhost:3000") is not None
+
+
+# --- ASGI app selection -------------------------------------------------------------
+
+
+def _captured_app(monkeypatch, argv: list[str]):
+    """Run ``main`` far enough to capture the ASGI app it would serve.
+
+    Args:
+        monkeypatch: The pytest monkeypatch fixture.
+        argv: Command-line arguments for the server entry point.
+
+    Returns:
+        The application handed to :func:`uvicorn.run`.
+    """
+    import kindly_web_search_mcp_server.server as server
+
+    captured: dict[str, object] = {}
+
+    def fake_run(app, host: str, port: int) -> None:
+        captured["app"] = app
+        captured["host"] = host
+        captured["port"] = port
+
+    monkeypatch.setattr(server.uvicorn, "run", fake_run)
+    server.main(argv)
+    return captured
+
+
+def _route_paths(app) -> set[str]:
+    """List the paths served by a CORS-wrapped Starlette application.
+
+    Args:
+        app: The :class:`~starlette.middleware.cors.CORSMiddleware` instance.
+
+    Returns:
+        The path of every route on the wrapped application.
+    """
+    return {route.path for route in app.app.routes}
+
+
+def test_sse_transport_serves_the_sse_routes(monkeypatch) -> None:
+    """Serve ``/sse`` for ``--sse``
+
+    ``streamable_http_app`` exists on every supported SDK version, so selecting the app
+    by ``hasattr`` silently served Streamable HTTP and 404'd every existing SSE client.
+    """
+    captured = _captured_app(monkeypatch, ["--sse", "--host", "127.0.0.1", "--port", "8001"])
+
+    assert "/sse" in _route_paths(captured["app"])
+    assert captured["port"] == 8001
+
+
+def test_streamable_http_transport_serves_the_mcp_route(monkeypatch) -> None:
+    """Serve ``/mcp`` for ``--http``"""
+    captured = _captured_app(monkeypatch, ["--http", "--host", "127.0.0.1", "--port", "8002"])
+
+    assert "/mcp" in _route_paths(captured["app"])
+
+
+def test_mount_path_is_forwarded_to_the_sse_app(monkeypatch) -> None:
+    """Honour ``--mount-path``, which the HTTP branch had turned into a no-op
+
+    ``mount_path`` does not rename the Starlette routes; it changes the message
+    endpoint the SSE transport advertises to the client, which is what makes the server
+    usable behind a proxy prefix. That advertised path is asserted here because the
+    route set alone cannot tell the two branches apart.
+    """
+    import kindly_web_search_mcp_server.server as server
+
+    # `mcp` is a module-level singleton, so the original value is restored on teardown.
+    monkeypatch.setattr(server.mcp.settings, "mount_path", "/")
+    _captured_app(monkeypatch, ["--sse", "--mount-path", "/kindly", "--port", "8003"])
+
+    assert server.mcp.settings.mount_path == "/kindly"
+    assert (
+        server.mcp._normalize_path(
+            server.mcp.settings.mount_path, server.mcp.settings.message_path
+        )
+        == "/kindly/messages/"
+    )

--- a/tests/test_uvx_cli.py
+++ b/tests/test_uvx_cli.py
@@ -85,3 +85,62 @@ def test_start_mcp_server_restores_existing_context(monkeypatch) -> None:
     assert captured["argv"] == ["--stdio"]
     assert captured["context"] == "codex"
     assert os.environ.get("KINDLY_MCP_CONTEXT") == "existing"
+
+
+def test_start_mcp_server_honours_transport_env_var(monkeypatch) -> None:
+    """Leave the transport to the server when FASTMCP_TRANSPORT selects one
+
+    Injecting `--stdio` unconditionally made this the one entry point where
+    FASTMCP_TRANSPORT was ignored, so a container configured for HTTP came up in
+    stdio and exited immediately.
+    """
+    from kindly_web_search_mcp_server import cli
+    import kindly_web_search_mcp_server.server as server
+
+    captured: dict[str, object] = {}
+
+    def fake_server_main(argv: list[str] | None = None) -> None:
+        captured["argv"] = argv
+
+    monkeypatch.setattr(server, "main", fake_server_main)
+    monkeypatch.setenv("FASTMCP_TRANSPORT", "http")
+
+    cli.main(["start-mcp-server", "--context", "codex"])
+
+    assert captured["argv"] == []
+
+
+def test_start_mcp_server_ignores_blank_transport_env_var(monkeypatch) -> None:
+    """Still default to stdio when FASTMCP_TRANSPORT is set but blank"""
+    from kindly_web_search_mcp_server import cli
+    import kindly_web_search_mcp_server.server as server
+
+    captured: dict[str, object] = {}
+
+    def fake_server_main(argv: list[str] | None = None) -> None:
+        captured["argv"] = argv
+
+    monkeypatch.setattr(server, "main", fake_server_main)
+    monkeypatch.setenv("FASTMCP_TRANSPORT", "   ")
+
+    cli.main(["start-mcp-server"])
+
+    assert captured["argv"] == ["--stdio"]
+
+
+def test_start_mcp_server_flag_still_wins_over_transport_env_var(monkeypatch) -> None:
+    """Forward an explicit flag untouched even when the env var disagrees"""
+    from kindly_web_search_mcp_server import cli
+    import kindly_web_search_mcp_server.server as server
+
+    captured: dict[str, object] = {}
+
+    def fake_server_main(argv: list[str] | None = None) -> None:
+        captured["argv"] = argv
+
+    monkeypatch.setattr(server, "main", fake_server_main)
+    monkeypatch.setenv("FASTMCP_TRANSPORT", "http")
+
+    cli.main(["start-mcp-server", "--stdio"])
+
+    assert captured["argv"] == ["--stdio"]


### PR DESCRIPTION
Solved some problems with the current upstream implementation:

- Better handling of transport parameter:
  - setting via FASTMCP_TRANSPORT environment variable
  - consistent `http` -> `streamable-http` aliasing
  - `stdio` by default without explicit docker CMD
- supported `TransportSecuritySettings` present in newer FastMCP versions according to the guide at https://github.com/modelcontextprotocol/python-sdk/issues/1798. Solves "OPTIONS /mcp HTTP/1.1" 421 Misdirected Request.
- added CORS middleware. Solves "OPTIONS /mcp HTTP/1.1" 405 Method Not Allowed.

I didn't find a contribution guide, so I did my best to explain problems and changes above. Feel free to ask if you need more information.