### PR TITLE
chore: apply §10.2's dependency constraints in full (E0-1 / KMCP-16)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ __pycache__/
 /codex_session.txt
 /CLAUDE.md
 /REQUIREMENTS.md
+/.requirements/
 /.claude/
 /research/

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -797,13 +797,38 @@ project is pure asyncio, so the marker is noise. Migration removes every
 | `diff-cover` | `>=10.4,<11` | Diff coverage on changed lines; 10.4 is the floor because `--branch-coverage` does not exist below it (§10.4) |
 | `mutmut` | `>=3,<4` | L1 validation; **needs `fork()` — Linux/WSL only** |
 | `ruff` | `>=0.6,<1` | Lint |
-| `mypy` | `>=1.11,<2` | Static check for the test-double Protocols (§8A step 3) |
+| `mypy` | `>=2.3.1,<3` | Static check for the test-double Protocols (§8A step 3) |
 | `packaging` | `>=24` | Dependency guard |
 
 Bounds, not "current": this project has twice been broken by an unbounded
 dependency, which is why `test_dependency_constraints.py` exists. **Update
 policy:** bounds are raised in a PR that runs the full suite against the new
 version; Dependabot may propose, never auto-merge.
+
+**This table is machine-checked.** `tests/test_dependency_constraints.py` parses
+it and fails if it and `pyproject.toml` disagree in either direction, so a
+docs-only edit here turns CI red. Change both in the same PR. `packaging>=24` is
+deliberately one-sided — it is the only entry without an upper bound, because the
+guard module needs a floor for `Requirement`/`SpecifierSet` behaviour and
+`packaging` has no breaking-major cadence to defend against.
+
+**The `mutation` extra is additive and is never installed alone.** `mutmut` drives
+pytest over the L1 suite, which needs `hypothesis` and `pytest-asyncio`; mutmut's
+own metadata declares neither. The nightly installs `.[dev,mutation]`. Installed
+by itself it produces a mutmut whose test command fails at import, which surfaces
+as "tests fail on unmutated code" rather than as a missing dependency.
+
+**`mypy` tracks the current major, not the 1.x line.** An earlier draft of this
+table said `>=1.11,<2`. mypy 2.0.0 shipped 6 May 2026 and 2.3.1 is current, so
+that bound excluded every supported release of the tool. The 2.0 breaking changes
+are dropping Python 3.9 as a runtime and as a `--python-version` target, and
+enabling `--local-partial-types` and `--strict-bytes` by default. The first is
+irrelevant to a `requires-python >=3.13` project; the second two change what mypy
+reports, not what the code may express. §8A step 3's Protocol harness is the first
+mypy harness in this repo, so writing it against 1.x defaults would only buy a
+second migration later, against code written for the superseded behaviour. The floor is
+the exact release verified rather than a bare `>=2`, matching how `mcp>=1.25` is
+justified in `pyproject.toml`.
 
 **No HTTP-mocking library.** `httpx.MockTransport` is already the pattern in
 `test_searxng_unit.py:57` and covers every case here.
@@ -1410,11 +1435,47 @@ free would reopen the same hole one level down.
 
 `requirements-ratchet.txt` is regenerated deliberately, and its header records how:
 install a `ratchet` extra — declaring pytest, pytest-asyncio, hypothesis, coverage,
-diff-cover and mypy — into a clean Python 3.13 Linux virtualenv, then
+diff-cover, mypy and packaging — into a clean Python 3.13 Linux virtualenv, then
 `pip freeze --exclude-editable` with the project itself filtered out, since a
 `pip freeze` after `pip install .[…]` otherwise records a local path or URL that no
 other machine can resolve. Add `--require-hashes` if this lane is ever treated as
 security-relevant; reproducibility alone does not need it.
+
+`packaging` is in that list for the same reason it is in `dev`:
+`test_dependency_constraints.py` imports it directly, and a directly-imported
+package that arrives only transitively is precisely the failure that guard exists
+to catch. It *would* resolve through `pytest`, whose metadata requires
+`packaging>=22` unconditionally — so declaring it changes nothing about whether
+the lane runs, and everything about whether the declaration is honest. `ruff` and
+`mutmut` stay out: `ruff` is lint rather than measurement, and `mutmut` is
+Linux-only and belongs to the nightly.
+
+`mypy` is in the pinned lane on the assumption that E2-1's negative type-check
+fixture runs inside the ratcheted selection. If E2-1 marks that fixture
+`subsystem` — §10.5 defines the marker as needing "a real socket or child
+process", and the fixture shells out to mypy — then it leaves the hermetic set and
+`mypy` should be dropped from both this extra and the lockfile. **E2-1 must state
+the marker explicitly**; the two readings disagree and nothing else settles it.
+
+**The lockfile is the whole environment, not just the tooling.** §10.3's lane
+installs the project with `--no-deps`, so nothing else resolves `mcp`, `httpx`,
+`nodriver` or `trafilatura` — they are pinned here too. That is deliberate, and it
+has a consequence the reset rule above must absorb: **a runtime dependency bump
+moves the baseline**, because a different `mcp` or `nodriver` takes different
+branches in the hermetic suite. The reset trigger is therefore a `coverage`,
+Python, **or pinned runtime-dependency** update, not the first two alone. Where
+this file and `requirements.txt` disagree, this file wins for this lane; they are
+permitted to diverge.
+
+Adopting `--require-hashes` also means relaxing
+`test_ratchet_lockfile_pins_every_entry`, which currently requires every line to
+be a bare `name==version`; a hash-pinned file is a continuation line plus
+`--hash=` entries. Change both in the same PR.
+
+The exact `coverage` pin is raised only in a labelled `coverage-baseline-reset`
+PR, and the baseline is only ever measured from `requirements-ratchet.txt` —
+never from `.[dev]`, whose `>=7.10.3,<8` range resolves higher and would report a
+different number locally than CI does.
 
 Because the ratcheted set is `fast` only, no browser image is involved and the
 test-runtime image digest cannot move the baseline. That is a further reason to

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -293,6 +293,14 @@ it carries no X-number.
   job is red forever. It lives under `tests/typing_negative/`, is excluded in mypy
   config, and is exercised by a harness that shells out to mypy, asserts a
   non-zero exit, and asserts the *specific* diagnostic code.
+  **Two consequences of §10.2's `mypy>=2.3.1,<3`.** mypy 2.x enables
+  `--strict-bytes` by default, so the fake's `stdout`/`stderr` must return `bytes`
+  — a buffer-backed fake returning `bytearray` or `memoryview` no longer
+  type-checks. And this step must **state the harness's marker**: it shells out to
+  mypy, which §10.5's `subsystem` definition ("a real socket or child process")
+  covers, but §10.4 currently puts `mypy` in the `ratchet` extra on the assumption
+  the harness stays in the hermetic set. Mark it `subsystem` and `mypy` leaves
+  both the `ratchet` extra and the lockfile.
   *Verify:* the harness fails if the negative fixture starts type-checking
   cleanly; removing `stdout` from the fake fails mypy and the conformance test; a
   test documents that `isinstance` alone does not catch a wrong `wait()`
@@ -860,8 +868,9 @@ live credentials nor the live jobs**.
 The dependency list matches §3.2's mutation scope exactly: the URL parsers (E5-1,
 E5-2), the environment resolvers (E5-3, E5-4) and diagnostics redaction (E5-7).
 E5-6's accumulators are **not** in that scope, so they are not a dependency.
-Installs from the `mutation` extra (E0-1); Linux-only, since `mutmut` needs
-`fork()`.
+Installs `.[dev,mutation]` (E0-1) — the `mutation` extra is additive and carries
+only `mutmut`, which declares neither `hypothesis` nor `pytest-asyncio` and so
+cannot run E5-1/E5-2 on its own. Linux-only, since `mutmut` needs `fork()`.
 *Verify:* completes within the nightly budget; surviving mutants publish as a
 review queue, not a gate; the job is in `nightly-summary.needs`, and a failed or
 skipped mutation job makes the summary fail.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,10 +32,55 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Every bound below comes from §10.2 of `.system_design/TEST_SUITE.md` and is
+# asserted by `tests/test_dependency_constraints.py`. They are bounds rather than
+# "current" because this project has twice been broken by an unbounded dependency.
+# Raising one is a deliberate PR that runs the full suite against the new version;
+# Dependabot may propose, never auto-merge.
+#
 # `packaging` is declared rather than inherited from pytest: the dependency-bound
 # guard in `tests/test_dependency_constraints.py` imports it directly, and relying
 # on a transitive dep is the same failure mode that guard exists to prevent.
-dev = ["pytest", "ruff", "packaging"]
+dev = [
+    "pytest>=9,<10",
+    "pytest-asyncio>=1.4,<2",
+    "hypothesis>=6.167,<7",
+    "coverage>=7.10.3,<8",
+    "diff-cover>=10.4,<11",
+    "ruff>=0.6,<1",
+    "mypy>=2.3.1,<3",
+    "packaging>=24",
+]
+# `mutmut` needs `fork()` and therefore only runs on Linux/WSL. It is kept out of
+# `dev` so the extra everyone installs stays installable everywhere.
+#
+# This extra is ADDITIVE, never installed alone: `mutmut` drives pytest over the
+# L1 suite, which needs `hypothesis` and `pytest-asyncio`, and mutmut declares
+# neither. The nightly mutation job installs `.[dev,mutation]`. Installing this
+# extra by itself yields a mutmut whose test command fails at import — which
+# reads as "tests fail on unmutated code", not as a missing dependency.
+mutation = ["mutmut>=3,<4"]
+# The pinned environment §10.4's coverage baseline is measured in.
+# `requirements-ratchet.txt` is the frozen transitive closure of this extra and is
+# what CI installs; this list is the input that regenerates it.
+#
+# `coverage` is pinned exactly rather than range-bounded because a patch release
+# that moved a two-decimal total would fail the ratchet for reasons unrelated to
+# the change under test. `ruff` is absent because linting is not measurement, and
+# `mutmut` because it is Linux-only and belongs to the nightly. `packaging` is
+# present for the same reason it is in `dev`: the guard module imports it
+# directly. It does resolve transitively through `pytest`, so declaring it changes
+# nothing about whether the lane runs — only whether the declaration is honest,
+# which is the whole point of that guard.
+ratchet = [
+    "pytest>=9,<10",
+    "pytest-asyncio>=1.4,<2",
+    "hypothesis>=6.167,<7",
+    "coverage==7.13.5",
+    "diff-cover>=10.4,<11",
+    "mypy>=2.3.1,<3",
+    "packaging>=24",
+]
 # Optional extras for improved PDF-to-Markdown conversion on supported Python versions.
 # These pull in `onnxruntime` transitively (via `pymupdf-layout`), which may not have wheels
 # for the newest CPython releases (e.g., cp314). Keeping them optional avoids install

--- a/requirements-ratchet.txt
+++ b/requirements-ratchet.txt
@@ -1,0 +1,100 @@
+# requirements-ratchet.txt - the pinned environment for the coverage-ratchet lane.
+#
+# GENERATED FILE, do not hand-edit. This is the single dependency authority for
+# the `coverage` job of TEST_SUITE.md section 10.3, which measures the committed
+# coverage baseline. requirements.txt is not a substitute: it covers runtime only
+# and carries no pytest, coverage or diff-cover. Every entry is exact, including
+# the transitive ones - pinning the named tools while leaving their dependencies
+# free would reopen the same hole one level down.
+#
+# Regenerate deliberately, in a clean Python 3.13 Linux virtualenv:
+#
+#     python3.13 -m venv /tmp/ratchet && . /tmp/ratchet/bin/activate
+#     pip install '.[ratchet]'
+#     pip freeze --exclude-editable | grep -v '^kindly-web-search-mcp-server'
+#
+# The grep is required. `pip install .[ratchet]` installs the project itself, and
+# a plain freeze then records it as a local `file://` path no other machine can
+# resolve; --exclude-editable does not drop it, because it is not an editable
+# install. CI installs this file first and the project second, with
+# `pip install --no-deps -e .`, which is why the runtime dependencies are pinned
+# here too - the --no-deps step has nothing else to resolve them from.
+#
+# The platform matters: a lockfile taken on Windows or on another Python version
+# silently moves the coverage baseline the ratchet compares against.
+#
+# Last generated: 2026-08-30 - Python 3.13.7, Linux (Ubuntu 22.04 on WSL2).
+
+annotated-types==0.8.0
+anyio==4.14.2
+ast_serialize==0.8.0
+attrs==26.1.0
+babel==2.18.0
+beautifulsoup4==4.15.0
+certifi==2026.7.22
+cffi==2.1.1
+chardet==7.6.0
+charset-normalizer==3.5.1
+click==8.5.0
+courlan==1.4.0
+coverage==7.13.5
+cryptography==50.0.1
+dateparser==1.4.2
+Deprecated==1.3.1
+diff_cover==10.5.1
+h11==0.16.0
+htmldate==1.10.0
+httpcore==1.0.9
+httpx==0.28.1
+httpx-sse==0.4.3
+hypothesis==6.167.1
+idna==3.19
+iniconfig==2.3.0
+Jinja2==3.1.6
+jsonschema==4.26.0
+jsonschema-specifications==2025.9.1
+jusText==3.0.2
+librt==0.15.0
+lxml==6.1.2
+lxml_html_clean==0.4.5
+markdownify==1.2.3
+MarkupSafe==3.0.3
+mcp==1.29.1
+mss==10.2.0
+mypy==2.3.1
+mypy_extensions==1.1.0
+nodriver==0.50.3
+packaging==26.3
+pathspec==1.1.1
+pluggy==1.6.0
+pycparser==3.0
+pydantic==2.13.5
+pydantic-settings==2.15.0
+pydantic_core==2.46.5
+Pygments==2.21.0
+PyJWT==2.13.0
+pymupdf==1.28.2
+pytest==9.1.1
+pytest-asyncio==1.4.0
+python-dateutil==2.9.0.post0
+python-dotenv==1.2.3
+python-multipart==0.0.32
+pytz==2026.3.post1
+referencing==0.37.0
+regex==2026.8.31
+rpds-py==2026.6.3
+six==1.17.0
+socksio==1.0.0
+sortedcontainers==2.4.0
+soupsieve==2.9.2
+sse-starlette==3.4.8
+starlette==1.6.0
+tld==0.13.2
+trafilatura==2.2.0
+typing-inspection==0.4.4
+typing_extensions==4.16.0
+tzlocal==5.4.4
+urllib3==2.7.0
+uvicorn==0.52.4
+websockets==17.1
+wrapt==2.4.0

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -13,14 +13,20 @@ works; the assertions here constrain what may be resolved in the first place.
 
 from __future__ import annotations
 
+import re
 import tomllib
 from pathlib import Path
 
 import pytest
 from packaging.requirements import Requirement
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.utils import canonicalize_name
 from packaging.version import Version
 
-PYPROJECT_PATH = Path(__file__).resolve().parents[1] / "pyproject.toml"
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
+TEST_SUITE_PATH = REPO_ROOT / ".system_design" / "TEST_SUITE.md"
+RATCHET_LOCKFILE_PATH = REPO_ROOT / "requirements-ratchet.txt"
 
 # The MCP SDK removed ``mcp.server.fastmcp`` in 2.0.0. The later versions are
 # listed deliberately: a too-narrow pin such as ``!=2.0.0`` excludes exactly the
@@ -40,6 +46,84 @@ SUPPORTED_MCP_VERSION = "1.25.0"
 # — at which point the documented ``uvx --from git+https://...`` install breaks at
 # import for every user. Declaring them turns that into a resolver error instead.
 DIRECTLY_IMPORTED_DEPENDENCIES = ("starlette", "uvicorn")
+
+
+# section 10.2 of ``.system_design/TEST_SUITE.md``, split across the extras that carry it.
+# The design document is the policy; this table is what ``pyproject.toml`` is
+# measured against, and ``test_design_table_matches_expected_bounds`` is what stops
+# the two drifting apart. Every entry carries a specifier, and every entry whose
+# upstream has a major-version cadence carries an upper bound too, because this
+# project has twice been broken by a dependency that had neither.
+EXPECTED_EXTRA_BOUNDS: dict[str, dict[str, str]] = {
+    "dev": {
+        "pytest": ">=9,<10",
+        "pytest-asyncio": ">=1.4,<2",
+        "hypothesis": ">=6.167,<7",
+        "coverage": ">=7.10.3,<8",
+        "diff-cover": ">=10.4,<11",
+        "ruff": ">=0.6,<1",
+        "mypy": ">=2.3.1,<3",
+        "packaging": ">=24",
+    },
+    # ``mutmut`` needs ``fork()`` and is therefore Linux-only. It lives in its own
+    # extra so the nightly can install it without making ``dev`` - which everyone
+    # installs - carry a tool that cannot work on Windows.
+    "mutation": {
+        "mutmut": ">=3,<4",
+    },
+    # The pinned lane of section 10.4. ``coverage`` is exact here and range-bounded in
+    # ``dev``: this is the environment the committed coverage baseline is measured
+    # in, so a patch release that moves a two-decimal total would break the ratchet
+    # for reasons that have nothing to do with the change under test.
+    "ratchet": {
+        "pytest": ">=9,<10",
+        "pytest-asyncio": ">=1.4,<2",
+        "hypothesis": ">=6.167,<7",
+        "coverage": "==7.13.5",
+        "diff-cover": ">=10.4,<11",
+        "mypy": ">=2.3.1,<3",
+        "packaging": ">=24",
+    },
+}
+
+# One case per tool per extra, so a removed or loosened bound fails exactly one
+# test and the failure names the extra it came from.
+EXTRA_BOUND_CASES = [
+    (extra, name, specifier)
+    for extra, bounds in EXPECTED_EXTRA_BOUNDS.items()
+    for name, specifier in bounds.items()
+]
+
+# A `pip freeze` run inside a directory containing the project records it as a
+# local path or URL - ``kindly-web-search-mcp-server @ file:///...`` - which no
+# other machine can resolve. These are the prefixes and infixes that betray it.
+UNRESOLVABLE_LOCKFILE_MARKERS = ("git+", "hg+", "svn+", "bzr+", "file:", " @ ", "-e ")
+
+# `pip freeze` emits bare `name==version` lines. Anything else in the ratchet
+# lockfile - a range, a marker, a URL - means the environment it was taken from
+# was not the clean one section 10.4 describes. If that section's `--require-hashes`
+# option is ever adopted, relax this in the same PR: hashed output is
+# `name==version \` followed by indented `--hash=` continuation lines.
+PIN_PATTERN = re.compile(r"^[A-Za-z0-9._-]+==[^\s;]+$")
+
+# Lowercased substrings the lockfile header must carry. A lockfile regenerated on
+# the wrong platform or Python version silently moves the coverage baseline, so
+# the file has to say which one produced it. Each token is specific enough to
+# distinguish the right procedure from a plausible wrong one: a bare "ratchet"
+# would be satisfied by the filename on line 1, a bare "3.13" by any prose
+# mentioning the interpreter, and a bare ".[ratchet]" by the paragraph below the
+# command that also names the extra. The install token is therefore the whole
+# command line, so pointing it at the wrong extra fails here.
+REGENERATION_HEADER_TOKENS = (
+    "pip install '.[ratchet]'",
+    "python3.13",
+    "linux",
+    "pip freeze --exclude-editable",
+)
+
+# Where the policy this module enforces is written down.
+DESIGN_TABLE_HEADING = "### 10.2 Dependencies and version policy"
+BACKTICKED_PATTERN = re.compile(r"`([^`]+)`")
 
 
 def _declared_dependency_names() -> set[str]:
@@ -109,4 +193,376 @@ def test_mcp_requirement_still_allows_supported_version(
     assert mcp_requirement.specifier.contains(Version(SUPPORTED_MCP_VERSION)), (
         f"pyproject.toml no longer allows the supported mcp {SUPPORTED_MCP_VERSION}. "
         f"Declared specifier: '{mcp_requirement}'."
+    )
+
+
+def _project_name() -> str:
+    """Read the distribution name declared in ``pyproject.toml``
+
+    Returns:
+        The project's own distribution name.
+    """
+    with PYPROJECT_PATH.open("rb") as handle:
+        return tomllib.load(handle)["project"]["name"]
+
+
+def _raw_extra_entries(extra: str) -> list[str]:
+    """Read one extra's requirement strings verbatim
+
+    Args:
+        extra: Name of the extra declared under ``[project.optional-dependencies]``.
+
+    Returns:
+        The declared requirement strings, in declaration order. An extra that is
+        not declared at all yields an empty list rather than raising, so the
+        assertion that fails is the readable one about a missing package instead
+        of a bare ``KeyError``.
+    """
+    with PYPROJECT_PATH.open("rb") as handle:
+        pyproject = tomllib.load(handle)
+
+    return pyproject["project"].get("optional-dependencies", {}).get(extra, [])
+
+
+def _extra_requirements(extra: str) -> dict[str, Requirement]:
+    """Parse one extra's requirements, keyed by canonical distribution name
+
+    Args:
+        extra: Name of the extra declared under ``[project.optional-dependencies]``.
+
+    Returns:
+        A mapping of canonical package name to parsed requirement. Duplicate
+        declarations collapse here, which is why they are asserted against
+        separately.
+    """
+    return {
+        canonicalize_name(requirement.name): requirement
+        for requirement in (Requirement(entry) for entry in _raw_extra_entries(extra))
+    }
+
+
+@pytest.mark.parametrize(
+    ("extra", "name", "specifier"),
+    EXTRA_BOUND_CASES,
+    ids=[f"{extra}-{name}" for extra, name, _ in EXTRA_BOUND_CASES],
+)
+def test_extra_declares_expected_bound(extra: str, name: str, specifier: str) -> None:
+    """Declare each section 10.2 tool in its extra with exactly the documented bound"""
+    declared = _extra_requirements(extra)
+    canonical = canonicalize_name(name)
+
+    assert canonical in declared, (
+        f"pyproject.toml's '{extra}' extra does not declare '{name}'. Section 10.2 of "
+        f"TEST_SUITE.md requires it at '{name}{specifier}'."
+    )
+    assert declared[canonical].specifier == SpecifierSet(specifier), (
+        f"pyproject.toml declares '{declared[canonical]}' in the '{extra}' extra, "
+        f"but section 10.2 of TEST_SUITE.md requires '{name}{specifier}'."
+    )
+
+
+@pytest.mark.parametrize("extra", sorted(EXPECTED_EXTRA_BOUNDS))
+def test_extra_declares_exactly_the_expected_packages(extra: str) -> None:
+    """Keep each tooling extra to exactly the packages section 10.2 assigns it"""
+    declared = set(_extra_requirements(extra))
+    expected = {canonicalize_name(name) for name in EXPECTED_EXTRA_BOUNDS[extra]}
+
+    assert declared == expected, (
+        f"pyproject.toml's '{extra}' extra declares {sorted(declared)}, but section 10.2 "
+        f"of TEST_SUITE.md assigns it {sorted(expected)}. Unexpected: "
+        f"{sorted(declared - expected)}; missing: {sorted(expected - declared)}."
+    )
+
+
+@pytest.mark.parametrize("extra", sorted(EXPECTED_EXTRA_BOUNDS))
+def test_extra_declares_each_package_once(extra: str) -> None:
+    """Refuse a duplicate declaration, which would hide an unbounded entry"""
+    entries = _raw_extra_entries(extra)
+    names = [canonicalize_name(Requirement(entry).name) for entry in entries]
+    duplicated = sorted({name for name in names if names.count(name) > 1})
+
+    assert not duplicated, (
+        f"pyproject.toml's '{extra}' extra declares {duplicated} more than once. "
+        "The last entry wins at resolve time, so a duplicate is a way to smuggle "
+        "an unbounded requirement past every other check in this module."
+    )
+
+
+@pytest.mark.parametrize("extra", sorted(EXPECTED_EXTRA_BOUNDS))
+def test_extra_dependencies_have_no_environment_marker(extra: str) -> None:
+    """Install the same tooling on every platform the suite runs on"""
+    conditional = sorted(
+        f"{name}; {requirement.marker}"
+        for name, requirement in _extra_requirements(extra).items()
+        if requirement.marker is not None
+    )
+
+    assert not conditional, (
+        f"pyproject.toml's '{extra}' extra declares {conditional} behind an "
+        "environment marker, so it silently vanishes on the platforms the marker "
+        "excludes. The suite runs on Windows and Linux and must get the same "
+        "tools on both; a platform-specific tool belongs in its own extra, the "
+        "way 'mutmut' does."
+    )
+
+
+@pytest.mark.parametrize("extra", sorted(EXPECTED_EXTRA_BOUNDS))
+def test_extra_dependencies_are_all_bounded(extra: str) -> None:
+    """Refuse an unbounded entry in any tooling extra"""
+    unbounded = sorted(
+        name for name, requirement in _extra_requirements(extra).items()
+        if len(requirement.specifier) == 0
+    )
+
+    assert not unbounded, (
+        f"pyproject.toml's '{extra}' extra declares {unbounded} without a version "
+        "bound. This project has twice been broken by an unbounded dependency, "
+        "which is why section 10.2 states bounds rather than 'current'."
+    )
+
+
+def _ratchet_lockfile_text() -> str:
+    """Read the committed ratchet lockfile
+
+    Returns:
+        The full text of ``requirements-ratchet.txt``.
+
+    Raises:
+        AssertionError: If the lockfile has not been generated.
+    """
+    assert RATCHET_LOCKFILE_PATH.is_file(), (
+        f"{RATCHET_LOCKFILE_PATH.name} is missing. Section 10.4's coverage-ratchet lane "
+        "installs from it and has no other dependency source - requirements.txt "
+        "covers runtime only and carries no pytest, coverage or diff-cover."
+    )
+    return RATCHET_LOCKFILE_PATH.read_text(encoding="utf-8")
+
+
+def _ratchet_lockfile_pins() -> list[str]:
+    """Return the lockfile's requirement lines, without comments or blanks
+
+    Returns:
+        Every meaningful line of ``requirements-ratchet.txt``, stripped.
+    """
+    return [
+        stripped
+        for stripped in (line.strip() for line in _ratchet_lockfile_text().splitlines())
+        if stripped and not stripped.startswith("#")
+    ]
+
+
+def test_ratchet_lockfile_pins_every_entry() -> None:
+    """Pin every ratchet dependency exactly, transitive ones included"""
+    unpinned = [line for line in _ratchet_lockfile_pins() if not PIN_PATTERN.match(line)]
+
+    assert not unpinned, (
+        "requirements-ratchet.txt must pin every entry with '=='. Pinning the named "
+        "tools while leaving their transitive dependencies free reopens the same "
+        f"hole one level down. Offending lines: {unpinned}."
+    )
+
+
+def test_ratchet_lockfile_has_no_local_or_vcs_reference() -> None:
+    """Keep every ratchet pin resolvable from a machine that is not this one"""
+    offending = [
+        line
+        for line in _ratchet_lockfile_pins()
+        if any(marker in line for marker in UNRESOLVABLE_LOCKFILE_MARKERS)
+    ]
+
+    assert not offending, (
+        "requirements-ratchet.txt contains a local path or VCS reference, which CI "
+        "cannot resolve. Regenerate it with 'pip freeze --exclude-editable' and "
+        f"filter the project itself out. Offending lines: {offending}."
+    )
+
+
+def _ratchet_lockfile_names() -> set[str]:
+    """Return the canonical name of every requirement in the lockfile
+
+    Splits on the first delimiter ``pip freeze`` can emit, so a direct-URL entry
+    such as ``name @ file:///...`` is recognised as naming that project rather
+    than collapsing into a single unparseable token.
+
+    Returns:
+        The canonical distribution names the lockfile mentions.
+    """
+    return {
+        canonicalize_name(re.split(r"==|\s+@\s+|\s", line, maxsplit=1)[0])
+        for line in _ratchet_lockfile_pins()
+    }
+
+
+def test_ratchet_lockfile_excludes_the_project_itself() -> None:
+    """Leave the project out of its own lockfile"""
+    project = canonicalize_name(_project_name())
+    pinned = _ratchet_lockfile_names()
+
+    assert project not in pinned, (
+        f"requirements-ratchet.txt pins '{project}'. Section 10.4's lane installs the "
+        "lockfile and then the project separately with 'pip install --no-deps -e .', "
+        "so a self-reference here would install a wheel over the working tree the "
+        "lane is supposed to measure."
+    )
+
+
+def test_ratchet_lockfile_contains_every_ratchet_tool() -> None:
+    """Cover every tool the ratchet extra declares"""
+    pinned = _ratchet_lockfile_names()
+    expected = {canonicalize_name(name) for name in EXPECTED_EXTRA_BOUNDS["ratchet"]}
+    missing = sorted(expected - pinned)
+
+    assert not missing, (
+        f"requirements-ratchet.txt is missing {missing}, which the 'ratchet' extra "
+        "declares. It was probably regenerated from the wrong extra."
+    )
+
+
+def test_ratchet_lockfile_versions_satisfy_the_ratchet_extra() -> None:
+    """Keep every pinned tool inside the bound the ratchet extra declares"""
+    declared = {
+        canonicalize_name(name): SpecifierSet(specifier)
+        for name, specifier in EXPECTED_EXTRA_BOUNDS["ratchet"].items()
+    }
+
+    # The lockfile is regenerated output and the extra is its input; without this
+    # they can disagree silently, which is the one drift this module exists to stop.
+    violations = []
+    for line in _ratchet_lockfile_pins():
+        name, _, pinned = line.partition("==")
+        bound = declared.get(canonicalize_name(name))
+        if bound is not None and not bound.contains(Version(pinned)):
+            violations.append(f"{line} violates '{bound}'")
+
+    assert not violations, (
+        "requirements-ratchet.txt pins a tool outside the bound the 'ratchet' extra "
+        "declares, so CI would measure the coverage baseline with a different tool "
+        f"than pyproject.toml specifies. Offending pins: {violations}."
+    )
+
+
+def test_ratchet_lockfile_header_records_regeneration() -> None:
+    """Record the regeneration procedure in the lockfile itself"""
+    header = "\n".join(
+        stripped
+        for stripped in (line.strip() for line in _ratchet_lockfile_text().splitlines())
+        if stripped.startswith("#")
+    ).lower()
+    missing = [token for token in REGENERATION_HEADER_TOKENS if token not in header]
+
+    assert not missing, (
+        f"requirements-ratchet.txt's header does not record {missing}. Section 10.4 "
+        "requires the file to say how it was produced, because a lockfile "
+        "regenerated on the wrong platform or Python version silently moves the "
+        "coverage baseline."
+    )
+
+
+def _design_table_constraints() -> dict[str, set[str]]:
+    """Parse section 10.2's dependency table out of ``TEST_SUITE.md``
+
+    Reads the Constraint cell of every row, which is where the policy actually
+    lives. ``coverage`` yields two specifiers because the pinned lane and every
+    other lane differ. The result is an unordered set, so this cannot detect the
+    two ``coverage`` lanes being described the wrong way round in prose; that one
+    row is checked by review, not here.
+
+    Returns:
+        A mapping of canonical tool name to the specifiers its row declares.
+
+    Raises:
+        AssertionError: If section 10.2 cannot be located.
+    """
+    text = TEST_SUITE_PATH.read_text(encoding="utf-8")
+    assert DESIGN_TABLE_HEADING in text, (
+        f"{TEST_SUITE_PATH.name} no longer contains '{DESIGN_TABLE_HEADING}'. This "
+        "test reads the dependency policy from that section; a renamed heading "
+        "would make the comparison vacuous rather than merely stale."
+    )
+    section = text.split(DESIGN_TABLE_HEADING, 1)[1].split("\n### ", 1)[0]
+
+    constraints: dict[str, set[str]] = {}
+    for line in section.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            continue
+        cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+        # The header row and the `|---|` separator carry no backticked tool name.
+        names = BACKTICKED_PATTERN.findall(cells[0]) if cells else []
+        if len(cells) < 2 or not names:
+            continue
+        constraints[canonicalize_name(names[0])] = set(
+            BACKTICKED_PATTERN.findall(cells[1])
+        )
+
+    return constraints
+
+
+def _expected_specifiers_by_tool() -> dict[str, set[str]]:
+    """Collapse the per-extra bounds into what section 10.2's table should declare
+
+    Returns:
+        A mapping of canonical tool name to every specifier that binds it.
+    """
+    collected: dict[str, set[str]] = {}
+    for bounds in EXPECTED_EXTRA_BOUNDS.values():
+        for name, specifier in bounds.items():
+            collected.setdefault(canonicalize_name(name), set()).add(specifier)
+
+    return collected
+
+
+def _specifier_sets(entries: set[str], context: str) -> set[SpecifierSet]:
+    """Convert one table cell's backticked tokens into specifier sets
+
+    Args:
+        entries: The backticked strings taken from a Constraint cell.
+        context: The tool the cell belongs to, used in the failure message.
+
+    Returns:
+        One :class:`SpecifierSet` per entry, compared by meaning rather than by
+        formatting so reflowing the table does not fail the check.
+
+    Raises:
+        AssertionError: If a token is not a valid version specifier.
+    """
+    converted = set()
+    for entry in entries:
+        try:
+            converted.add(SpecifierSet(entry))
+        except InvalidSpecifier:
+            raise AssertionError(
+                f"Section 10.2 of TEST_SUITE.md has a backticked token '{entry}' in "
+                f"the Constraint cell for '{context}' that is not a version "
+                "specifier. That cell must hold specifiers and nothing else - put "
+                "prose or file names in the Purpose cell, or this guard cannot read "
+                "the policy it is meant to enforce."
+            ) from None
+
+    return converted
+
+
+def test_design_table_lists_every_expected_tool() -> None:
+    """Parse the whole of section 10.2, so the per-tool comparison cannot go vacuous"""
+    documented = set(_design_table_constraints())
+    expected = set(_expected_specifiers_by_tool())
+
+    assert documented == expected, (
+        f"Section 10.2 of TEST_SUITE.md lists {sorted(documented)} but this module expects "
+        f"{sorted(expected)}. Undocumented here: {sorted(documented - expected)}; "
+        f"missing from the document: {sorted(expected - documented)}."
+    )
+
+
+@pytest.mark.parametrize("tool", sorted(_expected_specifiers_by_tool()))
+def test_design_table_matches_expected_bounds(tool: str) -> None:
+    """Keep section 10.2's table and the bounds asserted here in agreement"""
+    documented = _specifier_sets(_design_table_constraints().get(tool, set()), tool)
+    expected = _specifier_sets(_expected_specifiers_by_tool()[tool], tool)
+
+    assert documented == expected, (
+        f"Section 10.2 of TEST_SUITE.md constrains '{tool}' to "
+        f"{sorted(str(entry) for entry in documented)}, but this module asserts "
+        f"{sorted(str(entry) for entry in expected)} against pyproject.toml. The "
+        "design document is the policy: change it and this table together."
     )


### PR DESCRIPTION
Implements plan step **E0-1** — [KMCP-16](https://shelpuk.atlassian.net/browse/KMCP-16). First step of the test-suite plan; it gates six other tickets (KMCP-17, 19, 26, 41, 49, 50) and is itself blocked by nothing.

## Context for the Product Owner

This server is installed straight from git (`uvx --from git+https://...`). That path **re-resolves every dependency from PyPI on each start** and ignores any lock file — so when an upstream package ships a breaking release, it reaches every user immediately, with nothing in between. That has already happened to this project twice.

Today the project declares its test tooling as `pytest`, `ruff`, `packaging` with **no version limits at all**, and declares none of the other five tools the planned test suite needs. This PR closes that gap and lays the foundation the remaining 82 steps of the test plan build on:

- **A safety limit on every tool**, so an upstream release can no longer silently change what CI runs.
- **A frozen, reproducible environment** for the future code-quality gate, so the quality number moves only when the code moves — not when a dependency does.
- **An automated guard** that fails the build if anyone removes or weakens one of these limits, or if the policy document and the code stop agreeing.

No user-facing behaviour changes. This is scaffolding that makes the next 82 steps possible and keeps them honest.

## What changed

**`pyproject.toml`** — one unbounded extra becomes three bounded ones:

| Extra | Contents | Why separate |
|---|---|---|
| `dev` | pytest, pytest-asyncio, hypothesis, coverage, diff-cover, ruff, mypy, packaging | What everyone installs |
| `mutation` | `mutmut>=3,<4` | Needs `fork()` → Linux-only. Keeping it out of `dev` is what keeps `dev` installable on Windows. **Additive — never installed alone** |
| `ratchet` | the pinned measurement set | `coverage` is exact (`==7.13.5`) here and range-bounded in `dev`, so a patch release can't move a two-decimal coverage total and fail the gate for reasons unrelated to the change under test |

**`requirements-ratchet.txt`** (new) — the frozen transitive closure of `ratchet`, generated in a clean Python 3.13 **Linux** venv, project's own line filtered out, regeneration procedure recorded in the header. It pins the **runtime** dependencies too: §10.3's lane installs the project with `--no-deps`, so nothing else would resolve them.

**`tests/test_dependency_constraints.py`** — +44 cases: every bound, each extra's exact membership, duplicate-declaration and environment-marker smuggling, and six lockfile properties — including that its pins **satisfy the extra that generated it**, which is the specific drift this step exists to prevent.

**`.system_design/TEST_SUITE.md`** — §10.2 is now machine-checked against `pyproject.toml` in both directions; the two cannot drift.

## Two deliberate departures from the design, both recorded in the doc

1. **`mypy` is `>=2.3.1,<3`, not `>=1.11,<2`.** mypy 2.0 shipped 2026-05-06, so the documented bound excluded every supported release of the tool. Its breaking changes are dropping Python 3.9 (irrelevant here — `requires-python >=3.13`) and enabling two stricter defaults. Better absorbed now than after E2-1 writes the first type harness against superseded behaviour. E2-1 gains a note that the typed fake must return `bytes` under `--strict-bytes`.
2. **`packaging` joins `ratchet`.** The guard module imports it directly. It *would* resolve transitively via pytest — which is exactly the dependency shape that guard exists to reject.

## Verification

| Check | Result |
|---|---|
| Full suite, Windows | 11 failed / **246 passed** / 3 skipped — same 11 pre-existing failures, **+44** |
| Full suite, Linux in the lockfile env | 12 failed / **246 passed** / 2 skipped — 12th is the Linux-only root-sandbox case |
| `pip install -e .[dev]` | succeeds on **Windows and Linux**, identical resolved versions |
| `pip install -e .[mutation]` | `mutmut` installs and runs on Linux |
| Lockfile install + `--no-deps -e .` | package resolves to the working tree's `src/` — what the CI coverage job asserts |
| Mutation testing of the new guards | **18/18 caught**, each by the expected test |
| `ruff check` | clean |
| `scripts/check_plan_dag.py` | 78 steps, acyclic |

The lockfile pins `mcp==1.29.1` and `starlette==1.6.0`, ahead of the versions the transport regression tests were originally verified against — so the suite was **run inside that exact environment** and `test_server_transport.py` is green there.

## Noted, not fixed here (out of E0-1's scope)

- `starlette` and `uvicorn` are still unbounded in `[project.dependencies]`. §10.2's table covers tooling only; bounding runtime deps is a policy question for the design.
- `requirements.txt` is missing seven runtime packages (`trafilatura`, `lxml`, `courlan`, `htmldate`, `justext`, `dateparser`, `socksio`). Nothing installs from it today, but **E4-6** refers to "the pinned requirements" without naming a file — that ticket needs to name one.
- `ruff` has a bound and no CI job anywhere in the design. Worth a lint job or an explicit "local-only" note.

## Review

Reviewed by `system-design-reviewer` and `code-reviewer`. Both raised findings that are addressed in this branch — notably the missing lockfile-vs-extra version check, a self-refuting justification in the design doc, the `mutation` extra's additive nature, the baseline-reset rule needing to cover runtime bumps, and duplicate/marker smuggling in the extras.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013kB3d2mEtUkkANj92V8Nt7


[KMCP-16]: https://shelpuk.atlassian.net/browse/KMCP-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ