### PR TITLE
Add [tool.pytest.ini_options] with the seven markers

### DIFF
--- a/.github/review/rules/python-tests.md
+++ b/.github/review/rules/python-tests.md
@@ -44,7 +44,7 @@
 
 ## The guard tests — treat these as load-bearing
 
-Four tests exist to hold an invariant that nothing else enforces. A pull request
+Five tests exist to hold an invariant that nothing else enforces. A pull request
 that changes what they guard, without changing them, is a finding; a pull request
 that *weakens* one to make a change pass is a critical finding.
 
@@ -54,6 +54,7 @@ that *weakens* one to make a change pass is a critical finding.
 | `test_provider_registry_consistency.py` | `PROVIDERS` stays in step with the router, the startup check and the documentation |
 | `test_tool_descriptions.py` | the tool docstrings the calling model receives |
 | `test_diagnostics_masking.py` | that credentials do not reach diagnostics output |
+| `test_pytest_configuration.py` | that `[tool.pytest.ini_options]` matches TEST_SUITE.md §10.5, that the running pytest actually loaded it, and that `strict_markers` / `asyncio_mode` have their effect and not merely their declaration |
 
 Plus `test_worker_launch_args_redaction.py` for the subprocess command line — the
 same class of guard, one layer down.

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -1494,8 +1494,10 @@ mean anything. None substitutes for another.
 ```toml
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--strict-markers"
+strict_markers = true
+strict_config = true
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 markers = [
     "live: hits the real network; needs KINDLY_RUN_LIVE_TESTS=1",
     "subsystem: needs a real socket or child process; portable",
@@ -1506,6 +1508,60 @@ markers = [
     "slow: over a second",
 ]
 ```
+
+**This block is machine-checked.** `tests/test_pytest_configuration.py` parses
+it out of this section and fails if it and `pyproject.toml` disagree in either
+direction, so a docs-only edit here turns CI red. Change both in the same PR.
+The guard requires this section to keep its heading and to contain exactly one
+fenced `toml` block. `pyproject.toml` may carry comments the block does not; the
+comparison is between parsed tables, not text.
+
+**`strict_markers`, not `addopts = "--strict-markers"`.** An earlier draft of
+this section used the flag. pytest **9.0.0 through 9.0.3 silently ignore**
+`--strict-markers` and `--strict-config` when they arrive through `addopts`
+([pytest#14442](https://github.com/pytest-dev/pytest/issues/14442), fixed in
+9.1.0), and §10.2's bound is `pytest>=9,<10`, so those releases are installable.
+Measured across 9.0.0, 9.0.1, 9.0.2, 9.0.3, 9.1.0 and 9.1.1: every 9.0.x lets an
+unregistered marker pass at exit 0 under the `addopts` form, while
+`strict_markers = true` aborts collection at exit 2 on all six. The failure the flag exists
+to prevent is precisely a silent one — a marker accepted but unregistered labels
+a test that every marker-selected job then skips, while it still reports green —
+so a spelling that can itself fail silently is the wrong one. The ini options
+were added in pytest 9.0 (#13823) and work across the whole allowed range;
+upstream recommends them when targeting pytest ≥ 9. The same release added a
+`strict = true` umbrella covering `strict_config`, `strict_markers`,
+`strict_parametrization_ids` and `strict_xfail`. It is **not** used here: it
+opts this repository into every strictness option pytest adds in future, which
+upstream itself says to take only on a pinned version. §10.2 deliberately bounds
+rather than pins, so the two options wanted are named explicitly.
+`test_pytest_configuration.py`
+asserts no `--strict*` entry returns to `addopts`, because CI resolves a pytest
+where both spellings work and would not otherwise notice.
+
+**`strict_config` turns a missing plugin into an error rather than a symptom.**
+Without it, an environment lacking `pytest-asyncio` degrades `asyncio_mode` to a
+`PytestConfigWarning` and then fails every async test with `async def functions
+are not natively supported` — a symptom three steps from its cause. With it the
+run stops at `ERROR: Unknown config option: asyncio_mode`.
+
+**`asyncio_default_fixture_loop_scope` is set because unset is not neutral.**
+pytest-asyncio 1.4 raises a `PytestDeprecationWarning` when it is unset,
+announcing that a future release will change the async-fixture event-loop
+default from the `fixture` caching scope to `function`. `pytest-asyncio>=1.4,<2`
+admits that release, and it would land on §10.1's migration, which converts the
+whole suite at once. The warning is raised during `pytest_configure`, before the
+warnings plugin captures, so it never reaches the warnings summary and nobody
+would see it coming. `"function"` is the announced future default, chosen so the
+change is a no-op here.
+
+**Auto mode changes nothing about the existing suite.** pytest-asyncio does not
+handle `unittest` classes, so the `IsolatedAsyncioTestCase` tests are unaffected
+and the counts in §1.1 are unchanged by this block. Its effect is on the plain
+`async def` tests §10.1's migration produces. Measured on pytest 9.1.1: an
+unmarked `async def` test **fails** with `async def functions are not natively
+supported` when the mode is unset — it does not pass silently — so
+`test_pytest_configuration.py` carries one unmarked `async def` case whose
+passing is the observable that auto mode is in effect.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,3 +95,54 @@ mcp-server = "kindly_web_search_mcp_server.server:main"
 mcp-web-search = "kindly_web_search_mcp_server.server:main"
 kindly-web-search = "kindly_web_search_mcp_server.server:main"
 kindly-web-search-mcp-server = "kindly_web_search_mcp_server.cli:main"
+
+# Section 10.5 of `.system_design/TEST_SUITE.md`. That section is the policy and
+# this table is what the runner reads; `tests/test_pytest_configuration.py`
+# asserts they agree in both directions, so a docs-only edit there turns the
+# suite red. Change both in the same PR.
+[tool.pytest.ini_options]
+# Forward-looking: nothing outside `tests/` is collected today either, because
+# pytest's default `norecursedirs` already skips `.github/`. It matters once
+# E3-5 adds `tests/package/`, which §10.3's jobs select and deselect explicitly.
+testpaths = ["tests"]
+# The ini option, NOT `addopts = "--strict-markers"` as earlier drafts of §10.5
+# had it. pytest 9.0.0 through 9.0.3 silently ignore strictness flags that arrive
+# through `addopts` (pytest#14442, fixed in 9.1.0), and `pytest>=9,<10` allows
+# them. Measured across 9.0.0-9.1.1: on every 9.0.x the `addopts` form leaves an
+# unregistered marker passing at exit 0; this form aborts collection at exit 2 on
+# all of them. A marker that is
+# accepted but unregistered is the worst case available here -- the test it
+# labels is excluded from every marker-selected job while still reporting green.
+strict_markers = true
+# Makes an unknown or misspelled ini option a hard error rather than a warning
+# nobody reads. Concretely: without it, an environment missing `pytest-asyncio`
+# degrades `asyncio_mode` to a `PytestConfigWarning` and then fails every async
+# test with "async def functions are not natively supported" -- a symptom three
+# steps removed from the cause. With it, the run stops at
+# `ERROR: Unknown config option: asyncio_mode`.
+strict_config = true
+# §10.1: the project is pure asyncio, so the `asyncio` marker is noise. The
+# existing `unittest.IsolatedAsyncioTestCase` classes are unaffected --
+# pytest-asyncio does not handle unittest classes at all -- so this changes no
+# result today and is what E11's migration lands onto.
+asyncio_mode = "auto"
+# Set explicitly because leaving it unset is not neutral: pytest-asyncio 1.4
+# raises a `PytestDeprecationWarning` during `pytest_configure` -- before the
+# warnings plugin can capture it, so it never reaches the warnings summary --
+# announcing that a future release will flip the async-fixture loop default from
+# "fixture" caching scope to "function". `pytest-asyncio>=1.4,<2` allows that
+# release, and it would land on E11, the step that converts the whole suite.
+# "function" is the announced future default, chosen so the flip is a no-op.
+asyncio_default_fixture_loop_scope = "function"
+# All seven of §10.5. `slow` is registered ahead of its first real user and is
+# currently exercised only as the control case in
+# `tests/test_pytest_configuration.py`; it is not dead.
+markers = [
+    "live: hits the real network; needs KINDLY_RUN_LIVE_TESTS=1",
+    "subsystem: needs a real socket or child process; portable",
+    "chromium: needs a real browser; Linux container only",
+    "package: runs against an installed wheel, not the source tree",
+    "serper: live test requiring SERPER_API_KEY",
+    "extraction: live content-extraction canary; browser, no credential",
+    "slow: over a second",
+]

--- a/tests/test_pytest_configuration.py
+++ b/tests/test_pytest_configuration.py
@@ -311,14 +311,48 @@ async def test_asyncio_auto_mode_awaits_a_plain_async_test() -> None:
     assert asyncio.get_running_loop().is_running()
 
 
+def _section_body(text: str, heading: str) -> str:
+    """Return the lines of one Markdown section, ignoring fenced code blocks.
+
+    Bounded by walking lines and tracking fence state rather than by splitting
+    on a heading pattern. A regex cannot tell a heading from a ``#`` comment at
+    column 0 inside a fence, and this document is full of both -- section 10.4's
+    samples open with ``# tests/conftest.py`` and ``# .coveragerc``, and section
+    10.5's own prose invites a TOML comment inside its block. Splitting on the
+    pattern would truncate the section at that comment, leaving the closing
+    fence outside it and failing with a fence count that points away from the
+    cause.
+
+    Args:
+        text: The whole document.
+        heading: The exact heading line the section starts at.
+
+    Returns:
+        Everything after ``heading`` up to the next heading of level 1-3 that is
+        not inside a fence, or to the end of the document.
+    """
+    lines = text.splitlines()
+    start = lines.index(heading) + 1
+    body: list[str] = []
+    fenced = False
+    for line in lines[start:]:
+        if line.startswith("```"):
+            fenced = not fenced
+        elif not fenced and re.match(r"#{1,3} ", line):
+            break
+        body.append(line)
+    return "\n".join(body)
+
+
 def _design_document_ini_options() -> dict:
     """Parse section 10.5's TOML block out of ``TEST_SUITE.md``.
 
     The block is read as TOML rather than scraped line by line, so a formatting
     change to the document that preserves its meaning does not fail the
-    comparison. The search is bounded to the section and requires exactly one
-    fenced block inside it: an unbounded search would silently start comparing
-    against some later section's TOML the day one is added.
+    comparison. The search is bounded to the section by :func:`_section_body`
+    and requires exactly one fenced block inside it: an unbounded search would
+    silently start comparing against some later section's TOML the day one is
+    added.
 
     Returns:
         The ``[tool.pytest.ini_options]`` table the design document declares.
@@ -328,15 +362,12 @@ def _design_document_ini_options() -> dict:
             cannot be found.
     """
     text = TEST_SUITE_PATH.read_text(encoding="utf-8")
-    assert DESIGN_SECTION_HEADING in text, (
+    assert DESIGN_SECTION_HEADING in text.splitlines(), (
         f"{TEST_SUITE_PATH.name} no longer contains '{DESIGN_SECTION_HEADING}'. "
         "This guard parses that section; renaming it would silently disable the "
         "check."
     )
-    # Bound the search to this section: everything up to the next heading of the
-    # same or higher level, or end of file if it is the last one.
-    section = text.split(DESIGN_SECTION_HEADING, 1)[1]
-    section = re.split(r"\n#{1,3} ", section, maxsplit=1)[0]
+    section = _section_body(text, DESIGN_SECTION_HEADING)
     blocks = re.findall(r"```toml\n(.*?)```", section, re.DOTALL)
     assert len(blocks) == 1, (
         f"Section 10.5 of {TEST_SUITE_PATH.name} contains {len(blocks)} fenced "
@@ -366,6 +397,56 @@ def test_design_document_declares_the_same_configuration() -> None:
         f"{_design_document_ini_options()!r} but {PYPROJECT_PATH.name} declares "
         f"{_pyproject_ini_options()!r}. Change both in the same pull request."
     )
+
+
+# A miniature document exercising both bounds at once: a ``#`` comment at column
+# 0 inside the fence, which must NOT end the section, and a following heading,
+# which must.
+_SECTION_FIXTURE = """\
+### 10.5 pytest configuration
+
+```toml
+# a comment the section bound must not trip on
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+```
+
+Trailing prose.
+
+## 11. Next section
+
+```toml
+[tool.something.else]
+ignored = true
+```
+"""
+
+
+def test_section_bound_ignores_a_comment_inside_the_fence() -> None:
+    """Assert a ``#`` comment in the block does not truncate the section
+
+    Section 10.5's prose invites comments, and a heading-shaped regex cannot
+    tell one from a heading. Getting this wrong fails the guard with a fence
+    count that points away from the cause, so it is asserted directly.
+    """
+    section = _section_body(_SECTION_FIXTURE, DESIGN_SECTION_HEADING)
+
+    assert "# a comment the section bound must not trip on" in section
+    assert "Trailing prose." in section
+
+
+def test_section_bound_stops_at_the_next_heading() -> None:
+    """Assert the section really is bounded -- the control for the case above
+
+    Without this, :func:`_section_body` could satisfy the previous case by never
+    terminating at all, and the guard would start comparing against whatever
+    TOML a later section grows.
+    """
+    section = _section_body(_SECTION_FIXTURE, DESIGN_SECTION_HEADING)
+
+    assert "## 11. Next section" not in section
+    assert "tool.something.else" not in section
+    assert len(re.findall(r"```toml\n(.*?)```", section, re.DOTALL)) == 1
 
 
 @pytest.mark.subsystem

--- a/tests/test_pytest_configuration.py
+++ b/tests/test_pytest_configuration.py
@@ -1,0 +1,424 @@
+"""Guard the pytest configuration declared in ``pyproject.toml``.
+
+Section 10.5 of ``.system_design/TEST_SUITE.md`` is the policy; the
+``[tool.pytest.ini_options]`` table in ``pyproject.toml`` is what the runner
+actually reads. This module keeps the two in step, and is the same guard shape
+as :mod:`tests.test_dependency_constraints`, which does the job for section
+10.2's dependency table.
+
+Every check here exists because the failure it catches is **silent**. An
+unregistered marker without ``strict_markers`` is accepted with a warning, and
+the test it labels is then excluded from every marker-selected CI job while
+still reporting as "passing". A configuration file that pytest never loaded --
+because a stray ``pytest.ini`` outranks ``pyproject.toml`` -- leaves the suite
+running unconfigured while every assertion about the file's *contents* stays
+green. Neither turns anything red on its own, so something has to assert them.
+
+The checks come in two kinds, and both are needed:
+
+* those reading ``pyproject.toml`` with :mod:`tomllib`, which pin what the
+  repository declares -- including that it declares nothing extra;
+* those reading :class:`~pytest.Config` through the ``pytestconfig`` fixture,
+  which pin what the **running** pytest actually loaded.
+
+Neither kind implies the other.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
+TEST_SUITE_PATH = REPO_ROOT / ".system_design" / "TEST_SUITE.md"
+
+DESIGN_SECTION_HEADING = "### 10.5 pytest configuration"
+
+# Section 10.5 of ``.system_design/TEST_SUITE.md``, in the order that section
+# lists them. The order is asserted along with the contents: it makes a drift
+# between the document and ``pyproject.toml`` a one-line diff to read rather
+# than a set comparison to reason about.
+EXPECTED_MARKERS: dict[str, str] = {
+    "live": "hits the real network; needs KINDLY_RUN_LIVE_TESTS=1",
+    "subsystem": "needs a real socket or child process; portable",
+    "chromium": "needs a real browser; Linux container only",
+    "package": "runs against an installed wheel, not the source tree",
+    "serper": "live test requiring SERPER_API_KEY",
+    "extraction": "live content-extraction canary; browser, no credential",
+    "slow": "over a second",
+}
+
+# The rest of section 10.5's block. Kept separate from the markers because
+# pytest's own ``markers`` ini value is additive at runtime -- plugins append to
+# it -- so the two are asserted against the runner in different ways.
+EXPECTED_SETTINGS: dict[str, object] = {
+    "testpaths": ["tests"],
+    "strict_markers": True,
+    "strict_config": True,
+    "asyncio_mode": "auto",
+    "asyncio_default_fixture_loop_scope": "function",
+}
+
+# What pytest reports for a marker it does not know. Asserted in pytest's own
+# wording rather than a paraphrase, so a release that changes the message fails
+# here loudly instead of quietly weakening the check to "some error occurred".
+UNKNOWN_MARKER_ERROR = "not found in `markers` configuration option"
+
+# ``pytest.ExitCode.INTERRUPTED``, which is what an aborted collection returns.
+# Deliberately distinguished from 1 (``TESTS_FAILED``): a test that merely fails
+# is not the outcome being asserted.
+EXIT_INTERRUPTED = 2
+
+
+def _pyproject_ini_options() -> dict:
+    """Read the ``[tool.pytest.ini_options]`` table out of ``pyproject.toml``.
+
+    Returns:
+        The table's keys and values, as declared in the file.
+
+    Raises:
+        AssertionError: When the table is absent, which is the state this whole
+            module exists to prevent.
+    """
+    with PYPROJECT_PATH.open("rb") as handle:
+        document = tomllib.load(handle)
+    table = document.get("tool", {}).get("pytest", {}).get("ini_options")
+    assert table is not None, (
+        f"{PYPROJECT_PATH.name} declares no [tool.pytest.ini_options] table. "
+        "Section 10.5 of TEST_SUITE.md requires one."
+    )
+    return table
+
+
+def _expected_marker_entries() -> list[str]:
+    """Render :data:`EXPECTED_MARKERS` in pytest's ``name: description`` form.
+
+    Returns:
+        One entry per marker, in section 10.5's order.
+    """
+    return [f"{name}: {description}" for name, description in EXPECTED_MARKERS.items()]
+
+
+def _expected_ini_options() -> dict:
+    """Assemble the whole table section 10.5 requires.
+
+    Returns:
+        :data:`EXPECTED_SETTINGS` plus the rendered ``markers`` list.
+    """
+    return {**EXPECTED_SETTINGS, "markers": _expected_marker_entries()}
+
+
+def _run_pytest(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    """Run a child pytest against the **committed** ``pyproject.toml``.
+
+    ``-c`` points the child at this repository's real configuration rather than
+    at a copy written into a temporary directory. That distinction is the point:
+    a test that builds its own config file proves only that pytest works, not
+    that the configuration this repository ships does.
+
+    Args:
+        *args: Arguments appended after the configuration flags.
+        cwd: Working directory for the child, kept off the repository tree so
+            the run cannot pick up ``tests/conftest.py`` or write into it.
+
+    Returns:
+        The completed process, with ``stdout`` and ``stderr`` captured as text.
+
+    Raises:
+        subprocess.TimeoutExpired: When the child has not exited within 120
+            seconds. A bounded wait rather than an unbounded one, so a child
+            that hangs fails the case instead of the run.
+    """
+    # ``PYTEST_ADDOPTS`` from the parent environment would silently change the
+    # child's behaviour, so the child gets a cleaned copy.
+    environment = dict(os.environ)
+    environment.pop("PYTEST_ADDOPTS", None)
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-p",
+            "no:cacheprovider",
+            "-c",
+            str(PYPROJECT_PATH),
+            *args,
+        ],
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+        env=environment,
+        timeout=120,
+        check=False,
+    )
+
+
+def _write_marked_test(directory: Path, marker: str) -> Path:
+    """Write a one-case test module carrying ``marker``.
+
+    Args:
+        directory: Where to write the module.
+        marker: The marker name to apply.
+
+    Returns:
+        The path written.
+    """
+    path = directory / "test_marked.py"
+    path.write_text(
+        "import pytest\n"
+        "\n"
+        "\n"
+        f"@pytest.mark.{marker}\n"
+        "def test_marked() -> None:\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_configuration_source_is_pyproject(pytestconfig: pytest.Config) -> None:
+    """Assert the running pytest loaded this repository's ``pyproject.toml``
+
+    pytest's precedence is ``pytest.ini`` > ``pyproject.toml`` > ``tox.ini`` >
+    ``setup.cfg``, so a single stray ``pytest.ini`` at the repository root takes
+    the whole block below out of service. Every check that reads
+    ``pyproject.toml`` directly would still pass, and the suite would run
+    unconfigured. This is the case that notices.
+
+    Args:
+        pytestconfig: The session's configuration, injected by pytest.
+    """
+    # Both sides are resolved before comparing. ``inipath`` is built with
+    # ``absolutepath()``, which does not expand symlinks or Windows 8.3 short
+    # names, so comparing spellings would fail on a symlinked checkout while
+    # reporting a configuration takeover that had not happened.
+    inipath = pytestconfig.inipath
+    assert inipath is not None and inipath.resolve() == PYPROJECT_PATH, (
+        f"pytest loaded its configuration from {inipath}, not from "
+        f"{PYPROJECT_PATH}. A higher-precedence configuration file has taken "
+        "over and the [tool.pytest.ini_options] block is not in effect."
+    )
+
+
+@pytest.mark.parametrize(("option", "value"), sorted(EXPECTED_SETTINGS.items()))
+def test_runner_loaded_expected_setting(
+    pytestconfig: pytest.Config, option: str, value: object
+) -> None:
+    """Assert one section 10.5 setting reached the runner, not merely the file
+
+    Parametrized one setting per case so five broken settings report as five
+    failures rather than one.
+
+    Args:
+        pytestconfig: The session's configuration, injected by pytest.
+        option: The ini option name.
+        value: The value section 10.5 requires.
+    """
+    assert pytestconfig.getini(option) == value, (
+        f"pytest reports {option} = {pytestconfig.getini(option)!r}; section "
+        f"10.5 of TEST_SUITE.md requires {value!r}."
+    )
+
+
+@pytest.mark.parametrize(("name", "description"), sorted(EXPECTED_MARKERS.items()))
+def test_runner_registered_expected_marker(
+    pytestconfig: pytest.Config, name: str, description: str
+) -> None:
+    """Assert one section 10.5 marker is registered with its documented text
+
+    Asserted as containment rather than equality: pytest's ``markers`` value is
+    additive at runtime, and the installed plugins and pytest's own built-ins
+    append to it. The "and nothing else" half of this claim is
+    :func:`test_pyproject_declares_exactly_the_expected_ini_options`, which
+    reads the file.
+
+    Args:
+        pytestconfig: The session's configuration, injected by pytest.
+        name: The marker name.
+        description: The description section 10.5 gives it.
+    """
+    registered = pytestconfig.getini("markers")
+    assert f"{name}: {description}" in registered, (
+        f"pytest does not report marker '{name}' as '{name}: {description}'. "
+        "Section 10.5 of TEST_SUITE.md defines it; this is what "
+        "'pytest --markers' prints."
+    )
+
+
+def test_pyproject_declares_exactly_the_expected_ini_options() -> None:
+    """Assert ``pyproject.toml`` declares section 10.5's table and nothing more
+
+    The other direction of the two cases above. Without it, a setting or marker
+    could be added to ``pyproject.toml`` alone and the design document would
+    stop describing the configuration CI actually runs under.
+    """
+    assert _pyproject_ini_options() == _expected_ini_options(), (
+        f"{PYPROJECT_PATH.name} declares {_pyproject_ini_options()!r}, but "
+        f"section 10.5 of TEST_SUITE.md defines {_expected_ini_options()!r}."
+    )
+
+
+def test_strict_markers_is_not_declared_through_addopts() -> None:
+    """Reject the ``addopts`` spelling of strictness, which pytest 9.0 ignores
+
+    pytest 9.0.0 through 9.0.3 **silently ignore** ``--strict-markers`` and
+    ``--strict-config`` when they arrive through ``addopts``
+    (`pytest#14442 <https://github.com/pytest-dev/pytest/issues/14442>`_, fixed
+    in 9.1.0). Section 10.2's bound is ``pytest>=9,<10``, so those releases are
+    installable, and on them the ``addopts`` form leaves an unregistered marker
+    passing with nothing but a warning. Measured across 9.0.0, 9.0.1, 9.0.2,
+    9.0.3, 9.1.0 and 9.1.1: every 9.0.x exits 0 under the ``addopts`` form,
+    where ``strict_markers = true`` exits 2 on all six.
+
+    The two spellings are therefore not interchangeable here, and moving the
+    setting back into ``addopts`` would be a silent regression on any allowed
+    pytest below 9.1.0 -- which the child-process cases below cannot catch,
+    because they run on whatever pytest CI resolved, where both spellings work.
+    """
+    addopts = _pyproject_ini_options().get("addopts", "")
+    entries = addopts if isinstance(addopts, list) else addopts.split()
+    offenders = [entry for entry in entries if entry.startswith("--strict")]
+    assert not offenders, (
+        f"{PYPROJECT_PATH.name} declares {offenders} in addopts. pytest 9.0.0 "
+        "through 9.0.3 ignore strictness flags passed that way (pytest#14442); "
+        "use the strict_markers / strict_config ini options instead."
+    )
+
+
+async def test_asyncio_auto_mode_awaits_a_plain_async_test() -> None:
+    """Assert ``asyncio_mode = "auto"`` is in effect, by depending on it
+
+    Deliberately an unmarked ``async def``. Section 10.1 standardizes on
+    pytest-asyncio in auto mode because the project is pure asyncio and the
+    ``asyncio`` marker is noise; this case is what makes that observable rather
+    than merely declared. Measured on pytest 9.1.1: with the mode unset, or with
+    the plugin not loaded, this fails with ``async def functions are not
+    natively supported``; with auto mode it passes.
+
+    That failure is loud, which is the point -- the setting reaching the runner
+    is asserted by :func:`test_runner_loaded_expected_setting`, and this asserts
+    the runner does something with it.
+    """
+    await asyncio.sleep(0)
+    assert asyncio.get_running_loop().is_running()
+
+
+def _design_document_ini_options() -> dict:
+    """Parse section 10.5's TOML block out of ``TEST_SUITE.md``.
+
+    The block is read as TOML rather than scraped line by line, so a formatting
+    change to the document that preserves its meaning does not fail the
+    comparison. The search is bounded to the section and requires exactly one
+    fenced block inside it: an unbounded search would silently start comparing
+    against some later section's TOML the day one is added.
+
+    Returns:
+        The ``[tool.pytest.ini_options]`` table the design document declares.
+
+    Raises:
+        AssertionError: When the heading, or exactly one fenced block under it,
+            cannot be found.
+    """
+    text = TEST_SUITE_PATH.read_text(encoding="utf-8")
+    assert DESIGN_SECTION_HEADING in text, (
+        f"{TEST_SUITE_PATH.name} no longer contains '{DESIGN_SECTION_HEADING}'. "
+        "This guard parses that section; renaming it would silently disable the "
+        "check."
+    )
+    # Bound the search to this section: everything up to the next heading of the
+    # same or higher level, or end of file if it is the last one.
+    section = text.split(DESIGN_SECTION_HEADING, 1)[1]
+    section = re.split(r"\n#{1,3} ", section, maxsplit=1)[0]
+    blocks = re.findall(r"```toml\n(.*?)```", section, re.DOTALL)
+    assert len(blocks) == 1, (
+        f"Section 10.5 of {TEST_SUITE_PATH.name} contains {len(blocks)} fenced "
+        "```toml blocks; this guard requires exactly one."
+    )
+    table = (
+        tomllib.loads(blocks[0]).get("tool", {}).get("pytest", {}).get("ini_options")
+    )
+    assert table is not None, (
+        f"Section 10.5's TOML block in {TEST_SUITE_PATH.name} declares no "
+        "[tool.pytest.ini_options] table."
+    )
+    return table
+
+
+def test_design_document_declares_the_same_configuration() -> None:
+    """Assert TEST_SUITE.md section 10.5 and ``pyproject.toml`` agree exactly
+
+    Compared as parsed tables, key for key, in both directions. Comments are
+    invisible to the parser, so ``pyproject.toml`` may explain itself at
+    whatever length is useful. Editing either file alone turns the suite red,
+    which is what keeps the design document describing the configuration that
+    actually runs rather than the one it was written against.
+    """
+    assert _design_document_ini_options() == _pyproject_ini_options(), (
+        f"Section 10.5 of {TEST_SUITE_PATH.name} declares "
+        f"{_design_document_ini_options()!r} but {PYPROJECT_PATH.name} declares "
+        f"{_pyproject_ini_options()!r}. Change both in the same pull request."
+    )
+
+
+@pytest.mark.subsystem
+def test_unregistered_marker_fails_collection(tmp_path: Path) -> None:
+    """Assert an unregistered marker aborts collection
+
+    This is the behaviour ``strict_markers`` is set for, as opposed to the
+    setting itself, which :func:`test_runner_loaded_expected_setting` asserts.
+    Turning the option off leaves that case failing on the declaration and this
+    one failing on the consequence, which is the pair worth having.
+
+    Marked ``subsystem`` because it spawns a child process, which is what
+    section 10.5 defines that marker to mean. It needs nothing else -- no
+    network, no browser, no credential.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory, kept off the
+            repository tree.
+    """
+    _write_marked_test(tmp_path, "definitely_not_a_registered_marker")
+
+    result = _run_pytest("-q", "test_marked.py", cwd=tmp_path)
+
+    assert result.returncode == EXIT_INTERRUPTED, (
+        f"Expected exit {EXIT_INTERRUPTED} (collection interrupted), got "
+        f"{result.returncode}.\n{result.stdout}\n{result.stderr}"
+    )
+    assert UNKNOWN_MARKER_ERROR in result.stdout, (
+        "Collection failed, but not for the unregistered marker.\n"
+        f"{result.stdout}\n{result.stderr}"
+    )
+
+
+@pytest.mark.subsystem
+def test_registered_marker_is_collected(tmp_path: Path) -> None:
+    """Assert a registered marker still runs -- the control for the case above
+
+    Without this, :func:`test_unregistered_marker_fails_collection` would pass
+    against a configuration that broke collection for any reason at all. It is
+    also the only user of the ``slow`` marker until the suite grows a test that
+    earns it.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory.
+    """
+    _write_marked_test(tmp_path, "slow")
+
+    result = _run_pytest("-q", "test_marked.py", cwd=tmp_path)
+
+    assert result.returncode == 0, (
+        f"A registered marker should collect and pass, got exit "
+        f"{result.returncode}.\n{result.stdout}\n{result.stderr}"
+    )
+    assert "1 passed" in result.stdout, (
+        f"Expected one passing test.\n{result.stdout}\n{result.stderr}"
+    )


### PR DESCRIPTION
## Context for the Product Owner

This repository has 28 test modules and **no test strategy**. There is no way to say "run only the fast tests", "run only the ones that need a browser", or "run only the ones that hit the live network" — and those distinctions are what every CI job in the test-suite design is built out of. Until they exist, no automated quality gate can be built at all.

This PR installs that vocabulary: seven labels (`live`, `subsystem`, `chromium`, `package`, `serper`, `extraction`, `slow`) plus the rules that keep them honest. It is the step the rest of the programme waits on — `scripts/check_plan_dag.py` reports that **51 further steps, 47 of them PR-sized, become workable** once this lands.

No product behaviour changes. Nothing users touch is affected.

## What changed

- `pyproject.toml` gains the `[tool.pytest.ini_options]` block of TEST_SUITE §10.5.
- `tests/test_pytest_configuration.py` — a new 19-case guard that holds it there.
- `.system_design/TEST_SUITE.md` §10.5 — the corrected block plus the reasoning behind it, and a "this block is machine-checked" note matching §10.2's.
- `.github/review/rules/python-tests.md` — the new guard added to the load-bearing table.

## Three departures from §10.5 as it was written

Each measured, each approved before implementing, each carried back into the design document so a future reader cannot mistake a deliberate trade-off for an accident.

**1. `strict_markers = true`, not `addopts = "--strict-markers"`.** The important one. pytest **9.0.0 through 9.0.3 silently ignore** strictness flags arriving through `addopts` ([pytest#14442](https://github.com/pytest-dev/pytest/issues/14442), fixed in 9.1.0), and §10.2's bound `pytest>=9,<10` admits them. Measured in throwaway environments across six releases:

```
pytest 9.0.0  addopts --strict-markers -> exit 0   marker IGNORED
pytest 9.0.1  addopts --strict-markers -> exit 0   marker IGNORED
pytest 9.0.2  addopts --strict-markers -> exit 0   marker IGNORED
pytest 9.0.3  addopts --strict-markers -> exit 0   marker IGNORED
pytest 9.1.0  addopts --strict-markers -> exit 2   ENFORCED
pytest 9.1.1  addopts --strict-markers -> exit 2   ENFORCED
```

`strict_markers = true` aborts collection at exit 2 on **all six**. A guard whose whole job is to make a silent failure loud must not itself be able to fail silently.

**2. `strict_config = true` added.** An unknown or misspelled ini option becomes an error rather than a warning nobody reads. Without it, an environment missing `pytest-asyncio` degrades `asyncio_mode` to a `PytestConfigWarning` and then fails every async test with a message three steps from the cause.

**3. `asyncio_default_fixture_loop_scope = "function"` added.** Unset is not neutral: pytest-asyncio 1.4 announces a future flip of the async-fixture loop default, `pytest-asyncio>=1.4,<2` admits that release, and it would land on the async migration that converts the whole suite at once. The deprecation warning is raised inside `pytest_configure`, before the warnings plugin captures, so it never reaches the warnings summary.

The `strict = true` umbrella was considered and rejected: it opts the repository into every strictness option pytest adds in future, which upstream says to take only on a pinned version. §10.2 bounds rather than pins.

## How the guard is built

Same shape as `test_dependency_constraints.py` — one guard convention in this repo, not two. It pins three parties against each other in both directions:

- **what the repository declares** — `pyproject.toml` read with `tomllib`, exact table equality, so no eighth marker and no extra key slips in;
- **what the running pytest loaded** — read from `pytest.Config`, because a stray `pytest.ini` at the root outranks `pyproject.toml` and would leave every file-based assertion green while the suite ran unconfigured;
- **what the design document says** — the TOML block parsed back out of §10.5, so a docs-only edit turns CI red.

Only two cases spawn a child process (the strict-marker violation and its control) and only those carry `subsystem`. Everything else is in-process, so it runs on every leg of §10.3's Python × mcp matrix rather than only the single-version `subsystem` job.

## Verification

| Stated criterion | Result |
|---|---|
| `pytest --markers` lists all seven | Confirmed; they print ahead of the plugin and built-in markers |
| An unregistered marker fails collection | Exit 2, with a control case proving a registered marker still collects at exit 0 |
| Pass/fail counts unchanged | `12 failed, 246 passed, 2 skipped, 9 subtests` before → `12 failed, 265 passed, 2 skipped, 9 subtests` after, the 19 being this module's own. Also proved by deleting the block and re-running: identical. `asyncio_mode = "auto"` does not touch `unittest.IsolatedAsyncioTestCase`, which is what the existing async tests use. |

The 12 failures are the repository's known baseline and are a later step's to repair.

**Every new assertion was watched failing first**, then made to pass. Nine faults injected and reverted, all caught:

| Fault | Result |
|---|---|
| Drop a marker from `pyproject.toml` only | 3 failed |
| Drop it from §10.5 only | 1 failed (the sync guard) |
| Reword a description in `pyproject.toml` only | 3 failed |
| Move strictness back to `addopts` | 3 failed |
| `asyncio_mode = "strict"` | 4 failed, including the `async def` case |
| An eighth marker in `pyproject.toml` only | 2 failed |
| A stray `pytest.ini` at the root | 14 failed, led by the config-source check |
| Drop `asyncio_default_fixture_loop_scope` | 3 failed |
| Rename the §10.5 heading | 1 failed, naming the heading |

The `addopts` fault is worth reading twice: on 9.1.0 and later it changes no behaviour at all, so only the explicit assertion catches it — and CI will resolve a pytest where both spellings work.

## Adjacent, deliberately not fixed here

- TEST_SUITE §1 and the plan's §1.1 both still say the repository has no `.github/` and no CI. It has had `.github/workflows/ci.yml` since the automatic-review work, though that workflow deliberately does not run this repo's own suite. Worth correcting before the CI epic, which is written as if creating `ci.yml` from nothing.
- `.github/review/rules/docs.md` still says "This repository has no `.system_design/` directory today." Second PR to contradict it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AejTrP3GkUcKkv9UkXYbsP
