### PR TITLE
Add the --min-selected collection guard

### DIFF
--- a/.github/review/rules/python-tests.md
+++ b/.github/review/rules/python-tests.md
@@ -44,7 +44,7 @@
 
 ## The guard tests — treat these as load-bearing
 
-Five tests exist to hold an invariant that nothing else enforces. A pull request
+Six tests exist to hold an invariant that nothing else enforces. A pull request
 that changes what they guard, without changing them, is a finding; a pull request
 that *weakens* one to make a change pass is a critical finding.
 
@@ -55,6 +55,13 @@ that *weakens* one to make a change pass is a critical finding.
 | `test_tool_descriptions.py` | the tool docstrings the calling model receives |
 | `test_diagnostics_masking.py` | that credentials do not reach diagnostics output |
 | `test_pytest_configuration.py` | that `[tool.pytest.ini_options]` matches TEST_SUITE.md §10.5, that the running pytest actually loaded it, and that `strict_markers` / `asyncio_mode` have their effect and not merely their declaration |
+| `test_min_selected_guard.py` | that the `--min-selected` collection floor in `tests/conftest.py` matches TEST_SUITE.md §10.3 and still fires — an under-selected marker job exits 4 and names both counts, while a genuine failure keeps exit 1 and a collection error keeps its own diagnosis |
+
+These two are coupled: `test_min_selected_guard.py` imports `_section_body` from
+`test_pytest_configuration.py` rather than keeping a second copy of the
+fence-aware section bound, which exists because the naive heading regex was
+measured wrong. A change to that helper's name or behaviour breaks both guards,
+so it is not the private detail its underscore suggests.
 
 Plus `test_worker_launch_args_redaction.py` for the subprocess command line — the
 same class of guard, one layer down.

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -450,8 +450,11 @@ fixture server, so §5.4's anti-flake rules apply here in full, plus two
 requirements specific to testing an installed artefact:
 
 - **A fresh virtual environment**, and a working directory **outside the
-  checkout**. Running from the repo root puts `src/` on `sys.path` ahead of the
-  installed package on some invocations.
+  checkout** — necessary but **not sufficient**. `tests/conftest.py` inserts
+  `<checkout>/src` at `sys.path[0]` unconditionally, so any invocation that loads
+  it shadows the installed package from every working directory, and the cwd is
+  not the mechanism. Measured; see §10.3, where the unresolved conflict and its
+  two candidate resolutions are recorded.
 - **Assert the import actually resolves to the wheel.** The test asserts the
   server module's `__file__` lies under the venv's `site-packages` and not under
   the checkout. Without it the job can pass while exercising the source tree — a
@@ -1054,7 +1057,7 @@ def pytest_addoption(parser):
 
 def pytest_collection_finish(session):
     minimum = session.config.getoption("--min-selected")
-    if minimum and len(session.items) < minimum:
+    if minimum and not session.testsfailed and len(session.items) < minimum:
         raise pytest.UsageError(
             f"selected {len(session.items)} tests, expected at least {minimum}; "
             "check the -m expression against the registered markers"
@@ -1066,6 +1069,92 @@ def pytest_collection_finish(session):
 deselection, so `len(items)` is 3 when `-m` selects none, and the guard never
 fires. `collection_finish` reads `session.items` after deselection and reports the
 true selected count.
+
+**The guard stands down when the run has already failed.** `not
+session.testsfailed` is not defensive padding; it is the difference between an
+accurate alarm and a misleading one. Measured: a module that fails to import
+leaves `session.testsfailed` at 1 *and* lowers `len(session.items)`, so without
+the condition the guard fires on top of the collection error. The engineer's
+headline becomes `selected 1 tests, expected at least 2; check the -m expression
+against the registered markers` — blaming an innocent selector for an unrelated
+import break, with the real `ModuleNotFoundError` buried above it, and pytest's
+own exit 2 replaced by exit 4. The guard exists to turn a **green** run red. A
+run that is already red needs nothing from it, and no safety is lost by the
+silence: every suppressed case still fails the job.
+
+**The option exists only for invocations targeting `tests/`.** `pytest_addoption`
+is honoured in *initial* conftests only, and `tests/conftest.py` is one by virtue
+of `testpaths = ["tests"]` and of any argument resolving under `tests/`. Measured
+on pytest 9.1.1: `pytest --min-selected=1 src/` exits 4 with `unrecognized
+arguments`, from inside the checkout and from outside it alike. Every job in the
+table above selects by marker over `tests/`, so every one of them has the option;
+the constraint binds nothing that exists today, and is recorded because a job
+pointed anywhere else would fail with a message about a flag rather than about a
+selector. `test_min_selected_guard.py` asserts the negative, so the day this
+stops being true a test says so.
+
+**A repository-root `conftest.py` was measured, not merely declined.** It does
+register the option universally, but it solves nothing: with an argument of
+`<checkout>/tests/package` the rootdir is still the checkout, so the root file
+loads *and* `tests/conftest.py` loads, because it sits between the rootdir and
+the argument. The package still resolved to the checkout's `src/`. The cost of
+the extra file is real but small — hatchling builds the wheel from `src/`, so a
+root file would reach only the sdist, which already carries `tests/conftest.py` —
+so the reason to reject it is simply that it buys nothing.
+
+**Unresolved, and named here rather than discovered in CI: `tests/conftest.py`
+shadows any installed copy of the package.** Line 8 of that file inserts
+`<checkout>/src` at `sys.path[0]` and line 10 then imports the package, caching
+the checkout's copy in `sys.modules` before the first test runs. Position 0 beats
+site-packages, so this happens from **every** working directory. §6.1's "run from
+outside the checkout" is necessary but not sufficient. Measured from a directory
+outside the checkout with the package installed in the active environment:
+`kindly_web_search_mcp_server.__file__` resolved to `<checkout>/src/…`, and the
+result was identical with `--min-selected` present and absent — so this is **not**
+a consequence of the floor. The floor merely made the collision visible, by
+forcing the question of how a job outside `tests/` would spell its target.
+
+Two assertions in this document therefore cannot hold as written while that line
+stands: §6.1's "`__file__` under the venv's `site-packages` and not the checkout"
+for the `package` job, and the identical claim made above for the `chromium` job,
+which selects `-m "chromium and not live"` over `tests/` and so loads the same
+conftest. The mirror-image assertion in the `coverage` job's step 1 is affected in
+the opposite direction: it passes *because* of line 8, whether or not the editable
+install succeeded, so it currently measures nothing.
+
+**The resolution belongs to the step that builds the wheel harness, not here.**
+This step neither introduced the conflict nor can settle it without changing the
+`sys.path` convention every existing test module depends on, and settling it in a
+bootstrap step would be a decision made where its consequences cannot be observed.
+Two candidates were measured and both work, so the choice is a decision and not a
+research task:
+
+- **An explicit opt-out on the insert.** `tests/conftest.py` skips line 8 when the
+  job sets, say, `KINDLY_TEST_INSTALLED=1`. The installed copy then wins,
+  `--min-selected` still exists, and no other invocation changes. It is the only
+  candidate that also fixes `chromium`, whose tests stay under `tests/`. An
+  implicit form — insert only if the package is not already importable — is
+  rejected: a developer with a stale `pip install .` in their virtualenv would
+  silently start testing the wrong tree.
+- **Moving the wheel tests to a sibling of `tests/`.** Works, and plain `pytest`
+  is unaffected because `testpaths = ["tests"]`. But it contradicts the
+  `tests/package/` location this document assumes throughout, including every
+  `--ignore=tests/package`, and it leaves `chromium` broken.
+
+`--confcutdir=<checkout>/tests/package` also works — the parent conftest is not
+loaded and the installed copy wins — but only if the option is registered in
+`tests/package/conftest.py`, and registering it in both files is a hard
+`ValueError: option names {'--min-selected'} already added` on any run that loads
+both, including a bare `pytest`. Recorded so it is not tried a second time.
+
+Until that is settled, **this section deliberately does not tell the `package` job
+how to spell its target.** An earlier draft did, and the advice was wrong: it
+would have set that job up to fail its own §6.1 assertion.
+
+Only a positive floor arms the guard. Zero is the default and disables it, which
+is what keeps every existing invocation unaffected; a negative value disables it
+just as silently, so a job computing its floor in the shell should not let one
+through.
 
 Every marker-selected job passes `--min-selected=<n>`. Measured behaviour:
 under-selection fails at collection (exit 4, with the count in the message),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,3 +19,66 @@ def patch_settings():
     # This keeps unit tests deterministic while allowing opt-in live integration tests.
     if not settings.settings.serper_api_key:
         settings.settings.serper_api_key = "test_api_key"
+
+
+def pytest_addoption(parser):
+    """Register the ``--min-selected`` collection floor.
+
+    Section 10.3 of ``.system_design/TEST_SUITE.md`` requires every
+    marker-selected CI job to declare how many tests it expects to select.
+    ``--strict-markers`` cannot cover this: it rejects an *unknown* mark applied
+    to a test, but says nothing about a job whose ``-m`` expression matches two
+    tests when it should match forty.
+
+    Defined here rather than in a repository-root ``conftest.py`` because
+    ``testpaths = ["tests"]`` makes this file an initial conftest for every
+    ordinary invocation. The consequence, recorded in section 10.3, is that the
+    option exists only for invocations whose targets resolve under ``tests/``.
+
+    Args:
+        parser: pytest's option parser, injected by pytest.
+    """
+    parser.addoption(
+        "--min-selected",
+        type=int,
+        default=0,
+        help="Fail if fewer than N tests are selected.",
+    )
+
+
+def pytest_collection_finish(session):
+    """Fail the run when fewer tests were selected than the job declared.
+
+    ``pytest_collection_finish``, not ``pytest_collection_modifyitems``:
+    ``modifyitems`` receives the full collected list *before* mark-based
+    deselection, so its ``len(items)`` is the collected count and the guard would
+    never fire under an ``-m`` selector. ``session.items`` here is the true
+    selected count.
+
+    Enforced inside pytest rather than by wrapping the command in shell
+    arithmetic. The obvious shell form, ``pytest … || [ $? -ne 5 ]``, is broken in
+    both directions: on exit 0 the ``||`` short-circuits and the under-selected
+    run passes anyway, and on exit 1 it converts a genuinely failing job into a
+    green one.
+
+    Args:
+        session: The collection session, injected by pytest. Its ``items`` are
+            counted, never inspected.
+
+    Raises:
+        pytest.UsageError: When the floor is armed and the selection falls short.
+            Raising rather than reporting is deliberate: pytest turns this into
+            exit code 4, distinct from 1 (tests failed) and 5 (nothing
+            collected), so a CI log distinguishes a bad selector from a bad test.
+    """
+    minimum = session.config.getoption("--min-selected")
+    # A run that has already failed is not re-diagnosed. A module that fails to
+    # import lowers the selected count too, and firing on top of that would blame
+    # an innocent -m expression for an unrelated import break while replacing
+    # pytest's own exit code. The guard exists to turn a *green* run red; an
+    # already-red run needs nothing from it.
+    if minimum and not session.testsfailed and len(session.items) < minimum:
+        raise pytest.UsageError(
+            f"selected {len(session.items)} tests, expected at least {minimum}; "
+            "check the -m expression against the registered markers"
+        )

--- a/tests/test_min_selected_guard.py
+++ b/tests/test_min_selected_guard.py
@@ -1,0 +1,705 @@
+"""Guard the ``--min-selected`` collection floor declared in ``tests/conftest.py``.
+
+Section 10.3 of ``.system_design/TEST_SUITE.md`` is the policy; the
+``pytest_addoption`` and ``pytest_collection_finish`` hooks in
+:mod:`tests.conftest` are what the runner actually executes. This module keeps
+the two in step, in the same guard shape as
+:mod:`tests.test_pytest_configuration`.
+
+The floor exists because ``strict_markers`` cannot see the failure it addresses.
+Strict markers reject an *unknown* mark applied to a test; they say nothing about
+a CI job whose ``-m`` expression selects two tests when it should select forty.
+Measured on pytest 9.1.1, a selector matching *nothing* exits 5 and fails the
+job, but a selector matching *too few* exits 0 and the job is green while most of
+its tests never ran. That is the silent case, and only a declared floor catches
+it.
+
+Two things about this module's assertions are deliberate and load-bearing:
+
+* **Every child-process case asserts a message, never an exit code alone.**
+  pytest returns 4 for an unrecognized argument as readily as for a
+  :class:`pytest.UsageError`, so ``exit == 4`` is satisfied by a repository where
+  the option was never added at all. Each such case therefore also asserts that
+  ``unrecognized arguments`` is absent.
+* **The design document is compared behaviourally, not textually.** Section
+  10.3's snippet is executed and exercised against the same inputs as the shipped
+  hooks, so a snippet that merely looks similar cannot pass.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests import conftest as shipped
+from tests.test_pytest_configuration import _section_body
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
+TEST_SUITE_PATH = REPO_ROOT / ".system_design" / "TEST_SUITE.md"
+
+DESIGN_SECTION_HEADING = "### 10.3 CI"
+
+# The first line of section 10.3's ``--min-selected`` code block. Section 10.3 is
+# the CI section and already holds several fenced blocks -- two YAML samples and
+# this one -- so "the only block in the section" is the wrong selector here, even
+# though it is correct for section 10.5. Anchoring on the path comment keeps the
+# comparison pointed at this snippet as the section grows.
+DESIGN_SNIPPET_ANCHOR = "# tests/conftest.py"
+
+OPTION = "--min-selected"
+
+# A marker name no test carries and none ever will. Used to drive the selected
+# count to zero while the collected count stays positive.
+UNMATCHED_MARKER = "no_test_carries_this_marker"
+
+# The module the child-process cases collect. One named module rather than the
+# whole of ``tests/``: the claim under test is about the option and the hook, and
+# a child that imports every test module would fail this guard, with a message
+# about ``--min-selected``, whenever any unrelated module broke at import.
+CHILD_TARGET = Path("tests") / "test_pytest_configuration.py"
+
+# ``pytest.ExitCode`` values, spelled out because the distinctions matter and a
+# bare integer in an assertion hides them.
+EXIT_OK = 0
+EXIT_TESTS_FAILED = 1
+EXIT_INTERRUPTED = 2
+EXIT_USAGE_ERROR = 4
+EXIT_NO_TESTS_COLLECTED = 5
+
+# What pytest prints when an option was never registered. Its *absence* is what
+# makes an exit-4 assertion mean "the guard fired" rather than "the flag does not
+# exist", so it is asserted on every case that expects 4 from the guard.
+UNRECOGNIZED = "unrecognized arguments"
+
+
+class _FakeConfig:
+    """Stand-in for :class:`pytest.Config` exposing one option.
+
+    The hook reads exactly one thing from the configuration, so the fake offers
+    exactly that. Anything wider would let a change to the hook's dependencies
+    pass unnoticed.
+    """
+
+    def __init__(self, minimum: int) -> None:
+        """Record the value ``getoption`` will return.
+
+        Args:
+            minimum: The value to report for ``--min-selected``.
+        """
+        self._minimum = minimum
+
+    def getoption(self, name: str) -> int:
+        """Return the recorded value for ``--min-selected``.
+
+        Args:
+            name: The option being read.
+
+        Returns:
+            The minimum this fake was built with.
+
+        Raises:
+            AssertionError: When the hook reads any option other than
+                ``--min-selected``, which would mean it had grown a dependency
+                this fake does not model.
+        """
+        assert name == OPTION, f"hook read unexpected option {name!r}"
+        return self._minimum
+
+
+class _FakeSession:
+    """Stand-in for :class:`pytest.Session` carrying the three fields the hook reads.
+
+    ``items`` is the post-deselection selected list, ``testsfailed`` is pytest's
+    running failure count, and ``config`` supplies the floor.
+    """
+
+    def __init__(self, *, selected: int, minimum: int, testsfailed: int = 0) -> None:
+        """Build a session in a given collection state.
+
+        Args:
+            selected: How many items survived deselection. The items themselves
+                are never inspected by the hook, only counted.
+            minimum: The value of ``--min-selected``.
+            testsfailed: pytest's failure count at collection time; non-zero when
+                a module failed to import.
+        """
+        self.items: list[object] = [object()] * selected
+        self.testsfailed = testsfailed
+        self.config = _FakeConfig(minimum)
+
+
+class _RecordingParser:
+    """Stand-in for pytest's option parser that records the registration call.
+
+    Used to compare the shipped ``pytest_addoption`` with the design document's
+    without depending on pytest's internal parser state.
+    """
+
+    def __init__(self) -> None:
+        """Start with no recorded call."""
+        self.calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    def addoption(self, *args: Any, **kwargs: Any) -> None:
+        """Record one option registration.
+
+        Args:
+            *args: Positional arguments, in practice the option string.
+            **kwargs: Keyword arguments such as ``type``, ``default`` and
+                ``help``.
+        """
+        self.calls.append((args, kwargs))
+
+
+def test_guard_raises_when_selection_is_below_the_minimum() -> None:
+    """Assert an under-selected run is rejected, naming both counts
+
+    The message is asserted along with the raise because the message *is* the
+    feature: an engineer meeting this in CI has a green-looking selector and no
+    other clue. "selected 1 tests, expected at least 5" plus a pointer at the
+    ``-m`` expression is the whole diagnosis.
+    """
+    session = _FakeSession(selected=1, minimum=5)
+
+    with pytest.raises(pytest.UsageError) as raised:
+        shipped.pytest_collection_finish(session)
+
+    message = str(raised.value)
+    assert "selected 1 tests" in message, message
+    assert "expected at least 5" in message, message
+    assert "-m" in message, message
+
+
+def test_guard_accepts_exactly_the_minimum() -> None:
+    """Assert the floor is inclusive -- the control for the case above
+
+    Without this, the guard could satisfy the previous case by rejecting every
+    run, and a correct selection matching its floor exactly would fail CI.
+    """
+    shipped.pytest_collection_finish(_FakeSession(selected=5, minimum=5))
+
+
+def test_guard_is_inert_at_the_default_of_zero() -> None:
+    """Assert the default disables the guard, even with nothing selected
+
+    Every existing invocation in this repository, and every developer running
+    ``pytest`` by hand, runs without the option. A guard that fired at its
+    default would break all of them, so the disabled state is asserted at its
+    most extreme input: zero selected.
+    """
+    shipped.pytest_collection_finish(_FakeSession(selected=0, minimum=0))
+
+
+def test_guard_stands_down_when_the_run_has_already_failed() -> None:
+    """Assert a run that has already failed is not re-diagnosed as under-selection
+
+    A module that fails to import lowers the selected count and leaves
+    ``testsfailed`` non-zero. Without this condition the guard fires on top of
+    the collection error and the headline becomes "check the -m expression" --
+    blaming an innocent selector for an unrelated import break, and replacing
+    pytest's own exit 2 with exit 4.
+
+    The guard exists to turn a **green** run red. A run that is already red needs
+    no help and loses nothing by the guard staying quiet.
+    """
+    shipped.pytest_collection_finish(
+        _FakeSession(selected=1, minimum=5, testsfailed=1)
+    )
+
+
+def test_option_default_is_zero(pytestconfig: pytest.Config) -> None:
+    """Assert the option is registered in the **running** pytest, defaulting to 0
+
+    Read through ``pytestconfig`` rather than from the source: this is the case
+    that notices if ``tests/conftest.py`` stops being an initial conftest and the
+    registration silently stops happening.
+
+    Args:
+        pytestconfig: The session's configuration, injected by pytest.
+    """
+    assert pytestconfig.getoption(OPTION) == 0, (
+        f"pytest reports {OPTION} = {pytestconfig.getoption(OPTION)!r}; section "
+        "10.3 of TEST_SUITE.md requires a default of 0 so that every invocation "
+        "without the option is unaffected."
+    )
+
+
+def _design_document_snippet() -> str:
+    """Extract section 10.3's ``--min-selected`` code block from ``TEST_SUITE.md``.
+
+    The section is bounded with :func:`tests.test_pytest_configuration._section_body`
+    rather than a fresh heading regex. That helper exists because the naive bound
+    was measured wrong -- a ``#`` comment at column 0 inside a fence is
+    indistinguishable from a heading -- and it carries its own rationale and
+    tests. A second copy here would drift from it.
+
+    Within the section the block is chosen by its first line rather than by being
+    the only one: section 10.3 is the CI section and already holds two YAML
+    samples besides this snippet, and the CI epic will add more.
+
+    Returns:
+        The snippet's source, ready to execute.
+
+    Raises:
+        AssertionError: When the heading, or exactly one anchored block beneath
+            it, cannot be found -- either of which would silently disable this
+            comparison.
+    """
+    text = TEST_SUITE_PATH.read_text(encoding="utf-8")
+    assert DESIGN_SECTION_HEADING in text.splitlines(), (
+        f"{TEST_SUITE_PATH.name} no longer contains "
+        f"'{DESIGN_SECTION_HEADING}'. This guard parses that section; renaming "
+        "it would silently disable the check."
+    )
+    section = _section_body(text, DESIGN_SECTION_HEADING)
+    blocks = [
+        block
+        for block in re.findall(r"```python\n(.*?)```", section, re.DOTALL)
+        if block.startswith(f"{DESIGN_SNIPPET_ANCHOR}\n")
+    ]
+    assert len(blocks) == 1, (
+        f"Section 10.3 of {TEST_SUITE_PATH.name} contains {len(blocks)} python "
+        f"blocks opening with '{DESIGN_SNIPPET_ANCHOR}'; this guard requires "
+        "exactly one."
+    )
+    return blocks[0]
+
+
+def _design_document_hooks() -> dict[str, Any]:
+    """Execute the design document's snippet and return the names it defines.
+
+    Executing rather than pattern-matching the source is the point of this
+    comparison: a snippet that merely *looks* like the shipped hook cannot pass,
+    and the option's name, its default, the arming condition and the message text
+    are all checked by exercising them rather than by four separate string
+    searches that each risk being satisfied by a near miss.
+
+    Returns:
+        The namespace the snippet defines.
+
+    Raises:
+        AssertionError: When the snippet does not define both hooks.
+    """
+    namespace: dict[str, Any] = {}
+    # The executed source is a fenced block in a version-controlled design
+    # document in this repository, reached through no input this test does not
+    # control -- the same trust level as importing a module from the tree.
+    exec(  # noqa: S102
+        compile(_design_document_snippet(), str(TEST_SUITE_PATH), "exec"),
+        namespace,
+    )
+    for hook in ("pytest_addoption", "pytest_collection_finish"):
+        assert hook in namespace, (
+            f"Section 10.3's snippet in {TEST_SUITE_PATH.name} no longer defines "
+            f"{hook}; {shipped.__name__} does."
+        )
+    return namespace
+
+
+def test_design_document_registers_the_same_option() -> None:
+    """Assert the documented and shipped ``pytest_addoption`` calls are identical
+
+    Compared as the recorded call -- option string, type, default and help text --
+    so a document that renames the option, or changes the default that keeps
+    every existing invocation unaffected, turns this red.
+    """
+    documented, actual = _RecordingParser(), _RecordingParser()
+
+    _design_document_hooks()["pytest_addoption"](documented)
+    shipped.pytest_addoption(actual)
+
+    assert documented.calls == actual.calls, (
+        f"Section 10.3 of {TEST_SUITE_PATH.name} registers "
+        f"{documented.calls!r} but {shipped.__name__} registers "
+        f"{actual.calls!r}. Change both in the same pull request."
+    )
+
+
+@pytest.mark.parametrize(
+    ("selected", "minimum", "testsfailed"),
+    [
+        pytest.param(1, 5, 0, id="below-the-floor"),
+        pytest.param(5, 5, 0, id="exactly-at-the-floor"),
+        pytest.param(0, 0, 0, id="guard-disabled"),
+        pytest.param(1, 5, 1, id="run-already-failed"),
+        pytest.param(0, -1, 0, id="negative-floor"),
+    ],
+)
+def test_design_document_hook_behaves_identically(
+    selected: int, minimum: int, testsfailed: int
+) -> None:
+    """Assert the documented and shipped hooks agree on one collection state
+
+    The four states are the whole behaviour: fire, do not fire at the boundary,
+    do not fire when disabled, and do not fire on an already-failed run. Where
+    both raise, the messages are compared too -- the message is what an engineer
+    reads in CI, and a document whose snippet says something else has stopped
+    describing what ships.
+
+    Args:
+        selected: Items surviving deselection.
+        minimum: The declared floor.
+        testsfailed: pytest's failure count at collection time.
+    """
+    documented = _design_document_hooks()["pytest_collection_finish"]
+
+    def outcome(hook: Any) -> str | None:
+        """Run one hook and reduce it to a comparable result.
+
+        Args:
+            hook: The hook to invoke.
+
+        Returns:
+            The error message, or ``None`` when the hook allowed the run.
+        """
+        try:
+            hook(
+                _FakeSession(
+                    selected=selected, minimum=minimum, testsfailed=testsfailed
+                )
+            )
+        except pytest.UsageError as error:
+            return str(error)
+        return None
+
+    assert outcome(documented) == outcome(shipped.pytest_collection_finish), (
+        f"Section 10.3 of {TEST_SUITE_PATH.name} and {shipped.__name__} disagree "
+        f"for selected={selected}, minimum={minimum}, testsfailed={testsfailed}. "
+        "Change both in the same pull request."
+    )
+
+
+def _child_environment() -> dict[str, str]:
+    """Build the environment every child pytest runs under.
+
+    ``PYTEST_ADDOPTS`` is dropped: inherited from the parent it would silently
+    change the child's selection, which is the one thing these cases measure.
+
+    Returns:
+        A copy of the current environment, cleaned.
+    """
+    environment = dict(os.environ)
+    environment.pop("PYTEST_ADDOPTS", None)
+    # Pinned so the child's stdout is UTF-8 on every platform. Without it a
+    # Windows runner encodes with the locale codec while this process decodes
+    # with its own, and a message assertion becomes a question about codecs.
+    environment["PYTHONIOENCODING"] = "utf-8"
+    return environment
+
+
+def _run_pytest(
+    *args: str, cwd: Path, environment: dict[str, str]
+) -> subprocess.CompletedProcess[str]:
+    """Run a child pytest against the **committed** ``pyproject.toml``.
+
+    ``-c`` points the child at this repository's real configuration rather than
+    at a copy written for the occasion, which is the same reasoning as
+    :mod:`tests.test_pytest_configuration`: a test that builds its own config
+    proves only that pytest works.
+
+    Args:
+        *args: Arguments appended after the configuration flags.
+        cwd: Working directory for the child.
+        environment: The child's environment.
+
+    Returns:
+        The completed process, with ``stdout`` and ``stderr`` captured as text.
+
+    Raises:
+        subprocess.TimeoutExpired: When the child has not exited within 120
+            seconds, so a hung child fails one case instead of the whole run.
+    """
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-p",
+            "no:cacheprovider",
+            "-c",
+            str(PYPROJECT_PATH),
+            *args,
+        ],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        cwd=cwd,
+        env=environment,
+        timeout=120,
+        check=False,
+    )
+
+
+def _run_in_repository(*args: str) -> subprocess.CompletedProcess[str]:
+    """Run a child pytest from the repository root, over the real tree.
+
+    This shape is what proves ``tests/conftest.py`` is genuinely wired in as an
+    *initial* conftest -- the one fact no in-process test can reach, since a
+    registration that stopped happening would leave the source unchanged.
+
+    Args:
+        *args: Arguments for the child.
+
+    Returns:
+        The completed process.
+    """
+    return _run_pytest(*args, cwd=REPO_ROOT, environment=_child_environment())
+
+
+def _run_over_temporary_tests(
+    *args: str, cwd: Path
+) -> subprocess.CompletedProcess[str]:
+    """Run a child pytest over a temporary directory, loading the shipped conftest.
+
+    ``-p tests.conftest`` loads :mod:`tests.conftest` itself as a plugin -- the
+    real module, not a copy -- which is how a case that needs a *failing* or
+    *un-importable* module still exercises the shipped hook. The repository tree
+    contains neither, and adding one to it would break every other run.
+
+    Two constraints, both measured, both load-bearing:
+
+    * ``PYTHONPATH`` must carry the repository root. The child's ``sys.path[0]``
+      is its own working directory, and ``-c`` sets the rootdir without adding
+      anything importable. Without it the plugin import fails -- and that failure
+      exits 1, the exact code one of these cases asserts as success, so the case
+      would pass forever for the wrong reason.
+    * The target is always given explicitly. ``testpaths`` is consulted only
+      when the invocation directory *is* the rootdir, and ``-c`` puts the rootdir
+      at the repository root while the child runs in a temporary directory -- so
+      an omitted target would silently fall back to the invocation directory
+      rather than to ``tests``. Correct either way here, but not for a reason
+      worth leaving implicit.
+    * The target must never lie under ``tests/``. Normal conftest discovery would
+      then reach the same file that ``-p`` already loaded, and pytest raises
+      ``ValueError: Plugin already registered under a different name``.
+
+    Args:
+        *args: Arguments for the child, appended after the plugin flag.
+        cwd: The temporary directory holding the test modules.
+
+    Returns:
+        The completed process.
+    """
+    environment = _child_environment()
+    environment["PYTHONPATH"] = str(REPO_ROOT)
+    return _run_pytest(
+        "-p", "tests.conftest", *args, cwd=cwd, environment=environment
+    )
+
+
+def _write(directory: Path, name: str, body: str) -> None:
+    """Write one test module into a temporary directory.
+
+    Args:
+        directory: Where to write.
+        name: The module's file name.
+        body: Its source, dedented before writing.
+    """
+    (directory / name).write_text(textwrap.dedent(body), encoding="utf-8")
+
+
+@pytest.mark.subsystem
+def test_under_selection_exits_usage_error_with_the_count() -> None:
+    """Assert an under-selected real run aborts with exit 4 and names the counts
+
+    The end-to-end form of the whole feature, and the case that pins the choice
+    of hook. The floor of 1 sits deliberately *between* the selected count (0,
+    after deselection) and the collected count (every case in the target module).
+    A ``pytest_collection_modifyitems`` implementation reads the collected count,
+    would find it comfortably above 1, would not fire, and this run would exit 5
+    instead.
+
+    The message is asserted alongside the exit code, and ``unrecognized
+    arguments`` asserted absent, because pytest returns 4 for an unknown flag
+    too: without that second half this case is green against a repository where
+    the option was never added.
+    """
+    result = _run_in_repository(
+        "-q", "-m", UNMATCHED_MARKER, f"{OPTION}=1", str(CHILD_TARGET)
+    )
+
+    assert result.returncode == EXIT_USAGE_ERROR, (
+        f"Expected exit {EXIT_USAGE_ERROR} (usage error), got "
+        f"{result.returncode}.\n{result.stdout}\n{result.stderr}"
+    )
+    assert UNRECOGNIZED not in result.stderr, (
+        f"pytest exited {EXIT_USAGE_ERROR} because {OPTION} is not registered, "
+        f"not because the guard fired.\n{result.stderr}"
+    )
+    assert "selected 0 tests, expected at least 1" in result.stderr, (
+        f"The guard fired without naming both counts.\n{result.stderr}"
+    )
+    assert "-m" in result.stderr, (
+        f"The guard's message does not point at the -m expression.\n"
+        f"{result.stderr}"
+    )
+    # The precondition the paragraph above depends on, asserted rather than
+    # assumed. If the target module ever collects nothing, the floor no longer
+    # lies between the selected and collected counts, a modifyitems
+    # implementation would exit 4 here too, and this case would silently stop
+    # discriminating while staying green.
+    # Matched without the surrounding parentheses: pytest brackets the count as
+    # "(21 deselected)" only under --collect-only, and prints "21 deselected"
+    # for a run that executes. This case is the executing shape.
+    deselected = re.search(r"(\d+) deselected", result.stdout)
+    assert deselected and int(deselected.group(1)) >= 1, (
+        f"{CHILD_TARGET} collected nothing, so this case no longer pins the "
+        f"choice of hook.\n{result.stdout}"
+    )
+
+
+@pytest.mark.subsystem
+def test_without_the_option_an_empty_selection_still_exits_five() -> None:
+    """Assert the unguarded behaviour is unchanged -- the control for the case above
+
+    Without this, the previous case would pass against any change that made the
+    run exit 4 for some unrelated reason. Exit 5 is what pytest already did, and
+    what every invocation that omits the option must keep doing.
+    """
+    result = _run_in_repository(
+        "-q", "--collect-only", "-m", UNMATCHED_MARKER, str(CHILD_TARGET)
+    )
+
+    assert result.returncode == EXIT_NO_TESTS_COLLECTED, (
+        f"Expected exit {EXIT_NO_TESTS_COLLECTED} (nothing collected), got "
+        f"{result.returncode}.\n{result.stdout}\n{result.stderr}"
+    )
+
+
+@pytest.mark.subsystem
+def test_a_real_failure_keeps_its_own_exit_code(tmp_path: Path) -> None:
+    """Assert a genuine test failure under a satisfied floor still exits 1
+
+    This is the failure mode the design rejects the shell workaround for: a guard
+    that converts exit 1 into anything else -- 0 especially -- turns a failing job
+    green. ``1 failed, 1 passed`` is asserted as well as the exit code, because a
+    plugin that failed to import would also exit 1 while running nothing at all.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory, off the repository tree.
+    """
+    _write(
+        tmp_path,
+        "test_mixed.py",
+        """
+        def test_passes() -> None:
+            pass
+
+
+        def test_fails() -> None:
+            assert False
+        """,
+    )
+
+    result = _run_over_temporary_tests(
+        "-q", f"{OPTION}=1", "test_mixed.py", cwd=tmp_path
+    )
+
+    assert result.returncode == EXIT_TESTS_FAILED, (
+        f"Expected exit {EXIT_TESTS_FAILED} (tests failed), got "
+        f"{result.returncode}.\n{result.stdout}\n{result.stderr}"
+    )
+    assert "1 failed, 1 passed" in result.stdout, (
+        f"The run did not execute both tests; the guard or the plugin "
+        f"interfered.\n{result.stdout}\n{result.stderr}"
+    )
+
+
+@pytest.mark.subsystem
+def test_a_satisfied_minimum_lets_a_passing_run_pass(tmp_path: Path) -> None:
+    """Assert a satisfied floor leaves a passing run passing
+
+    Executed rather than merely collected: ``--collect-only`` would show that
+    collection was not aborted, which is a weaker claim than the run completing
+    green with the guard in place.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory.
+    """
+    _write(
+        tmp_path,
+        "test_passing.py",
+        """
+        def test_passes() -> None:
+            pass
+        """,
+    )
+
+    result = _run_over_temporary_tests(
+        "-q", f"{OPTION}=1", "test_passing.py", cwd=tmp_path
+    )
+
+    assert result.returncode == EXIT_OK, (
+        f"Expected exit {EXIT_OK}, got {result.returncode}.\n"
+        f"{result.stdout}\n{result.stderr}"
+    )
+    assert "1 passed" in result.stdout, (
+        f"Expected one passing test.\n{result.stdout}\n{result.stderr}"
+    )
+
+
+@pytest.mark.subsystem
+def test_a_collection_error_is_not_rediagnosed_as_under_selection(
+    tmp_path: Path,
+) -> None:
+    """Assert an import error keeps its own exit code and its own diagnosis
+
+    A module that fails to import lowers the selected count, so an unconditional
+    guard fires on top of it and the engineer's headline blames a marker
+    expression that is innocent. Both halves are asserted: pytest's own exit 2
+    survives, and the guard's message is *absent* -- the second is the part that
+    would regress silently if the arming condition were simplified.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory.
+    """
+    _write(tmp_path, "test_fine.py", "def test_fine() -> None:\n    pass\n")
+    _write(tmp_path, "test_broken.py", "import definitely_no_such_module\n")
+
+    result = _run_over_temporary_tests("-q", f"{OPTION}=2", ".", cwd=tmp_path)
+
+    assert result.returncode == EXIT_INTERRUPTED, (
+        f"Expected exit {EXIT_INTERRUPTED} (collection interrupted), got "
+        f"{result.returncode}.\n{result.stdout}\n{result.stderr}"
+    )
+    assert "definitely_no_such_module" in result.stdout, (
+        f"The import error is not what was reported.\n{result.stdout}"
+    )
+    assert "expected at least 2" not in result.stderr, (
+        "The guard fired on top of a collection error and blamed the -m "
+        f"expression for it.\n{result.stderr}"
+    )
+
+
+@pytest.mark.subsystem
+def test_the_option_is_unknown_outside_the_tests_tree() -> None:
+    """Assert the option's documented reach -- it does not exist for other targets
+
+    ``pytest_addoption`` is honoured in *initial* conftests only, and
+    ``tests/conftest.py`` is one only for invocations resolving under ``tests/``.
+    Every job section 10.3 defines selects by marker over ``tests/``, so the
+    constraint binds nothing today; it is recorded and asserted because a job
+    pointed anywhere else would fail with a message about a flag rather than
+    about a selector, which is a confusing way to learn this.
+
+    Asserted rather than left implicit so the constraint cannot rot: if a later
+    change moves the registration to a repository-root ``conftest.py``, this case
+    turns red and the design document gets updated with it.
+    """
+    result = _run_in_repository("-q", "--collect-only", f"{OPTION}=1", "src")
+
+    assert result.returncode == EXIT_USAGE_ERROR, (
+        f"Expected exit {EXIT_USAGE_ERROR}, got {result.returncode}.\n"
+        f"{result.stdout}\n{result.stderr}"
+    )
+    assert UNRECOGNIZED in result.stderr, (
+        f"Expected {OPTION} to be unknown for a target outside tests/.\n"
+        f"{result.stderr}"
+    )

--- a/tests/test_min_selected_guard.py
+++ b/tests/test_min_selected_guard.py
@@ -337,11 +337,11 @@ def test_design_document_hook_behaves_identically(
 ) -> None:
     """Assert the documented and shipped hooks agree on one collection state
 
-    The four states are the whole behaviour: fire, do not fire at the boundary,
-    do not fire when disabled, and do not fire on an already-failed run. Where
-    both raise, the messages are compared too -- the message is what an engineer
-    reads in CI, and a document whose snippet says something else has stopped
-    describing what ships.
+    The five states are the whole behaviour: fire, do not fire at the boundary,
+    do not fire when disabled, do not fire on an already-failed run, and do not
+    fire on a negative floor. Where both raise, the messages are compared too --
+    the message is what an engineer reads in CI, and a document whose snippet
+    says something else has stopped describing what ships.
 
     Args:
         selected: Items surviving deselection.

--- a/tests/test_min_selected_guard.py
+++ b/tests/test_min_selected_guard.py
@@ -654,8 +654,18 @@ def test_a_collection_error_is_not_rediagnosed_as_under_selection(
     A module that fails to import lowers the selected count, so an unconditional
     guard fires on top of it and the engineer's headline blames a marker
     expression that is innocent. Both halves are asserted: pytest's own exit 2
-    survives, and the guard's message is *absent* -- the second is the part that
-    would regress silently if the arming condition were simplified.
+    survives, and the guard's message is *absent*.
+
+    The arming condition reads ``session.testsfailed``, which is pytest's own
+    counter rather than a documented contract. Measured non-zero at
+    ``pytest_collection_finish`` on **pytest 9.1.1**, the version this was written
+    against; §10.2 bounds the project at ``pytest>=9,<10``, so a minor release
+    could in principle move when it is set. That is not a silent risk: were it to
+    change, the guard would re-fire on the collection error and this case fails on
+    its *first* assertion with ``Expected exit 2 …, got 4`` -- verified by
+    simulating exactly that regression. The version is named here so the engineer
+    who meets that failure after a pytest bump reads it as the deliberate decision
+    it is, rather than as a puzzle.
 
     Args:
         tmp_path: pytest's per-test temporary directory.


### PR DESCRIPTION
## Context for the Product Owner

The test suite is about to be split into CI jobs that each run one slice of it, selected by label — "the browser ones", "the ones that hit the live network", and so on. That design has a silent failure mode: if a label is renamed or dropped, the job that selects it quietly runs *two* tests instead of forty and **reports green**. We would be shipping on a test suite that is not running, with no signal that anything is wrong.

Measured, on the pytest version this repository is bound to:

| What the job asks for | What pytest does |
|---|---|
| a label **no test carries** | exits 5 — the job fails, safe by default |
| a label carried by **1 test when 40 were expected** | exits **0** — the job passes silently |

The first case is already safe. The second is the one that costs you a release.

This PR installs the tripwire: each job declares the minimum number of tests it expects to select, and the run aborts if it comes up short. It is a prerequisite for the CI workflow skeleton and the nightly workflow, which are the next two pieces of work and cannot be built safely without it.

**No product behaviour changes.** Nothing users touch is affected, and every existing way of running the tests behaves exactly as before — the guard is off unless a job asks for it.

## What changed

- `tests/conftest.py` — the `--min-selected` option and a `pytest_collection_finish` hook.
- `tests/test_min_selected_guard.py` — a new 17-case guard, in three layers.
- `.system_design/TEST_SUITE.md` §10.3 — the corrected snippet and the reasoning behind it; §6.1 — a corrected factual claim (see below).
- `.github/review/rules/python-tests.md` — the new guard added to the load-bearing table.

## Why the guard lives inside pytest

The obvious shell form is rejected by the design and is worth restating, because it looks reasonable:

```sh
pytest -m slow || [ $? -ne 5 ]      # broken in BOTH directions
```

On exit 0 the `||` short-circuits and the under-selected run passes anyway. On exit 1 — real test failures — the guard runs, `[ 1 -ne 5 ]` succeeds, and **a failing job is converted into a green one.** Enforcing the count inside pytest keeps collection authoritative and preserves the test exit code.

`pytest_collection_finish`, **not** `pytest_collection_modifyitems`: `modifyitems` receives the collected list *before* label-based deselection, so its count is the collected count and a floor there never fires under a `-m` selector at all.

## Two departures from §10.3 as written

Both found during implementation, both measured, both carried back into the design document in this PR so the snippet stays the thing that ships.

**1. The guard stands down when the run has already failed.** A module that fails to import lowers the selected count *and* sets `session.testsfailed`. The snippet as written then fires on top of the collection error, and the engineer's headline becomes:

```
ERROR: selected 1 tests, expected at least 2; check the -m expression against the registered markers
```

— blaming an innocent selector for an unrelated import break, with the real `ModuleNotFoundError` buried above it, and pytest's own exit 2 replaced by exit 4. A guard exists to turn a **green** run red. A run that is already red needs nothing from it, and no safety is lost: every suppressed case still fails the job.

**2. The option's reach is documented and pinned by a test.** `pytest_addoption` is honoured in *initial* conftests only, so `--min-selected` exists only for invocations targeting `tests/`. Every job the design defines does, so nothing is constrained today — but a job pointed elsewhere would fail with a message about a flag rather than about a selector, which is a confusing way to learn this.

## A pre-existing conflict this PR records but does not fix

Asking how a job *outside* `tests/` would spell its target surfaced something older and more serious. `tests/conftest.py` line 8 inserts `<checkout>/src` at `sys.path[0]`, so it **shadows any installed copy of the package from every working directory**. Measured from an unrelated directory with the package installed: the import still resolved to the checkout's `src/`, with and without this PR's option — so it is not a consequence of the floor.

§6.1 says the installed-wheel job must run "from a working directory outside the checkout", and hedges that the repo root shadows the package "on some invocations". **The working directory is not the mechanism**, and that hedge is what let the error survive: two of the design's assertions about testing an installed wheel cannot hold while line 8 stands, and a third — the coverage job's mirror-image assertion — passes *because* of line 8 whether or not its editable install succeeded, so it currently measures nothing.

§6.1's stated mechanism is corrected here, because this PR's own text would otherwise contradict it. §10.3 now records the conflict, the measured mechanism, and **two candidate resolutions that were both measured and both work**, so the step that builds the wheel harness starts from evidence rather than from scratch. The choice belongs to that step, where its consequences are observable — not to a bootstrap step.

An earlier draft of this PR told the wheel job how to spell its target. That advice was measured to be wrong and has been removed.

## How the tests are built

Each claim is proved at the cheapest layer that can prove it.

- **Called directly (5 cases).** The hook is a pure predicate; a fake session is the whole fixture. Fires below the floor, inclusive at the floor, inert at the default, inert on an already-failed run.
- **Design-document contract (5 cases).** §10.3's snippet is **executed** and exercised against the same inputs as the shipped hook, rather than pattern-matched — so a snippet that merely *looks* similar cannot pass. Verified to fail when the document alone changes the option name, the default, the arming condition, or the message text.
- **Real child pytest (7 cases).** Only exit codes need a real process. Measured: `4` for under-selection, `5` unguarded, `1` for a genuine failure, `0` for a satisfied floor, `2` for a collection error, `4` + `unrecognized arguments` outside `tests/`.

**Every child-process case asserts a message, never an exit code alone.** pytest returns 4 for an unrecognized argument just as readily as for the guard firing, so `returncode == 4` on its own is green against a repository where the option was never added. Each such case also asserts that `unrecognized arguments` is *absent*.

## Verification

Five mutants introduced into the implementation, each killed by multiple cases:

| Mutant | Killed by |
|---|---|
| drop the `not session.testsfailed` condition | 3 cases |
| swap to `pytest_collection_modifyitems` | 10 cases |
| `<` → `<=` | 3 cases |
| guard never fires | 3 cases |
| default `0` → `1` | 3 cases |

Review also caught the one blind spot those mutants could not: the end-to-end case pins the *choice of hook* only because its target module happens to collect 21 tests. If that module were ever emptied, the wrong-hook bug would pass green. That precondition is now asserted, and confirmed to fire when pointed at a module that collects nothing.

- Suite: **284 passed**, up from 267. The 12 pre-existing failures are **byte-identical** to the baseline taken before any edit — this PR regresses nothing and fixes nothing it did not intend to.
- Review-system tests: 482 passed, including the leak guard.
- `ruff check` clean on both changed Python files.
- `scripts/check_plan_dag.py` exits 0.

> ⚠️ Note for reviewers: `.github/workflows/ci.yml` deliberately does **not** run `pytest` or `ruff`, so this PR's green checks say nothing about the suite. All figures above were measured locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AejTrP3GkUcKkv9UkXYbsP
