### PR TITLE
Add the three coverage configurations (plan step E0-4)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,40 @@
+# Base coverage configuration -- the whole-package view, which feeds control 1
+# of section 10.4 of `.system_design/TEST_SUITE.md`.
+#
+# Every job selects its configuration by an absolute `COVERAGE_RCFILE` and never
+# by discovery. Discovery walks up from the working directory, and the package
+# tests deliberately run from outside the checkout, where this file would not be
+# found -- the run would then silently fall back to coverage.py's defaults, which
+# is the one failure this file exists to prevent. `COVERAGE_FILE` is set to an
+# absolute path for the same reason.
+
+[run]
+# The setting that closes this project's worst measurement gap. By default
+# coverage.py reports only files it observed being executed, so a module no test
+# ever imports -- `scrape/chromium_pool.py`, 213 statements with no test file --
+# is absent from the report entirely rather than present and visibly at zero. It
+# would drag nothing down and nobody would see it. `source_pkgs` is what makes
+# never-executed files appear.
+source_pkgs = kindly_web_search_mcp_server
+
+# Branch coverage rather than statement coverage. The committed baseline is a
+# combined statement-and-branch measure, and most of what is untested in this
+# package is a fallback or retry *branch* through a statement some other test
+# already runs.
+branch = true
+
+# Keeps recorded paths comparable across jobs and platforms, and in the form
+# `git diff` produces, which is what diff-cover matches its changed lines
+# against.
+relative_files = true
+
+[paths]
+# Coverage recorded against an installed wheel lands under `site-packages` and
+# unmapped it never joins the source tree's own paths: the totals double-count
+# and diff-cover finds no coverage for any changed line, passing silently. The
+# mapping stays in this file even though the gating lane runs from a source
+# checkout, because the package tests install a wheel and their observational
+# report needs it.
+source =
+    src/kindly_web_search_mcp_server
+    */site-packages/kindly_web_search_mcp_server

--- a/.coveragerc
+++ b/.coveragerc
@@ -7,6 +7,15 @@
 # found -- the run would then silently fall back to coverage.py's defaults, which
 # is the one failure this file exists to prevent. `COVERAGE_FILE` is set to an
 # absolute path for the same reason.
+#
+# Three separate files rather than one `[tool.coverage.*]` table in
+# `pyproject.toml`: coverage.py reads exactly one configuration per run, and the
+# three views need different `[run]` sections, which a single table cannot
+# express. The consequence is worth knowing, because pytest's configuration went
+# the other way and lives in `pyproject.toml`: coverage.py consults
+# `.coveragerc` first and, having found it, never looks at `pyproject.toml` at
+# all. A `[tool.coverage.*]` table added there later would be dead text with no
+# error to say so.
 
 [run]
 # The setting that closes this project's worst measurement gap. By default

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,11 +2,15 @@
 # of section 10.4 of `.system_design/TEST_SUITE.md`.
 #
 # Every job selects its configuration by an absolute `COVERAGE_RCFILE` and never
-# by discovery. Discovery walks up from the working directory, and the package
-# tests deliberately run from outside the checkout, where this file would not be
-# found -- the run would then silently fall back to coverage.py's defaults, which
-# is the one failure this file exists to prevent. `COVERAGE_FILE` is set to an
-# absolute path for the same reason.
+# by discovery. Discovery does not search upwards: coverage.py looks only in the
+# directory it is run from, trying `.coveragerc`, `.coveragerc.toml`, `setup.cfg`,
+# `tox.ini` and `pyproject.toml`, and takes the first carrying coverage settings.
+# The package tests deliberately run from outside the checkout, so this file
+# would not be found there -- and an unrelated directory's `setup.cfg` or
+# `pyproject.toml` is a perfectly acceptable answer to that search, which is
+# worse than falling back to defaults. `COVERAGE_FILE` is absolute for the same
+# reason, and note that passing the bare string `.coveragerc` to coverage's API
+# means "no file specified", which makes it read `COVERAGE_RCFILE` instead.
 #
 # Three separate files rather than one `[tool.coverage.*]` table in
 # `pyproject.toml`: coverage.py reads exactly one configuration per run, and the

--- a/.coveragerc-gate
+++ b/.coveragerc-gate
@@ -1,0 +1,38 @@
+# Gating coverage configuration -- the declared gating scope, which feeds
+# controls 2 (diff coverage) and 3 (the committed baseline) of section 10.4 of
+# `.system_design/TEST_SUITE.md`.
+#
+# This is `.coveragerc` plus an `omit` list and nothing else. The two views are
+# taken from the same coverage run and are only comparable if they differ in
+# that one setting, so a change made here must be made there too.
+
+[run]
+source_pkgs = kindly_web_search_mcp_server
+branch = true
+relative_files = true
+
+# The modules with no hermetic seam. Under `source_pkgs` their statements are
+# reported at zero, and left inside the gating scope those zeros are not
+# harmless: diff-cover counts changed ones as uncovered, and adding L3-only
+# statements grows the baseline's denominator while the numerator stands still.
+# Ordinary worker or pool development would fail both gates, pushing authors
+# either to write hermetic tests for code that has no hermetic seam or to reach
+# for the baseline-reset escape hatch.
+#
+# Omission is not forgiveness. Each of these must still show non-zero coverage in
+# the observational L3 report, which is where they are actually exercised.
+#
+# `scrape/worker_runner.py` does not exist yet: it is the process-management
+# module extracted from `universal_html.py` by a later step. It is listed now
+# because `omit` works at file granularity, which is precisely what forces that
+# extraction -- the runner cannot be exempted while it still lives inside a
+# module that must stay in the gating scope.
+omit =
+    */scrape/nodriver_worker.py
+    */scrape/chromium_pool.py
+    */scrape/worker_runner.py
+
+[paths]
+source =
+    src/kindly_web_search_mcp_server
+    */site-packages/kindly_web_search_mcp_server

--- a/.coveragerc-subprocess
+++ b/.coveragerc-subprocess
@@ -1,0 +1,33 @@
+# Subprocess coverage configuration -- observational L3 jobs only, per section
+# 10.4 of `.system_design/TEST_SUITE.md`. It gates nothing.
+#
+# This lane exists because the worker runs in a child interpreter, and a child
+# started under `coverage run` is not instrumented by inheritance: without the
+# patch below its lines are never recorded at all, and the observational report
+# for the very modules the lane was built to cover reads zero.
+
+[run]
+source_pkgs = kindly_web_search_mcp_server
+branch = true
+relative_files = true
+
+# `patch = subprocess` implies `parallel`, but it is declared rather than
+# inherited: a job that writes suffixed data files and a job that does not need
+# different post-processing, and that fact should be legible in the file rather
+# than deduced from another setting.
+parallel = true
+
+# Instruments every child process this package spawns. The jobs using this file
+# must run a local `coverage combine` before reporting -- reporting does not
+# implicitly combine the suffixed data files, and a job that skips it reports the
+# parent's coverage alone while looking like it worked. That combine is local to
+# the job; nothing is combined across jobs.
+#
+# A forcibly killed child does not flush its data, so its lines are missing from
+# the report. That gap is expected and must not be papered over with an exclusion
+# that would also hide genuinely untested code.
+patch = subprocess
+
+# No `[paths]` section, deliberately. The mapping matters only where a wheel is
+# involved, and the jobs that use this file run from a source checkout, where
+# recorded paths already match the tree.

--- a/.coveragerc-subprocess
+++ b/.coveragerc-subprocess
@@ -28,6 +28,13 @@ parallel = true
 # that would also hide genuinely untested code.
 patch = subprocess
 
-# No `[paths]` section, deliberately. The mapping matters only where a wheel is
-# involved, and the jobs that use this file run from a source checkout, where
-# recorded paths already match the tree.
+# No `[paths]` section. Shipped exactly as section 10.4 specifies, and the reason
+# differs between this file's two consumers: the `subsystem` job runs from a
+# source checkout, where recorded paths already match the tree, but the
+# `chromium` job installs the PR's wheel and asserts the package resolves to it,
+# so its paths land under `site-packages` unmapped. That is accepted because this
+# lane is observational -- it feeds neither diff-cover nor the committed baseline,
+# the two places an unmapped path silently reads as "no coverage". If the
+# per-module summary this lane publishes is ever wanted keyed to source paths,
+# adding the mapping here is a section 10.4 change, not a fix to be made in
+# passing.

--- a/.github/review/rules/python-tests.md
+++ b/.github/review/rules/python-tests.md
@@ -44,7 +44,7 @@
 
 ## The guard tests — treat these as load-bearing
 
-Six tests exist to hold an invariant that nothing else enforces. A pull request
+Seven tests exist to hold an invariant that nothing else enforces. A pull request
 that changes what they guard, without changing them, is a finding; a pull request
 that *weakens* one to make a change pass is a critical finding.
 
@@ -56,12 +56,15 @@ that *weakens* one to make a change pass is a critical finding.
 | `test_diagnostics_masking.py` | that credentials do not reach diagnostics output |
 | `test_pytest_configuration.py` | that `[tool.pytest.ini_options]` matches TEST_SUITE.md §10.5, that the running pytest actually loaded it, and that `strict_markers` / `asyncio_mode` have their effect and not merely their declaration |
 | `test_min_selected_guard.py` | that the `--min-selected` collection floor in `tests/conftest.py` matches TEST_SUITE.md §10.3 and still fires — an under-selected marker job exits 4 and names both counts, while a genuine failure keeps exit 1 and a collection error keeps its own diagnosis |
+| `test_coverage_configuration.py` | that `.coveragerc`, `.coveragerc-gate` and `.coveragerc-subprocess` match TEST_SUITE.md §10.4 and still behave — the base config reports an unexecuted module at zero, the gate config omits the modules with no hermetic seam, and the subprocess config captures a child process |
 
-These two are coupled: `test_min_selected_guard.py` imports `_section_body` from
-`test_pytest_configuration.py` rather than keeping a second copy of the
+Three of these are coupled: `test_min_selected_guard.py` and
+`test_coverage_configuration.py` both import `_section_body` from
+`test_pytest_configuration.py` rather than keeping their own copy of the
 fence-aware section bound, which exists because the naive heading regex was
-measured wrong. A change to that helper's name or behaviour breaks both guards,
-so it is not the private detail its underscore suggests.
+measured wrong — on §10.4's own blocks, whose opening comment sits at column 0
+and reads as a heading. A change to that helper's name or behaviour breaks all
+three guards, so it is not the private detail its underscore suggests.
 
 Plus `test_worker_launch_args_redaction.py` for the subprocess command line — the
 same class of guard, one layer down.

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,12 @@ __pycache__/
 # diagnostics, the execution record, the redaction ledger and the bridge
 # timeline.
 /artifacts/
+
+# Coverage artefacts. Shipping `.coveragerc` is what makes a local `coverage run`
+# the expected thing to do, so these start appearing now. `.coverage.*` covers the
+# suffixed data files `parallel = true` produces under `.coveragerc-subprocess`.
+/.coverage
+/.coverage.*
+/coverage.json
+/coverage.xml
+/htmlcov/

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -1254,9 +1254,20 @@ patch = subprocess
 ```
 
 Each job selects one by **absolute `COVERAGE_RCFILE`**, never by discovery.
-Discovery walks up from the working directory, and §6.1 deliberately runs the
-package tests from outside the checkout, where the file would not be found.
-`COVERAGE_FILE` is likewise set to an absolute path.
+Discovery does *not* walk up the tree — an earlier draft said it did. coverage.py
+looks only in the directory it is run from, trying `.coveragerc`, then
+`.coveragerc.toml`, `setup.cfg`, `tox.ini` and `pyproject.toml`, and takes the
+first that carries coverage settings. §6.1 deliberately runs the package tests
+from outside the checkout, so none of ours would be found there — and the failure
+is worse than falling back to defaults, because a `setup.cfg`, `tox.ini` or
+`pyproject.toml` belonging to some unrelated directory is a perfectly acceptable
+answer to that search. `COVERAGE_FILE` is likewise set to an absolute path.
+
+One more reason the path must be absolute, and a genuinely surprising one:
+`config_files_to_try` special-cases the literal string `".coveragerc"` to mean
+"no file specified", and the unspecified branch then reads `COVERAGE_RCFILE`
+from the environment. Passing the bare relative name therefore does not select
+this repository's file — it selects whatever the environment already pointed at.
 
 `patch = subprocess` implies `parallel = true`, so those jobs write suffixed data
 files and **must run a local `coverage combine` before reporting** — reporting does
@@ -1266,6 +1277,18 @@ cross-job fan-in removed above.
 The `[paths]` mapping stays in the gating configs even though that lane runs from a
 source checkout, because §6.1's package tests do install a wheel and their
 observational report needs the mapping to line up with the tree.
+
+**`.coveragerc-subprocess` has no `[paths]` mapping, and one of its two consumers
+is a wheel job.** `subsystem` runs from a source checkout, where recorded paths
+already match the tree; `chromium` does not — §10.3 has it install the PR's wheel
+and assert the package resolves to that wheel, so its paths land under
+`site-packages` with nothing mapping them back to `src/…`. This is accepted, not
+overlooked: that report feeds neither `diff-cover` nor the committed baseline,
+which are the two places an unmapped path silently reads as "no coverage". The
+cost is confined to the per-module summary this lane publishes, whose module
+names come out wheel-shaped. If that summary is ever wanted keyed to source
+paths, the mapping has to be added here — a change to this section, not a fix to
+make in passing.
 
 The `[paths]` mapping matters wherever a wheel is involved. The gating lane runs
 from a source checkout, so its own paths already match `git diff`; §6.1's package

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -1398,9 +1398,10 @@ under coverage does not instrument it — so without configuration the worker's 
 code reads as uncovered no matter how thoroughly the subsystem tests exercise it,
 and a PR touching it would be charged by control 2 for lines it cannot cover.
 
-The `subsystem` and `chromium` jobs therefore set `parallel = true` with
-`patch = subprocess` in `.coveragerc` and `coverage combine` the child data files
-before publishing their **observational** report. The floor is **7.10.3**, not
+The `subsystem` and `chromium` jobs therefore run under
+`.coveragerc-subprocess`, which sets `parallel = true` with `patch = subprocess`,
+and `coverage combine` the child data files before publishing their
+**observational** report. The floor is **7.10.3**, not
 7.10.0: the option arrived in 7.10.0, but 7.10.3 fixed missed nested children, data
 stranded when a child changes working directory, Windows startup failures and
 incomplete configuration propagation to children — every one of which this design's

--- a/tests/test_coverage_configuration.py
+++ b/tests/test_coverage_configuration.py
@@ -1,0 +1,569 @@
+"""Guard the three coverage configurations declared in ``.coveragerc*``.
+
+Section 10.4 of ``.system_design/TEST_SUITE.md`` is the policy; ``.coveragerc``,
+``.coveragerc-gate`` and ``.coveragerc-subprocess`` are what coverage.py actually
+reads. This module keeps the two in step, in the same guard shape as
+:mod:`tests.test_pytest_configuration` and :mod:`tests.test_min_selected_guard`.
+
+Two things about this module's assertions are deliberate and load-bearing:
+
+* **Every configuration is read through coverage.py's own parser, never through
+  :mod:`configparser`.** Measured on coverage 7.16.0: an unrecognised key in a
+  coveragerc -- ``source_pkg`` for ``source_pkgs``, a misspelled ``patch`` --
+  produces a :class:`~coverage.exceptions.CoverageWarning` and is *otherwise
+  ignored*. The run continues with that setting silently absent. A text
+  comparison sees the typo in both the document and the file, finds them
+  identical, and passes, while the coverage run it was meant to protect measures
+  the wrong thing. Only the value coverage.py *resolved* can fail on that typo.
+* **Each configuration is compared as its whole difference from coverage's
+  defaults**, not as a list of keys someone remembered to check. An option added
+  to a shipped file that this module does not name would otherwise take effect
+  unnoticed.
+
+The three behavioural cases at the end run real coverage in a child process,
+because section 10.4's central claim -- that a module no test imports is reported
+at zero rather than being absent -- is a claim about what coverage.py *does*, and
+no amount of reading the configuration file can establish it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import warnings
+from pathlib import Path
+from typing import Any
+
+import coverage
+import pytest
+from coverage.exceptions import CoverageWarning
+
+from tests.test_pytest_configuration import _section_body
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TEST_SUITE_PATH = REPO_ROOT / ".system_design" / "TEST_SUITE.md"
+
+DESIGN_SECTION_HEADING = "### 10.4 Coverage"
+
+PACKAGE = "kindly_web_search_mcp_server"
+
+BASE_CONFIG = ".coveragerc"
+GATE_CONFIG = ".coveragerc-gate"
+SUBPROCESS_CONFIG = ".coveragerc-subprocess"
+
+# The ``[run]`` settings every one of the three configurations shares, expressed
+# as the attribute names coverage.py resolves them to rather than as the keys the
+# file spells. ``source_pkgs`` is the whole point of control 1: it is what makes
+# coverage.py report a module no test ever imported, instead of leaving it out of
+# the report and out of everyone's attention.
+COMMON_RUN_SETTINGS: dict[str, object] = {
+    "source_pkgs": [PACKAGE],
+    "branch": True,
+    "relative_files": True,
+}
+
+# Section 10.4's ``[paths]`` mapping. Present in the two gating configurations
+# and deliberately absent from the subprocess one: the mapping matters only where
+# a wheel is involved, and the observational subsystem jobs run from a source
+# checkout.
+EXPECTED_PATHS: dict[str, list[str]] = {
+    "source": [f"src/{PACKAGE}", f"*/site-packages/{PACKAGE}"]
+}
+
+# The modules section 10.4 classifies as having no hermetic seam, in the order
+# the document lists them. ``worker_runner.py`` does not exist yet -- it is the
+# process-management module a later step extracts from ``universal_html.py`` --
+# and coverage.py tolerates an ``omit`` pattern that matches nothing, so the list
+# ships as designed.
+EXPECTED_OMIT: list[str] = [
+    "*/scrape/nodriver_worker.py",
+    "*/scrape/chromium_pool.py",
+    "*/scrape/worker_runner.py",
+]
+
+# What each shipped file must change relative to coverage.py's own defaults --
+# every setting, not a chosen subset. Compared as a whole mapping, so a file that
+# grows an extra option fails here rather than taking effect in silence.
+EXPECTED_CONFIGURATIONS: dict[str, dict[str, object]] = {
+    BASE_CONFIG: {**COMMON_RUN_SETTINGS, "paths": EXPECTED_PATHS},
+    GATE_CONFIG: {
+        **COMMON_RUN_SETTINGS,
+        "run_omit": EXPECTED_OMIT,
+        "paths": EXPECTED_PATHS,
+    },
+    SUBPROCESS_CONFIG: {
+        **COMMON_RUN_SETTINGS,
+        "parallel": True,
+        "patch": ["subprocess"],
+    },
+}
+
+# Attributes of :class:`~coverage.config.CoverageConfig` that record *which file*
+# was read rather than what it said. They differ between any two configurations
+# by construction, so comparing them would compare file names, not settings.
+PROVENANCE_ATTRIBUTES = frozenset(
+    {"config_file", "config_files_attempted", "config_files_read"}
+)
+
+# The module the probe imports. Any module the package can import without side
+# effects would do; this one is a plain dataclass module with no I/O.
+PROBE_MODULE = f"{PACKAGE}.models"
+PROBE_REPORT_PATH = f"src/{PACKAGE}/models.py"
+
+# The module with no test file anywhere -- 213 statements, and the concrete gap
+# that made control 1 necessary. It is the observable for both the whole-package
+# claim and the exemption claim.
+UNEXECUTED_REPORT_PATH = f"src/{PACKAGE}/scrape/chromium_pool.py"
+EXEMPT_REPORT_PATH = f"src/{PACKAGE}/scrape/nodriver_worker.py"
+
+
+def _config_path(name: str) -> Path:
+    """Return a shipped configuration file's path, asserting it is there.
+
+    Checked here rather than left to coverage.py, which answers a missing file
+    with a :class:`~coverage.exceptions.ConfigError` traceback. Every case in
+    this module is meaningless without the file, so all of them reach it through
+    this helper and fail with one sentence naming the document that requires it.
+
+    Args:
+        name: The configuration file's name at the repository root.
+
+    Returns:
+        The absolute path to the file.
+
+    Raises:
+        AssertionError: When the file does not exist.
+    """
+    path = REPO_ROOT / name
+    assert path.is_file(), (
+        f"{name} does not exist. Section 10.4 of {TEST_SUITE_PATH.name} "
+        "requires it at the repository root."
+    )
+    return path
+
+
+def _resolved_settings(config_path: Path) -> dict[str, object]:
+    """Load a coveragerc through coverage.py and return what it changes.
+
+    The configuration is diffed against one coverage.py built from an effectively
+    empty file in the same process, so the result names exactly the settings this
+    file establishes. Doing it as a diff rather than as a fixed list of
+    attributes is what lets an unexpected option fail the comparison.
+
+    Args:
+        config_path: The configuration file to load.
+
+    Returns:
+        Every non-default setting, keyed by coverage.py's own attribute name.
+    """
+    # The baseline is read from a file rather than from ``config_file=False`` so
+    # that both sides go down the identical code path; only the contents differ.
+    defaults = coverage.Coverage(config_file=os.devnull).config
+    actual = coverage.Coverage(config_file=str(config_path)).config
+    return {
+        name: value
+        for name, value in vars(actual).items()
+        if not name.startswith("_")
+        and name not in PROVENANCE_ATTRIBUTES
+        and value != getattr(defaults, name, None)
+    }
+
+
+@pytest.mark.parametrize("name", sorted(EXPECTED_CONFIGURATIONS))
+def test_configuration_file_declares_exactly_what_the_design_requires(
+    name: str,
+) -> None:
+    """Assert one shipped coveragerc resolves to section 10.4's settings, and no others
+
+    The comparison is of resolved values, so the file may carry as much comment
+    as it needs; it is a whole-mapping comparison, so an added option fails it.
+
+    Args:
+        name: The configuration file's name at the repository root.
+    """
+    resolved = _resolved_settings(_config_path(name))
+
+    assert resolved == EXPECTED_CONFIGURATIONS[name], (
+        f"{name} resolves to {resolved!r}, but "
+        f"section 10.4 of {TEST_SUITE_PATH.name} requires "
+        f"{EXPECTED_CONFIGURATIONS[name]!r}."
+    )
+
+
+def test_the_gate_configuration_is_the_base_plus_only_an_omit_list() -> None:
+    """Assert the gating config differs from the base in the omit list alone
+
+    Section 10.4 describes it in exactly those words -- "the same file plus an
+    ``omit`` list" -- and the two controls it feeds are only comparable with
+    control 1's view if nothing else differs. Asserted as a relationship rather
+    than left implicit in two separate expected tables, so the two cannot drift
+    apart in some third field while both still match their own row.
+    """
+    base = _resolved_settings(_config_path(BASE_CONFIG))
+    gate = _resolved_settings(_config_path(GATE_CONFIG))
+
+    assert gate.pop("run_omit", None) == EXPECTED_OMIT, (
+        f"{GATE_CONFIG} does not declare section 10.4's omit list."
+    )
+    assert gate == base, (
+        f"{GATE_CONFIG} differs from {BASE_CONFIG} in more than the omit list: "
+        f"{gate!r} against {base!r}. Section 10.4 requires 'the same file plus "
+        "an omit list'."
+    )
+
+
+def _design_document_block(name: str) -> str:
+    """Extract one of section 10.4's three ``ini`` blocks from ``TEST_SUITE.md``.
+
+    The section is bounded with :func:`tests.test_pytest_configuration._section_body`
+    rather than a fresh heading regex; that helper exists because the naive bound
+    was measured wrong on this very section, whose blocks open with a ``#``
+    comment at column 0. A second copy here would drift from it.
+
+    Within the section the block is chosen by the file name in its opening
+    comment. Section 10.4 holds four fenced blocks -- these three and a shell
+    sample -- so neither "the only block" nor "the only ``ini`` block" selects
+    one, and position would silently start comparing against the wrong file the
+    day the order changes.
+
+    Args:
+        name: The configuration file the block documents.
+
+    Returns:
+        The block's contents, ready to be written out and parsed.
+
+    Raises:
+        AssertionError: When the heading, or exactly one block naming that file,
+            cannot be found -- either of which would silently disable the
+            comparison.
+    """
+    text = TEST_SUITE_PATH.read_text(encoding="utf-8")
+    assert DESIGN_SECTION_HEADING in text.splitlines(), (
+        f"{TEST_SUITE_PATH.name} no longer contains "
+        f"'{DESIGN_SECTION_HEADING}'. This guard parses that section; renaming "
+        "it would silently disable the check."
+    )
+    section = _section_body(text, DESIGN_SECTION_HEADING)
+    blocks = [
+        block
+        for block in re.findall(r"```ini\n(.*?)```", section, re.DOTALL)
+        if block.splitlines()[0].split()[1:2] == [name]
+    ]
+    assert len(blocks) == 1, (
+        f"Section 10.4 of {TEST_SUITE_PATH.name} contains {len(blocks)} ini "
+        f"blocks whose opening comment names {name}; this guard requires "
+        "exactly one."
+    )
+    return blocks[0]
+
+
+@pytest.mark.parametrize("name", sorted(EXPECTED_CONFIGURATIONS))
+def test_design_document_declares_the_same_configuration(
+    name: str, tmp_path: Path
+) -> None:
+    """Assert TEST_SUITE.md section 10.4 and the shipped file agree exactly
+
+    The document's block is written to a temporary file and loaded through
+    coverage.py, so the comparison is of settings rather than of text: the
+    shipped file may explain itself at whatever length is useful, and a
+    reformatting that preserves meaning does not fail. Editing either file alone
+    turns the suite red, which is what keeps the design document describing the
+    configuration that actually runs.
+
+    Args:
+        name: The configuration file's name at the repository root.
+        tmp_path: pytest's per-test temporary directory.
+    """
+    documented_path = tmp_path / name
+    documented_path.write_text(_design_document_block(name), encoding="utf-8")
+
+    documented = _resolved_settings(documented_path)
+    shipped = _resolved_settings(_config_path(name))
+
+    assert documented == shipped, (
+        f"Section 10.4 of {TEST_SUITE_PATH.name} declares {documented!r} for "
+        f"{name} but the file resolves to {shipped!r}. Change both in the same "
+        "pull request."
+    )
+
+
+@pytest.mark.parametrize("name", sorted(EXPECTED_CONFIGURATIONS))
+def test_configuration_file_uses_no_option_coverage_does_not_recognise(
+    name: str,
+) -> None:
+    """Assert coverage.py recognises every option the file sets
+
+    coverage.py answers an unknown option with a warning and then ignores it, so
+    a single mistyped key leaves a configuration that looks complete in review
+    and measures something else at runtime. The warning is the only signal
+    available, and nothing in CI would read it, so it is asserted here.
+
+    Args:
+        name: The configuration file's name at the repository root.
+    """
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", CoverageWarning)
+        coverage.Coverage(config_file=str(_config_path(name)))
+
+    unrecognised = [str(w.message) for w in caught if "Unrecognized" in str(w.message)]
+    assert not unrecognised, (
+        f"coverage.py does not recognise every option in {name}, and ignores "
+        f"the ones it does not: {unrecognised}."
+    )
+
+
+def _child_environment(config_path: Path, data_path: Path) -> dict[str, str]:
+    """Build the environment one child coverage run executes under.
+
+    ``COVERAGE_RCFILE`` and ``COVERAGE_FILE`` are absolute, which is section
+    10.4's own requirement for every job: configuration discovery walks up from
+    the working directory, and the package tests deliberately run from outside
+    the checkout where nothing would be found.
+
+    Args:
+        config_path: The coveragerc the child must use.
+        data_path: Where the child writes its coverage data -- always under the
+            test's temporary directory, never into the repository.
+
+    Returns:
+        A copy of the current environment, cleaned and pointed at those files.
+    """
+    environment = dict(os.environ)
+    # Inherited from the parent this would silently change the child's run,
+    # which is the one thing these cases measure.
+    environment.pop("PYTEST_ADDOPTS", None)
+    environment["PYTHONIOENCODING"] = "utf-8"
+    # The package is imported from the checkout rather than from an install:
+    # ``source_pkgs`` resolves the package by importing it, so the child needs it
+    # on the path exactly as ``tests/conftest.py`` arranges for this suite.
+    environment["PYTHONPATH"] = str(REPO_ROOT / "src")
+    environment["COVERAGE_RCFILE"] = str(config_path)
+    environment["COVERAGE_FILE"] = str(data_path)
+    return environment
+
+
+def _run_coverage(
+    *args: str, environment: dict[str, str]
+) -> subprocess.CompletedProcess[str]:
+    """Run one child ``coverage`` command from the repository root.
+
+    The working directory is the repository root because ``relative_files =
+    true`` makes every reported path relative to it; run anywhere else and the
+    report keys stop matching what ``git diff`` produces, which is the failure
+    the ``[paths]`` mapping exists to prevent.
+
+    Args:
+        *args: The coverage subcommand and its arguments.
+        environment: The child's environment.
+
+    Returns:
+        The completed process, with ``stdout`` and ``stderr`` captured as text.
+
+    Raises:
+        subprocess.TimeoutExpired: When the child has not exited within 120
+            seconds, so a hung child fails one case instead of the whole run.
+    """
+    return subprocess.run(
+        [sys.executable, "-m", "coverage", *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        cwd=REPO_ROOT,
+        env=environment,
+        timeout=120,
+        check=False,
+    )
+
+
+def _report_under(config_name: str, probe: Path, tmp_path: Path) -> dict[str, Any]:
+    """Measure one probe script under one configuration and return the JSON report.
+
+    Args:
+        config_name: The configuration file to measure under.
+        probe: The script to run under ``coverage run``.
+        tmp_path: The test's temporary directory, which receives every artefact.
+
+    Returns:
+        The ``files`` mapping of ``coverage json`` output, keyed by report path.
+
+    Raises:
+        AssertionError: When either child command fails, reported with its own
+            output so the failure names the coverage error rather than a
+            missing file.
+    """
+    environment = _child_environment(_config_path(config_name), tmp_path / ".coverage")
+    run = _run_coverage("run", str(probe), environment=environment)
+    assert run.returncode == 0, (
+        f"coverage run failed under {config_name}.\n{run.stdout}\n{run.stderr}"
+    )
+
+    report_path = tmp_path / "coverage.json"
+    report = _run_coverage(
+        "json", "-o", str(report_path), environment=environment
+    )
+    assert report.returncode == 0, (
+        f"coverage json failed under {config_name}.\n{report.stdout}\n"
+        f"{report.stderr}"
+    )
+    return json.loads(report_path.read_text(encoding="utf-8"))["files"]
+
+
+def _write_probe(tmp_path: Path, body: str) -> Path:
+    """Write a probe script into the test's temporary directory.
+
+    Args:
+        tmp_path: The test's temporary directory.
+        body: The script's source.
+
+    Returns:
+        The path written.
+    """
+    probe = tmp_path / "probe.py"
+    probe.write_text(body, encoding="utf-8")
+    return probe
+
+
+@pytest.mark.subsystem
+def test_the_base_configuration_reports_an_unexecuted_module_at_zero(
+    tmp_path: Path,
+) -> None:
+    """Assert a module the run never imports is reported, at zero
+
+    This is control 1, and the one observable that proves ``source_pkgs`` is
+    doing its job. Under coverage.py's defaults the report contains only files
+    that were observed executing, so ``chromium_pool.py`` -- which no test
+    imports -- would be absent from the report rather than visibly uncovered,
+    and would drag nothing down.
+
+    ``num_statements`` is asserted alongside the zero because a module reported
+    with no statements at all would satisfy ``covered_lines == 0`` while proving
+    nothing.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory.
+    """
+    probe = _write_probe(tmp_path, f"import {PROBE_MODULE}\n")
+
+    files = _report_under(BASE_CONFIG, probe, tmp_path)
+
+    assert UNEXECUTED_REPORT_PATH in files, (
+        f"{UNEXECUTED_REPORT_PATH} is missing from a report taken under "
+        f"{BASE_CONFIG}, so source_pkgs is not in effect and an untested module "
+        f"is invisible rather than at zero. Reported: {sorted(files)}"
+    )
+    summary = files[UNEXECUTED_REPORT_PATH]["summary"]
+    assert summary["num_statements"] > 0, (
+        f"{UNEXECUTED_REPORT_PATH} is reported with no statements, so the zero "
+        "below asserts nothing."
+    )
+    assert summary["covered_lines"] == 0, (
+        f"{UNEXECUTED_REPORT_PATH} is reported as covered by a run that only "
+        f"imports {PROBE_MODULE}; this case no longer measures what it claims."
+    )
+
+
+@pytest.mark.subsystem
+def test_the_gate_configuration_omits_the_modules_with_no_hermetic_seam(
+    tmp_path: Path,
+) -> None:
+    """Assert the gating view excludes the exempt modules entirely
+
+    The counterpart to the case above, and the reason two configurations exist
+    rather than one. Left in the gating view, these modules' zero-hit statements
+    would count against ``diff-cover`` and grow the baseline's denominator, so
+    ordinary worker development would fail both gates.
+
+    The probe module is asserted still present, as the control: a report that
+    failed to produce anything at all would otherwise satisfy every absence
+    assertion here.
+
+    ``worker_runner.py`` is deliberately not asserted -- it is the module a later
+    step extracts, and does not exist yet.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory.
+    """
+    probe = _write_probe(tmp_path, f"import {PROBE_MODULE}\n")
+
+    files = _report_under(GATE_CONFIG, probe, tmp_path)
+
+    assert PROBE_REPORT_PATH in files, (
+        f"The report taken under {GATE_CONFIG} does not contain "
+        f"{PROBE_REPORT_PATH}, so its emptiness -- not the omit list -- is what "
+        f"the assertions below would be measuring. Reported: {sorted(files)}"
+    )
+    for omitted in (UNEXECUTED_REPORT_PATH, EXEMPT_REPORT_PATH):
+        assert omitted not in files, (
+            f"{omitted} appears in a report taken under {GATE_CONFIG}; section "
+            "10.4 classifies it as having no hermetic seam and requires it out "
+            "of the gating view."
+        )
+
+
+@pytest.mark.subsystem
+def test_the_subprocess_configuration_captures_a_child_process(
+    tmp_path: Path,
+) -> None:
+    """Assert code that runs only in a child process is measured
+
+    The worker runs in a child interpreter, and a child started under ``coverage
+    run`` is not instrumented by inheritance -- without ``patch = subprocess``
+    its lines are simply never recorded, and the observational report for the
+    very modules it was meant to cover reads zero. Measured on coverage 7.16.0:
+    under the base configuration this same parent produces one data file and a
+    report with nothing in it.
+
+    Both halves are asserted. More than one data file proves the child was
+    instrumented at all; a module the child imported and the parent did not,
+    reported as covered, proves the child's data survived ``coverage combine``.
+    A module neither process imported is asserted at zero in the same report, so
+    a report that somehow marked everything covered could not pass.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory.
+    """
+    child = tmp_path / "child.py"
+    child.write_text(f"import {PROBE_MODULE}\n", encoding="utf-8")
+    probe = _write_probe(
+        tmp_path,
+        "import subprocess, sys\n"
+        f"subprocess.run([sys.executable, {str(child)!r}], check=True)\n",
+    )
+    environment = _child_environment(
+        _config_path(SUBPROCESS_CONFIG), tmp_path / ".coverage"
+    )
+
+    run = _run_coverage("run", str(probe), environment=environment)
+    assert run.returncode == 0, (
+        f"coverage run failed under {SUBPROCESS_CONFIG}.\n{run.stdout}\n"
+        f"{run.stderr}"
+    )
+
+    data_files = sorted(tmp_path.glob(".coverage*"))
+    assert len(data_files) > 1, (
+        f"{SUBPROCESS_CONFIG} produced {len(data_files)} data file(s); the "
+        "child was not instrumented, so patch = subprocess is not in effect."
+    )
+
+    combine = _run_coverage("combine", environment=environment)
+    assert combine.returncode == 0, (
+        f"coverage combine failed.\n{combine.stdout}\n{combine.stderr}"
+    )
+    report_path = tmp_path / "coverage.json"
+    report = _run_coverage("json", "-o", str(report_path), environment=environment)
+    assert report.returncode == 0, (
+        f"coverage json failed.\n{report.stdout}\n{report.stderr}"
+    )
+
+    files = json.loads(report_path.read_text(encoding="utf-8"))["files"]
+    assert files[PROBE_REPORT_PATH]["summary"]["covered_lines"] > 0, (
+        f"{PROBE_REPORT_PATH} ran only in the child and is reported uncovered, "
+        "so the child's data never reached the combined report."
+    )
+    assert files[UNEXECUTED_REPORT_PATH]["summary"]["covered_lines"] == 0, (
+        f"{UNEXECUTED_REPORT_PATH} was imported by neither process yet is "
+        "reported as covered; this report is not measuring what it claims."
+    )

--- a/tests/test_coverage_configuration.py
+++ b/tests/test_coverage_configuration.py
@@ -5,27 +5,39 @@ Section 10.4 of ``.system_design/TEST_SUITE.md`` is the policy; ``.coveragerc``,
 reads. This module keeps the two in step, in the same guard shape as
 :mod:`tests.test_pytest_configuration` and :mod:`tests.test_min_selected_guard`.
 
-Two things about this module's assertions are deliberate and load-bearing:
+Each configuration is checked **two ways, and both are needed** -- the same
+two-kinds framing :mod:`tests.test_pytest_configuration` uses for the pytest
+table:
 
-* **Every configuration is read through coverage.py's own parser, never through
-  :mod:`configparser`.** Measured on coverage 7.16.0: an unrecognised key in a
-  coveragerc -- ``source_pkg`` for ``source_pkgs``, a misspelled ``patch`` --
-  produces a :class:`~coverage.exceptions.CoverageWarning` and is *otherwise
-  ignored*. The run continues with that setting silently absent. A text
-  comparison sees the typo in both the document and the file, finds them
-  identical, and passes, while the coverage run it was meant to protect measures
-  the wrong thing. Only the value coverage.py *resolved* can fail on that typo.
-* **Each configuration is compared as its whole difference from coverage's
-  defaults**, not as a list of keys someone remembered to check. An option added
-  to a shipped file that this module does not name would otherwise take effect
+* **By the values coverage.py resolved**, read through coverage.py's own parser
+  and compared as the configuration's *whole difference* from coverage's
+  defaults. An unrecognised key in a coveragerc -- ``source_pkg`` for
+  ``source_pkgs``, a misspelled ``patch`` -- produces a
+  :class:`~coverage.exceptions.CoverageWarning` and is *otherwise ignored*, so a
+  text comparison finds the typo identical in document and file and passes while
+  the coverage run measures the wrong thing. Only the resolved value can fail on
+  that. Comparing the whole difference, rather than a list of keys someone
+  remembered, also means an option added to a shipped file cannot take effect
   unnoticed.
+* **By the keys the file actually declares**, read with :mod:`configparser`.
+  Resolved values alone are not enough, because coverage.py *derives* some of
+  them: ``post_process`` sets ``parallel`` whenever ``patch`` contains
+  ``subprocess``, so ``parallel = true`` could be deleted from
+  ``.coveragerc-subprocess`` and every resolved-value comparison would still
+  pass. That file states in its own comment that the setting is declared rather
+  than inherited so the fact is legible; nothing but a declared-key check can
+  hold it.
+
+Neither kind implies the other. A declared key can be a typo coverage ignores; a
+resolved value can be one coverage supplied by itself.
 
 The behavioural cases at the end run real coverage in a child process, because
 section 10.4's central claim -- that a module no test imports is reported at zero
 rather than being absent -- is a claim about what coverage.py *does*, and no
 amount of reading the configuration file can establish it.
 
-Every measurement quoted here was taken on **both 7.13.5 and 7.16.0** and agreed.
+Every measurement quoted in this module was taken on **both 7.13.5 and 7.16.0**
+and agreed; individual claims below do not repeat the versions.
 Those are the two ends that matter: section 10.2 bounds the project at
 ``coverage>=7.10.3,<8``, the pinned lane that runs the controls installs
 ``7.13.5`` exactly, and a developer's ``dev`` environment resolves to whatever is
@@ -35,6 +47,7 @@ coverage bump reads it as new behaviour rather than as a puzzle.
 
 from __future__ import annotations
 
+import configparser
 import json
 import os
 import re
@@ -72,10 +85,10 @@ COMMON_RUN_SETTINGS: dict[str, object] = {
     "relative_files": True,
 }
 
-# Section 10.4's ``[paths]`` mapping. Present in the two gating configurations
-# and deliberately absent from the subprocess one: the mapping matters only where
-# a wheel is involved, and the observational subsystem jobs run from a source
-# checkout.
+# Section 10.4's ``[paths]`` mapping. Present in the two gating configurations and
+# deliberately absent from the subprocess one; that absence has a reason worth
+# reading and it is kept in one place, the trailing comment in
+# ``.coveragerc-subprocess``, rather than restated here where it would drift.
 EXPECTED_PATHS: dict[str, list[str]] = {
     "source": [f"src/{PACKAGE}", f"*/site-packages/{PACKAGE}"]
 }
@@ -115,6 +128,57 @@ PROVENANCE_ATTRIBUTES = frozenset(
     {"config_file", "config_files_attempted", "config_files_read"}
 )
 
+# Attributes that are not settings a coveragerc declares: the file's own raw
+# bytes, and the two that only a ``Coverage(...)`` constructor argument can set.
+# Named explicitly rather than filtered by leading underscore, which is the
+# obvious shape and the wrong one: ``CONFIG_FILE_OPTIONS`` contains
+# ``("_crash", "run:_crash")``, a genuine file-settable option that makes
+# coverage raise on a matching call stack. An underscore filter hides it, and a
+# ``_crash`` added to a shipped file would pass both kinds of check here while
+# breaking the coverage job outright. Excluding ``_config_contents`` is
+# load-bearing rather than cosmetic: the shipped files carry comments the design
+# document's blocks do not, so the document comparison cannot pass with it in.
+DERIVED_ATTRIBUTES = frozenset({"_config_contents", "_include", "_omit"})
+
+# The keys each file must *declare*, section by section, as configparser reads
+# them. The counterpart to the resolved-value table above, and the only check
+# that can see a declared setting coverage would have derived anyway.
+EXPECTED_DECLARED_KEYS: dict[str, dict[str, set[str]]] = {
+    BASE_CONFIG: {
+        "run": {"source_pkgs", "branch", "relative_files"},
+        "paths": {"source"},
+    },
+    GATE_CONFIG: {
+        "run": {"source_pkgs", "branch", "relative_files", "omit"},
+        "paths": {"source"},
+    },
+    SUBPROCESS_CONFIG: {
+        "run": {"source_pkgs", "branch", "relative_files", "parallel", "patch"},
+    },
+}
+
+# Environment variables coverage.py applies *after* the configuration file, and
+# which therefore mask a file setting of the same name. Measured: with
+# ``COVERAGE_FILE`` exported, a shipped ``data_file =`` vanishes from the
+# comparison entirely, because both sides of the diff get the same override. That
+# is not academic -- section 10.4 requires every job to set ``COVERAGE_FILE`` to
+# an absolute path, so without this scrubbing the guard would be weaker in CI
+# than on the machine it was written on.
+MASKING_VARIABLES = (
+    "COVERAGE_FILE",
+    "COVERAGE_CORE",
+    "COVERAGE_DEBUG",
+)
+
+# Variables the coverage ``.pth`` hook reads to auto-start measurement in any
+# child process. A CI job running this suite under ``.coveragerc-subprocess``
+# exports them, and an inherited value would silently start a second, differently
+# configured coverage inside every child these cases spawn.
+INHERITED_COVERAGE_STARTUP_VARIABLES = (
+    "COVERAGE_PROCESS_CONFIG",
+    "COVERAGE_PROCESS_START",
+)
+
 # The module the probe imports. Chosen for two properties, both of which keep a
 # failure here meaning what it says: it imports nothing outside the standard
 # library, so a broken runtime dependency cannot turn this guard red for a reason
@@ -128,6 +192,11 @@ PROBE_REPORT_PATH = f"src/{PACKAGE}/utils/logging.py"
 # that made control 1 necessary. It is the observable for both the whole-package
 # claim and the exemption claim.
 UNEXECUTED_REPORT_PATH = f"src/{PACKAGE}/scrape/chromium_pool.py"
+
+# The opening of coverage.py's warning for an option it does not know. Spelled
+# once so the check and its control cannot drift onto different substrings, at
+# which point the control would stop controlling anything.
+UNRECOGNISED_OPTION = "Unrecognized option"
 EXEMPT_REPORT_PATH = f"src/{PACKAGE}/scrape/nodriver_worker.py"
 
 
@@ -138,6 +207,14 @@ def _config_path(name: str) -> Path:
     with a :class:`~coverage.exceptions.ConfigError` traceback. Every case in
     this module is meaningless without the file, so all of them reach it through
     this helper and fail with one sentence naming the document that requires it.
+
+    It returns an **absolute** path, and that is not merely tidiness.
+    ``config_files_to_try`` special-cases the literal string ``".coveragerc"`` to
+    mean "no file specified", and the unspecified branch then reads
+    ``COVERAGE_RCFILE`` from the environment. Every job section 10.4 defines
+    exports that variable, so a guard passing the bare relative name would
+    quietly assert against whatever the job pointed at -- three times over, and
+    green.
 
     Args:
         name: The configuration file's name at the repository root.
@@ -167,20 +244,84 @@ def _resolved_settings(config_path: Path) -> dict[str, object]:
     Args:
         config_path: The configuration file to load.
 
+    Two limits are worth knowing. A setting whose value happens to equal
+    coverage's default is invisible by construction -- that is the price of
+    expressing this as a difference at all. And a setting coverage *derives*
+    rather than reads looks identical to one the file declared, which is why
+    :func:`_declared_keys` exists alongside this.
+
+    The baseline is read from :data:`os.devnull`, which is accepted rather than
+    raising ``Couldn't read ... as a config file``: ``from_file`` counts a
+    specified file as read whatever it contains.
+
     Returns:
         Every non-default setting, keyed by coverage.py's own attribute name.
     """
-    # The baseline is read from a file rather than from ``config_file=False`` so
-    # that both sides go down the identical code path; only the contents differ.
-    defaults = coverage.Coverage(config_file=os.devnull).config
-    actual = coverage.Coverage(config_file=str(config_path)).config
+    # Both objects are built with the masking variables removed, so a shipped
+    # setting cannot hide behind an override that lands on either side equally.
+    # Restored by hand rather than with ``unittest.mock.patch.dict``: importing
+    # anything from ``unittest`` makes the plan validator read this pytest-native
+    # module as unittest-style and demand a migration batch for it.
+    saved = {name: os.environ.pop(name, None) for name in MASKING_VARIABLES}
+    try:
+        # The baseline is read from a file rather than from ``config_file=False``
+        # so that both sides go down the identical code path.
+        defaults = coverage.Coverage(config_file=os.devnull).config
+        actual = coverage.Coverage(config_file=str(config_path)).config
+    finally:
+        os.environ.update({k: v for k, v in saved.items() if v is not None})
     return {
         name: value
         for name, value in vars(actual).items()
-        if not name.startswith("_")
+        if name not in DERIVED_ATTRIBUTES
         and name not in PROVENANCE_ATTRIBUTES
         and value != getattr(defaults, name, None)
     }
+
+
+def _declared_keys(config_path: Path) -> dict[str, set[str]]:
+    """Return the sections and keys a coveragerc literally declares.
+
+    Read with :mod:`configparser` rather than through coverage.py, which is the
+    one job coverage.py cannot do here: it reports the configuration *after*
+    ``post_process``, where ``parallel`` has been set from ``patch`` and a
+    declared key is indistinguishable from a derived one.
+
+    Args:
+        config_path: The configuration file to read.
+
+    Returns:
+        Each section's option names, keyed by section name.
+    """
+    parser = configparser.ConfigParser()
+    parser.read(config_path, encoding="utf-8")
+    return {section: set(parser.options(section)) for section in parser.sections()}
+
+
+@pytest.mark.parametrize("name", sorted(EXPECTED_DECLARED_KEYS))
+def test_configuration_file_declares_the_expected_keys(name: str) -> None:
+    """Assert one shipped coveragerc spells out exactly section 10.4's keys
+
+    The companion to the resolved-value case below, and not redundant with it.
+    ``parallel`` is the concrete reason: coverage derives it from
+    ``patch = subprocess``, so deleting the line from
+    ``.coveragerc-subprocess`` changes no resolved value and no behaviour --
+    only the file's stated intent that the setting be legible rather than
+    inferred. Nothing but this case can fail on that.
+
+    It also catches the mirror image: a key deleted from a file and from section
+    10.4 together, which the document comparison cannot see because both sides
+    move.
+
+    Args:
+        name: The configuration file's name at the repository root.
+    """
+    declared = _declared_keys(_config_path(name))
+
+    assert declared == EXPECTED_DECLARED_KEYS[name], (
+        f"{name} declares {declared!r}, but section 10.4 of "
+        f"{TEST_SUITE_PATH.name} spells out {EXPECTED_DECLARED_KEYS[name]!r}."
+    )
 
 
 @pytest.mark.parametrize("name", sorted(EXPECTED_CONFIGURATIONS))
@@ -270,6 +411,12 @@ def _design_document_blocks() -> dict[str, str]:
     position. Section 10.4 holds a shell sample as well as these, so neither
     "the only block" nor "the only ``ini`` block" selects one, and position would
     silently start comparing against the wrong file the day the order changes.
+
+    This imposes a constraint on the document worth stating: **every** ``ini``
+    fence in section 10.4 must open with a comment naming a shipped file, so the
+    section cannot carry an illustrative ini snippet. That is deliberate -- an
+    unnamed block is indistinguishable from a configuration someone forgot to
+    ship -- but it is a rule a future author would otherwise meet as a puzzle.
 
     Returns:
         Each block's contents, keyed by the configuration file it documents.
@@ -369,13 +516,21 @@ def test_design_document_declares_the_same_configuration(
     documented_path = tmp_path / name
     documented_path.write_text(_design_document_block(name), encoding="utf-8")
 
-    documented = _resolved_settings(documented_path)
-    shipped = _resolved_settings(_config_path(name))
+    shipped_path = _config_path(name)
 
-    assert documented == shipped, (
-        f"Section 10.4 of {TEST_SUITE_PATH.name} declares {documented!r} for "
-        f"{name} but the file resolves to {shipped!r}. Change both in the same "
-        "pull request."
+    assert _resolved_settings(documented_path) == _resolved_settings(shipped_path), (
+        f"Section 10.4 of {TEST_SUITE_PATH.name} declares "
+        f"{_resolved_settings(documented_path)!r} for {name} but the file "
+        f"resolves to {_resolved_settings(shipped_path)!r}. Change both in the "
+        "same pull request."
+    )
+    # Compared as well as the resolved values, so the document cannot keep a
+    # setting the shipped file dropped when coverage would have derived it
+    # anyway -- ``parallel`` being exactly that case.
+    assert _declared_keys(documented_path) == _declared_keys(shipped_path), (
+        f"Section 10.4 of {TEST_SUITE_PATH.name} spells out "
+        f"{_declared_keys(documented_path)!r} for {name} but the file spells "
+        f"out {_declared_keys(shipped_path)!r}."
     )
 
 
@@ -397,7 +552,9 @@ def test_configuration_file_uses_no_option_coverage_does_not_recognise(
         warnings.simplefilter("always", CoverageWarning)
         coverage.Coverage(config_file=str(_config_path(name)))
 
-    unrecognised = [str(w.message) for w in caught if "Unrecognized" in str(w.message)]
+    unrecognised = [
+        str(w.message) for w in caught if UNRECOGNISED_OPTION in str(w.message)
+    ]
     assert not unrecognised, (
         f"coverage.py does not recognise every option in {name}, and ignores "
         f"the ones it does not: {unrecognised}."
@@ -428,7 +585,7 @@ def test_a_mistyped_option_is_warned_about_and_then_ignored(tmp_path: Path) -> N
         warnings.simplefilter("always", CoverageWarning)
         settings = _resolved_settings(mistyped)
 
-    assert any("Unrecognized option" in str(w.message) for w in caught), (
+    assert any(UNRECOGNISED_OPTION in str(w.message) for w in caught), (
         "coverage.py no longer warns about an unknown option, so the "
         "no-warnings case above has stopped being able to fail. "
         f"Warnings seen: {[str(w.message) for w in caught]}"
@@ -456,9 +613,14 @@ def _child_environment(config_path: Path, data_path: Path) -> dict[str, str]:
         A copy of the current environment, cleaned and pointed at those files.
     """
     environment = dict(os.environ)
-    # Inherited from the parent this would silently change the child's run,
-    # which is the one thing these cases measure.
-    environment.pop("PYTEST_ADDOPTS", None)
+    # Inherited from the parent, each of these would silently change the child's
+    # run, which is the one thing these cases measure. The coverage startup
+    # variables matter for a specific arrangement section 10.4 prescribes: once
+    # the subsystem job runs this suite under ``.coveragerc-subprocess``, it
+    # exports them, and the installed ``.pth`` would then auto-start a second,
+    # differently configured coverage inside every child spawned here.
+    for leaked in ("PYTEST_ADDOPTS", *INHERITED_COVERAGE_STARTUP_VARIABLES):
+        environment.pop(leaked, None)
     environment["PYTHONIOENCODING"] = "utf-8"
     # The package is imported from the checkout rather than from an install:
     # ``source_pkgs`` resolves the package by importing it, so the child needs it
@@ -532,7 +694,28 @@ def _report_under(config_name: str, probe: Path, tmp_path: Path) -> dict[str, An
         f"coverage json failed under {config_name}.\n{report.stdout}\n"
         f"{report.stderr}"
     )
-    return json.loads(report_path.read_text(encoding="utf-8"))["files"]
+    return _report_files(report_path)
+
+
+def _report_files(report_path: Path) -> dict[str, Any]:
+    """Read a ``coverage json`` report and return its files, keyed POSIX-style.
+
+    The keys come from ``FileReporter.relative_filename()``, which slices the
+    **native** absolute path -- so on Windows they are separated by backslashes
+    while every expected path in this module is written with forward slashes.
+    The ``omit`` patterns themselves are unaffected (coverage matches either
+    separator), so this is purely about what the assertions compare against, and
+    it matters because section 10.3 schedules the ``subsystem`` marker on Windows
+    as well as Linux and ``pyproject.toml`` documents that marker as portable.
+
+    Args:
+        report_path: The ``coverage json`` output to read.
+
+    Returns:
+        The report's ``files`` mapping with separators normalised.
+    """
+    files = json.loads(report_path.read_text(encoding="utf-8"))["files"]
+    return {key.replace(os.sep, "/"): value for key, value in files.items()}
 
 
 def _write_probe(tmp_path: Path, body: str) -> Path:
@@ -636,9 +819,9 @@ def test_the_subprocess_configuration_captures_a_child_process(
     The worker runs in a child interpreter, and a child started under ``coverage
     run`` is not instrumented by inheritance -- without ``patch = subprocess``
     its lines are simply never recorded, and the observational report for the
-    very modules it was meant to cover reads zero. Measured on coverage 7.16.0:
-    under the base configuration this same parent produces one data file and a
-    report with nothing in it.
+    very modules it was meant to cover reads zero. Measured: under the base
+    configuration this same parent produces one data file and a report with
+    nothing in it.
 
     Both halves are asserted. More than one data file proves the child was
     instrumented at all; a module the child imported and the parent did not,
@@ -649,12 +832,14 @@ def test_the_subprocess_configuration_captures_a_child_process(
     Three environmental facts this case depends on, recorded because each fails
     it for a reason that has nothing to do with the configuration:
 
-    * ``patch = subprocess`` works by writing a ``.pth`` file into a
-      site-packages directory at run time and exporting
-      ``COVERAGE_PROCESS_START``. It therefore needs a **writable**
-      site-packages -- a virtual environment has one; a read-only or
-      system-managed interpreter does not, and this case fails rather than skips
-      there.
+    * ``patch = subprocess`` exports ``COVERAGE_PROCESS_CONFIG``; the ``.pth``
+      that reads it, ``a1_coverage.pth``, ships **in the coverage wheel** and is
+      run by ``site`` at child startup. Nothing is written at run time, so
+      site-packages need not be writable -- but coverage must be *installed*
+      into a site-processed site-packages rather than merely reachable on
+      ``PYTHONPATH``. Measured: an otherwise identical child started with
+      ``-S`` produces one data file instead of two, because ``site`` never runs
+      and the hook never fires.
     * The probe spawns its child with **no explicit** ``env=``, so the child
       inherits the variable coverage exported. Passing a dict built before
       coverage patched the environment would leave the child unmeasured and fail
@@ -662,6 +847,12 @@ def test_the_subprocess_configuration_captures_a_child_process(
     * Under CI this case runs inside a job that is itself measured, so its
       children are nested one level deeper than usual. The nested-child handling
       that makes that safe is what the 7.10.3 floor in section 10.2 buys.
+
+    All three were measured on Linux. Section 10.3 schedules the ``subsystem``
+    marker on Windows too, and 7.10.3 is the floor partly because it fixed
+    *Windows* startup failures in this same feature -- so the platform is known
+    to matter here. Windows behaviour is therefore unproven until the CI epic
+    runs the job there; that is recorded rather than assumed away.
 
     Unlike the omit list, whose breakage is self-revealing, a broken subprocess
     patch is silent until the epic that first publishes an observational L3
@@ -704,7 +895,13 @@ def test_the_subprocess_configuration_captures_a_child_process(
         f"coverage json failed.\n{report.stdout}\n{report.stderr}"
     )
 
-    files = json.loads(report_path.read_text(encoding="utf-8"))["files"]
+    files = _report_files(report_path)
+    for required in (PROBE_REPORT_PATH, UNEXECUTED_REPORT_PATH):
+        assert required in files, (
+            f"{required} is missing from the combined report, so the assertions "
+            f"below would raise KeyError rather than explain themselves. "
+            f"Reported: {sorted(files)}"
+        )
     assert files[PROBE_REPORT_PATH]["summary"]["covered_lines"] > 0, (
         f"{PROBE_REPORT_PATH} ran only in the child and is reported uncovered, "
         "so the child's data never reached the combined report."

--- a/tests/test_coverage_configuration.py
+++ b/tests/test_coverage_configuration.py
@@ -20,10 +20,17 @@ Two things about this module's assertions are deliberate and load-bearing:
   to a shipped file that this module does not name would otherwise take effect
   unnoticed.
 
-The three behavioural cases at the end run real coverage in a child process,
-because section 10.4's central claim -- that a module no test imports is reported
-at zero rather than being absent -- is a claim about what coverage.py *does*, and
-no amount of reading the configuration file can establish it.
+The behavioural cases at the end run real coverage in a child process, because
+section 10.4's central claim -- that a module no test imports is reported at zero
+rather than being absent -- is a claim about what coverage.py *does*, and no
+amount of reading the configuration file can establish it.
+
+Every measurement quoted here was taken on **both 7.13.5 and 7.16.0** and agreed.
+Those are the two ends that matter: section 10.2 bounds the project at
+``coverage>=7.10.3,<8``, the pinned lane that runs the controls installs
+``7.13.5`` exactly, and a developer's ``dev`` environment resolves to whatever is
+current. The versions are named so that an engineer meeting a failure after a
+coverage bump reads it as new behaviour rather than as a puzzle.
 """
 
 from __future__ import annotations
@@ -108,10 +115,14 @@ PROVENANCE_ATTRIBUTES = frozenset(
     {"config_file", "config_files_attempted", "config_files_read"}
 )
 
-# The module the probe imports. Any module the package can import without side
-# effects would do; this one is a plain dataclass module with no I/O.
-PROBE_MODULE = f"{PACKAGE}.models"
-PROBE_REPORT_PATH = f"src/{PACKAGE}/models.py"
+# The module the probe imports. Chosen for two properties, both of which keep a
+# failure here meaning what it says: it imports nothing outside the standard
+# library, so a broken runtime dependency cannot turn this guard red for a reason
+# that has nothing to do with coverage configuration; and importing it only
+# defines a function, so the probe has no side effects. It is also outside
+# ``scrape/``, where the omit patterns live.
+PROBE_MODULE = f"{PACKAGE}.utils.logging"
+PROBE_REPORT_PATH = f"src/{PACKAGE}/utils/logging.py"
 
 # The module with no test file anywhere -- 213 statements, and the concrete gap
 # that made control 1 necessary. It is the observable for both the whole-package
@@ -215,30 +226,58 @@ def test_the_gate_configuration_is_the_base_plus_only_an_omit_list() -> None:
     )
 
 
-def _design_document_block(name: str) -> str:
-    """Extract one of section 10.4's three ``ini`` blocks from ``TEST_SUITE.md``.
+def test_the_subprocess_configuration_is_the_base_run_settings_plus_patching() -> None:
+    """Assert the third config differs from the base only as section 10.4 says
+
+    Stated as the same kind of relationship as the case above, so the three files
+    read as one table rather than as three unrelated value lists. Two differences
+    are expected and no others: the process patching this lane exists for, and
+    the absent ``[paths]`` mapping -- which is a real difference, deliberately
+    made, and so is asserted rather than left to be noticed.
+    """
+    base = _resolved_settings(_config_path(BASE_CONFIG))
+    subprocess_settings = _resolved_settings(_config_path(SUBPROCESS_CONFIG))
+
+    assert subprocess_settings.pop("parallel", None) is True, (
+        f"{SUBPROCESS_CONFIG} does not set parallel; the suffixed data files "
+        "its jobs combine would not be written."
+    )
+    assert subprocess_settings.pop("patch", None) == ["subprocess"], (
+        f"{SUBPROCESS_CONFIG} does not patch subprocess, which is the only "
+        "reason this configuration exists."
+    )
+    assert base.pop("paths", None) == EXPECTED_PATHS, (
+        f"{BASE_CONFIG} no longer carries section 10.4's paths mapping."
+    )
+
+    assert subprocess_settings == base, (
+        f"{SUBPROCESS_CONFIG} differs from {BASE_CONFIG}'s [run] settings in "
+        f"more than the process patching: {subprocess_settings!r} against "
+        f"{base!r}."
+    )
+
+
+def _design_document_blocks() -> dict[str, str]:
+    """Extract every ``ini`` block in section 10.4, keyed by the file it names.
 
     The section is bounded with :func:`tests.test_pytest_configuration._section_body`
     rather than a fresh heading regex; that helper exists because the naive bound
     was measured wrong on this very section, whose blocks open with a ``#``
-    comment at column 0. A second copy here would drift from it.
+    comment at column 0 that a heading pattern cannot tell from a heading. A
+    second copy here would drift from it.
 
-    Within the section the block is chosen by the file name in its opening
-    comment. Section 10.4 holds four fenced blocks -- these three and a shell
-    sample -- so neither "the only block" nor "the only ``ini`` block" selects
-    one, and position would silently start comparing against the wrong file the
-    day the order changes.
-
-    Args:
-        name: The configuration file the block documents.
+    Blocks are keyed by the file name in their opening comment rather than by
+    position. Section 10.4 holds a shell sample as well as these, so neither
+    "the only block" nor "the only ``ini`` block" selects one, and position would
+    silently start comparing against the wrong file the day the order changes.
 
     Returns:
-        The block's contents, ready to be written out and parsed.
+        Each block's contents, keyed by the configuration file it documents.
 
     Raises:
-        AssertionError: When the heading, or exactly one block naming that file,
-            cannot be found -- either of which would silently disable the
-            comparison.
+        AssertionError: When the heading is gone, when a block does not open with
+            a comment naming a file, or when two blocks name the same file --
+            each of which would silently disable part of the comparison.
     """
     text = TEST_SUITE_PATH.read_text(encoding="utf-8")
     assert DESIGN_SECTION_HEADING in text.splitlines(), (
@@ -247,17 +286,67 @@ def _design_document_block(name: str) -> str:
         "it would silently disable the check."
     )
     section = _section_body(text, DESIGN_SECTION_HEADING)
-    blocks = [
-        block
-        for block in re.findall(r"```ini\n(.*?)```", section, re.DOTALL)
-        if block.splitlines()[0].split()[1:2] == [name]
-    ]
-    assert len(blocks) == 1, (
-        f"Section 10.4 of {TEST_SUITE_PATH.name} contains {len(blocks)} ini "
-        f"blocks whose opening comment names {name}; this guard requires "
-        "exactly one."
+    named: dict[str, str] = {}
+    for block in re.findall(r"```ini\n(.*?)```", section, re.DOTALL):
+        opening = block.splitlines()[0].split()
+        assert opening[:1] == ["#"] and len(opening) > 1, (
+            f"An ini block in section 10.4 of {TEST_SUITE_PATH.name} does not "
+            f"open with a comment naming its file: {opening!r}"
+        )
+        assert opening[1] not in named, (
+            f"Section 10.4 of {TEST_SUITE_PATH.name} has two ini blocks naming "
+            f"{opening[1]}; this guard cannot tell which one ships."
+        )
+        named[opening[1]] = block
+    return named
+
+
+def _design_document_block(name: str) -> str:
+    """Return section 10.4's block for one configuration file.
+
+    Args:
+        name: The configuration file the block documents.
+
+    Returns:
+        The block's contents, ready to be written out and parsed.
+
+    Raises:
+        AssertionError: When the section documents no such file.
+    """
+    blocks = _design_document_blocks()
+    assert name in blocks, (
+        f"Section 10.4 of {TEST_SUITE_PATH.name} has no ini block for {name}; "
+        f"it documents {sorted(blocks)}."
     )
-    return blocks[0]
+    return blocks[name]
+
+
+def test_the_document_and_the_repository_agree_on_which_configurations_exist() -> None:
+    """Assert the documented set, the shipped set and this module's table are one set
+
+    The per-file comparisons each answer "does this pair agree?". None of them
+    notices a file with no block, a block with no file, or a fourth
+    configuration that no case in this module has ever heard of -- all three of
+    which leave the document and the tree diverged with the suite green. That is
+    the same reason the section bound requires *exactly* one match rather than at
+    least one.
+
+    The shipped set is read by globbing rather than from this module's own table,
+    so adding a `.coveragerc-something` without adding it to section 10.4 and to
+    :data:`EXPECTED_CONFIGURATIONS` fails here.
+    """
+    documented = set(_design_document_blocks())
+    shipped = {path.name for path in REPO_ROOT.glob(".coveragerc*")}
+    expected = set(EXPECTED_CONFIGURATIONS)
+
+    assert documented == expected, (
+        f"Section 10.4 of {TEST_SUITE_PATH.name} documents {sorted(documented)} "
+        f"but this guard knows {sorted(expected)}."
+    )
+    assert shipped == expected, (
+        f"The repository root holds {sorted(shipped)} but section 10.4 "
+        f"specifies {sorted(expected)}."
+    )
 
 
 @pytest.mark.parametrize("name", sorted(EXPECTED_CONFIGURATIONS))
@@ -312,6 +401,41 @@ def test_configuration_file_uses_no_option_coverage_does_not_recognise(
     assert not unrecognised, (
         f"coverage.py does not recognise every option in {name}, and ignores "
         f"the ones it does not: {unrecognised}."
+    )
+
+
+def test_a_mistyped_option_is_warned_about_and_then_ignored(tmp_path: Path) -> None:
+    """Assert the premise the case above rests on, and the whole module's approach
+
+    The case above can only mean something if coverage.py really does warn about
+    an option it does not know, and really does carry on without it. Both halves
+    are demonstrated here against a deliberately mistyped file, so "no warnings"
+    is a fact about the shipped configurations rather than a fact about a warning
+    that never fires.
+
+    The second half is the more important one: ``source_pkg`` is *absent* from
+    the resolved settings. That is why every comparison in this module reads
+    coverage.py's resolved values instead of the file's text -- a text comparison
+    would find this typo identical on both sides and pass.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory.
+    """
+    mistyped = tmp_path / ".coveragerc"
+    mistyped.write_text(f"[run]\nsource_pkg = {PACKAGE}\n", encoding="utf-8")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", CoverageWarning)
+        settings = _resolved_settings(mistyped)
+
+    assert any("Unrecognized option" in str(w.message) for w in caught), (
+        "coverage.py no longer warns about an unknown option, so the "
+        "no-warnings case above has stopped being able to fail. "
+        f"Warnings seen: {[str(w.message) for w in caught]}"
+    )
+    assert "source_pkgs" not in settings, (
+        "coverage.py accepted a mistyped option name, which would make the "
+        f"whole-package view work by accident. Resolved: {settings!r}"
     )
 
 
@@ -521,6 +645,28 @@ def test_the_subprocess_configuration_captures_a_child_process(
     reported as covered, proves the child's data survived ``coverage combine``.
     A module neither process imported is asserted at zero in the same report, so
     a report that somehow marked everything covered could not pass.
+
+    Three environmental facts this case depends on, recorded because each fails
+    it for a reason that has nothing to do with the configuration:
+
+    * ``patch = subprocess`` works by writing a ``.pth`` file into a
+      site-packages directory at run time and exporting
+      ``COVERAGE_PROCESS_START``. It therefore needs a **writable**
+      site-packages -- a virtual environment has one; a read-only or
+      system-managed interpreter does not, and this case fails rather than skips
+      there.
+    * The probe spawns its child with **no explicit** ``env=``, so the child
+      inherits the variable coverage exported. Passing a dict built before
+      coverage patched the environment would leave the child unmeasured and fail
+      this case for a reason the message would not explain.
+    * Under CI this case runs inside a job that is itself measured, so its
+      children are nested one level deeper than usual. The nested-child handling
+      that makes that safe is what the 7.10.3 floor in section 10.2 buys.
+
+    Unlike the omit list, whose breakage is self-revealing, a broken subprocess
+    patch is silent until the epic that first publishes an observational L3
+    report -- months of merges away. That gap is why this case is here rather
+    than deferred to the job that consumes the configuration.
 
     Args:
         tmp_path: pytest's per-test temporary directory.

--- a/tests/test_coverage_configuration.py
+++ b/tests/test_coverage_configuration.py
@@ -19,14 +19,15 @@ table:
   that. Comparing the whole difference, rather than a list of keys someone
   remembered, also means an option added to a shipped file cannot take effect
   unnoticed.
-* **By the keys the file actually declares**, read with :mod:`configparser`.
-  Resolved values alone are not enough, because coverage.py *derives* some of
-  them: ``post_process`` sets ``parallel`` whenever ``patch`` contains
-  ``subprocess``, so ``parallel = true`` could be deleted from
-  ``.coveragerc-subprocess`` and every resolved-value comparison would still
-  pass. That file states in its own comment that the setting is declared rather
-  than inherited so the fact is legible; nothing but a declared-key check can
-  hold it.
+* **By the settings the file actually spells out**, read with
+  :mod:`configparser` -- keys *and* values. Resolved values alone are not
+  enough, because coverage.py *derives* some of them: ``post_process`` sets
+  ``parallel`` whenever ``patch`` contains ``subprocess``. So ``parallel = true``
+  could be deleted from ``.coveragerc-subprocess``, or set to ``false``, and
+  every resolved-value comparison would still pass -- the second leaving the
+  file stating the opposite of the design it implements. That file says in its
+  own comment that the setting is declared rather than inherited so the fact is
+  legible; nothing but this check can hold it.
 
 Neither kind implies the other. A declared key can be a typo coverage ignores; a
 resolved value can be one coverage supplied by itself.
@@ -140,20 +141,45 @@ PROVENANCE_ATTRIBUTES = frozenset(
 # document's blocks do not, so the document comparison cannot pass with it in.
 DERIVED_ATTRIBUTES = frozenset({"_config_contents", "_include", "_omit"})
 
-# The keys each file must *declare*, section by section, as configparser reads
-# them. The counterpart to the resolved-value table above, and the only check
-# that can see a declared setting coverage would have derived anyway.
-EXPECTED_DECLARED_KEYS: dict[str, dict[str, set[str]]] = {
+# What each file must *declare*, section by section and value by value, as
+# configparser reads it. The counterpart to the resolved-value table above, and
+# the only check that can see a setting coverage would have derived anyway.
+#
+# Values, not just key names. Comparing key sets catches the lesser sin -- a line
+# deleted -- and misses the greater one: ``parallel = false`` states the opposite
+# of the design, and because ``post_process`` forces it back to ``True`` the
+# resolved value never moves and the key is still there. Measured: with key sets
+# alone, all nineteen cases passed against that file.
+#
+# Each value is held as its non-empty lines, stripped, so a multi-value option
+# reads as the list it is. Indentation is configparser's business and carries no
+# meaning; ``true`` against ``false`` still differs, which is the point.
+EXPECTED_DECLARED_SETTINGS: dict[str, dict[str, dict[str, tuple[str, ...]]]] = {
     BASE_CONFIG: {
-        "run": {"source_pkgs", "branch", "relative_files"},
-        "paths": {"source"},
+        "run": {
+            "source_pkgs": (PACKAGE,),
+            "branch": ("true",),
+            "relative_files": ("true",),
+        },
+        "paths": {"source": tuple(EXPECTED_PATHS["source"])},
     },
     GATE_CONFIG: {
-        "run": {"source_pkgs", "branch", "relative_files", "omit"},
-        "paths": {"source"},
+        "run": {
+            "source_pkgs": (PACKAGE,),
+            "branch": ("true",),
+            "relative_files": ("true",),
+            "omit": tuple(EXPECTED_OMIT),
+        },
+        "paths": {"source": tuple(EXPECTED_PATHS["source"])},
     },
     SUBPROCESS_CONFIG: {
-        "run": {"source_pkgs", "branch", "relative_files", "parallel", "patch"},
+        "run": {
+            "source_pkgs": (PACKAGE,),
+            "branch": ("true",),
+            "relative_files": ("true",),
+            "parallel": ("true",),
+            "patch": ("subprocess",),
+        },
     },
 }
 
@@ -168,6 +194,7 @@ MASKING_VARIABLES = (
     "COVERAGE_FILE",
     "COVERAGE_CORE",
     "COVERAGE_DEBUG",
+    "COVERAGE_FORCE_CONFIG",
 )
 
 # Variables the coverage ``.pth`` hook reads to auto-start measurement in any
@@ -279,48 +306,73 @@ def _resolved_settings(config_path: Path) -> dict[str, object]:
     }
 
 
-def _declared_keys(config_path: Path) -> dict[str, set[str]]:
-    """Return the sections and keys a coveragerc literally declares.
+def _declared_settings(config_path: Path) -> dict[str, dict[str, tuple[str, ...]]]:
+    """Return the sections, keys and values a coveragerc literally declares.
 
     Read with :mod:`configparser` rather than through coverage.py, which is the
     one job coverage.py cannot do here: it reports the configuration *after*
     ``post_process``, where ``parallel`` has been set from ``patch`` and a
-    declared key is indistinguishable from a derived one.
+    declared setting is indistinguishable from a derived one.
+
+    ``interpolation=None`` matches how coverage reads its own files. With
+    configparser's default ``BasicInterpolation`` a ``%`` in an omit pattern
+    would raise the moment a value is read -- which is a difference this guard
+    would introduce, not one the shipped configuration has.
+
+    One deliberate strictness: coverage also accepts these settings under a
+    ``[coverage:run]`` heading, which this function would report as a section
+    literally named ``coverage:run`` and so fail. That is fail-closed and
+    intended -- it pins the canonical section shape section 10.4 displays.
 
     Args:
         config_path: The configuration file to read.
 
     Returns:
-        Each section's option names, keyed by section name.
+        Each option's value as its non-empty stripped lines, keyed by section
+        and option name.
     """
-    parser = configparser.ConfigParser()
+    parser = configparser.ConfigParser(interpolation=None)
     parser.read(config_path, encoding="utf-8")
-    return {section: set(parser.options(section)) for section in parser.sections()}
+    return {
+        section: {
+            option: tuple(
+                line.strip()
+                for line in parser.get(section, option, raw=True).splitlines()
+                if line.strip()
+            )
+            for option in parser.options(section)
+        }
+        for section in parser.sections()
+    }
 
 
-@pytest.mark.parametrize("name", sorted(EXPECTED_DECLARED_KEYS))
-def test_configuration_file_declares_the_expected_keys(name: str) -> None:
-    """Assert one shipped coveragerc spells out exactly section 10.4's keys
+@pytest.mark.parametrize("name", sorted(EXPECTED_DECLARED_SETTINGS))
+def test_configuration_file_spells_out_exactly_what_the_design_shows(
+    name: str,
+) -> None:
+    """Assert one shipped coveragerc declares section 10.4's settings verbatim
 
     The companion to the resolved-value case below, and not redundant with it.
     ``parallel`` is the concrete reason: coverage derives it from
-    ``patch = subprocess``, so deleting the line from
-    ``.coveragerc-subprocess`` changes no resolved value and no behaviour --
-    only the file's stated intent that the setting be legible rather than
-    inferred. Nothing but this case can fail on that.
+    ``patch = subprocess``, so both deleting the line from
+    ``.coveragerc-subprocess`` and setting it to ``false`` leave every resolved
+    value untouched. The first loses only the file's stated intent that the
+    setting be legible rather than inferred; the second leaves the file saying
+    the opposite of the design it is supposed to implement. Nothing but this
+    case can fail on either.
 
-    It also catches the mirror image: a key deleted from a file and from section
+    It also catches the mirror image: a setting changed in a file and in section
     10.4 together, which the document comparison cannot see because both sides
     move.
 
     Args:
         name: The configuration file's name at the repository root.
     """
-    declared = _declared_keys(_config_path(name))
+    declared = _declared_settings(_config_path(name))
 
-    assert declared == EXPECTED_DECLARED_KEYS[name], (
+    assert declared == EXPECTED_DECLARED_SETTINGS[name], (
         f"{name} declares {declared!r}, but section 10.4 of "
-        f"{TEST_SUITE_PATH.name} spells out {EXPECTED_DECLARED_KEYS[name]!r}."
+        f"{TEST_SUITE_PATH.name} shows {EXPECTED_DECLARED_SETTINGS[name]!r}."
     )
 
 
@@ -517,20 +569,25 @@ def test_design_document_declares_the_same_configuration(
     documented_path.write_text(_design_document_block(name), encoding="utf-8")
 
     shipped_path = _config_path(name)
+    # Bound rather than recomputed inside the assertions: each call builds two
+    # configuration objects and edits the environment while it does so.
+    documented_resolved = _resolved_settings(documented_path)
+    shipped_resolved = _resolved_settings(shipped_path)
+    documented_declared = _declared_settings(documented_path)
+    shipped_declared = _declared_settings(shipped_path)
 
-    assert _resolved_settings(documented_path) == _resolved_settings(shipped_path), (
+    assert documented_resolved == shipped_resolved, (
         f"Section 10.4 of {TEST_SUITE_PATH.name} declares "
-        f"{_resolved_settings(documented_path)!r} for {name} but the file "
-        f"resolves to {_resolved_settings(shipped_path)!r}. Change both in the "
-        "same pull request."
+        f"{documented_resolved!r} for {name} but the file resolves to "
+        f"{shipped_resolved!r}. Change both in the same pull request."
     )
-    # Compared as well as the resolved values, so the document cannot keep a
-    # setting the shipped file dropped when coverage would have derived it
+    # Compared as well as the resolved values, so the document and the file
+    # cannot agree on a setting coverage would have derived or overridden
     # anyway -- ``parallel`` being exactly that case.
-    assert _declared_keys(documented_path) == _declared_keys(shipped_path), (
+    assert documented_declared == shipped_declared, (
         f"Section 10.4 of {TEST_SUITE_PATH.name} spells out "
-        f"{_declared_keys(documented_path)!r} for {name} but the file spells "
-        f"out {_declared_keys(shipped_path)!r}."
+        f"{documented_declared!r} for {name} but the file spells out "
+        f"{shipped_declared!r}."
     )
 
 


### PR DESCRIPTION
## Context for the Product Owner

**The problem in one sentence: code that nobody tests is currently invisible, not visibly untested.**

This repository has 29 production modules. Several have no test at all — the worst is the Chromium browser-pool module, 213 statements of logic with no test file anywhere. You would expect a coverage report to show that as a big red zero. It does not. Coverage tools, by default, only report files they *watched running*. A module no test ever imports simply does not appear in the report. The percentage looks respectable, the gap never reaches anyone's screen, and the code ships untested.

That is the founding problem the whole test-suite programme exists to fix, and this change is the piece that makes the gap visible.

**What ships here** is three small configuration files telling the coverage tool how to measure this project. They are plumbing — nothing user-facing changes, and no CI job runs them yet. But every coverage control the programme depends on is built on top of them:

- **`.coveragerc`** — the whole-package view. The one that makes untested modules show up as an explicit zero instead of not showing up. The browser-pool module now appears in the report, at zero, where someone has to look at it.
- **`.coveragerc-gate`** — the same, minus the handful of modules that genuinely cannot be tested without a real browser. Without this exclusion, ordinary work on the browser code would fail the quality gates for lines it is not possible to cover, which teaches people to bypass the gate — the failure mode that makes gates worthless.
- **`.coveragerc-subprocess`** — the browser work runs in a separate process, and coverage does not follow it there by default. Without this, the code doing the hardest work in the product would read as completely untested no matter how well tested it actually was.

**Why the accompanying test module is not ceremony.** Coverage tools answer a mistyped setting with a warning and then carry on ignoring it. A typo in one of these files leaves a configuration that looks correct in review and measures the wrong thing in production, silently, forever. The guard reads what the tool *actually resolved*, so a typo cannot survive it — and separately reads what the file literally says, so a setting the tool would have supplied on its own cannot be quietly dropped or inverted either.

**Risk: low.** Nothing in the running product changes. No CI job is altered. The three files are inert until a later change wires them into a job.

---

## What this is

Plan step **E0-4**. `.system_design/TEST_SUITE.md` §10.4 specifies three coverage configurations and displays all three in full; none of them existed. This materialises them and guards them.

Requirements, acceptance criteria and the recorded design decisions are in the task's `REQUIREMENTS.md` (untracked by design).

## Changes

| File | What |
|---|---|
| `.coveragerc` | Whole-package view: `source_pkgs`, `branch`, `relative_files`, `[paths]` |
| `.coveragerc-gate` | The same plus the `omit` list for the modules with no hermetic seam |
| `.coveragerc-subprocess` | `[run]` settings plus `parallel` and `patch = subprocess`; no `[paths]` |
| `tests/test_coverage_configuration.py` | 19-case guard — 16 contract, 3 subsystem |
| `.system_design/TEST_SUITE.md` | §10.4 named the wrong file for the subprocess options; misdescribed coverage's config discovery; and did not record the `[paths]` consequence for the wheel-installing job |
| `.github/review/rules/python-tests.md` | The new guard added to the load-bearing register |
| `.gitignore` | Coverage artefacts these configs invite people to produce |

## The one thing to review closely

**Each configuration is checked two ways, and neither implies the other.**

- **By the values coverage resolved**, compared as the config's *whole difference* from coverage's own defaults. Measured on 7.13.5 and 7.16.0 alike, an unrecognised key produces a `CoverageWarning` and is then ignored — so a text comparison between the design document and the shipped file sees the typo identically on both sides and passes. Only the resolved value can fail on it. Comparing the whole difference, rather than a hand-listed set of keys, means an added option cannot take effect unnoticed.
- **By the settings the file literally spells out**, keys *and* values. This exists because coverage *derives* some settings: `post_process` sets `parallel` whenever `patch` contains `subprocess`. So `parallel = true` could be deleted from `.coveragerc-subprocess`, or set to `false`, and every resolved-value comparison would still pass — the second leaving the file asserting the opposite of the design it implements.

Both halves were found by review, and both were verified failing before the fix.

## Verification

Every case was watched failing first. **Sixteen mutations, each caught by exactly the expected case**, including the ones that move the design document and the shipped file *together*:

dropped `source_pkgs` · typo'd it to `source_pkg` · added `concurrency = thread` · added `_crash` · dropped an `omit` entry · altered an `omit` pattern on both sides at once · dropped `patch = subprocess` · deleted `parallel = true` from the file · deleted it from file *and* design block · set it to `false` in the file · set it to `false` on both sides · drifted the design block · renamed the design section heading · added a fourth undocumented config file · deleted a design block · grew a `[paths]` section on the subprocess config.

Behaviour confirmed on **both** coverage 7.13.5 (what the pinned lane installs) and 7.16.0, with identical results — the design document warns that older versions had bugs in exactly this area, so the local version's word was not taken for it.

Suite: **12 failed / 303 passed / 2 skipped** — the same 12 pre-existing failures as `main`, verified by diffing the sorted `FAILED` lines before and after rather than comparing counts. The review system's own 482 tests pass, leak guard included.

## Three things recorded rather than fixed

1. **`.coveragerc-subprocess` has no `[paths]` mapping while one of its two consumers is a wheel job.** §10.3's `chromium` job installs the PR's wheel, so its paths land under `site-packages` unmapped. Accepted because that lane is observational and feeds neither `diff-cover` nor the committed baseline. Now recorded in §10.4 itself, since that is where the next reader looks. Adding the mapping would be a §10.4 change with its own step.
2. **`scripts/check_plan_dag.py` misclassifies `from unittest import mock`** as unittest-style framework use, contradicting its own comment saying it means to exempt exactly that. A common idiom, so the next person will hit it. Worked around here with a hand-rolled save/restore; the fix is a negative lookahead, and it needs its own guard test.
3. **Windows behaviour of the subprocess case.** Its report-key comparisons are separator-normalised so they *can* pass there, but the environmental prerequisites were measured on Linux. Unproven until the CI epic runs the `subsystem` job on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AejTrP3GkUcKkv9UkXYbsP
