### PR TITLE
Record the per-OS baseline as a guarded ledger (plan step E1-1)

### DIFF
--- a/.github/review/rules/python-tests.md
+++ b/.github/review/rules/python-tests.md
@@ -44,7 +44,7 @@
 
 ## The guard tests — treat these as load-bearing
 
-Seven tests exist to hold an invariant that nothing else enforces. A pull request
+Eight tests exist to hold an invariant that nothing else enforces. A pull request
 that changes what they guard, without changing them, is a finding; a pull request
 that *weakens* one to make a change pass is a critical finding.
 
@@ -57,14 +57,16 @@ that *weakens* one to make a change pass is a critical finding.
 | `test_pytest_configuration.py` | that `[tool.pytest.ini_options]` matches TEST_SUITE.md §10.5, that the running pytest actually loaded it, and that `strict_markers` / `asyncio_mode` have their effect and not merely their declaration |
 | `test_min_selected_guard.py` | that the `--min-selected` collection floor in `tests/conftest.py` matches TEST_SUITE.md §10.3 and still fires — an under-selected marker job exits 4 and names both counts, while a genuine failure keeps exit 1 and a collection error keeps its own diagnosis |
 | `test_coverage_configuration.py` | that `.coveragerc`, `.coveragerc-gate` and `.coveragerc-subprocess` match TEST_SUITE.md §10.4 and still behave — the base config reports an unexecuted module at zero, the gate config omits the modules with no hermetic seam, and the subprocess config captures a child process |
+| `test_baseline_failure_ledger.py` | that `.system_design/BASELINE_FAILURES.md` names exactly the tests that fail today — it re-runs the suite in a child process with the live-test opt-ins cleared and compares node ids, so a repair that forgets to delete its ledger entry and a new red test both turn it red, and for opposite reasons it names separately |
 
-Three of these are coupled: `test_min_selected_guard.py` and
-`test_coverage_configuration.py` both import `_section_body` from
-`test_pytest_configuration.py` rather than keeping their own copy of the
-fence-aware section bound, which exists because the naive heading regex was
-measured wrong — on §10.4's own blocks, whose opening comment sits at column 0
-and reads as a heading. A change to that helper's name or behaviour breaks all
-three guards, so it is not the private detail its underscore suggests.
+Four of these are coupled: `test_min_selected_guard.py`,
+`test_coverage_configuration.py` and `test_baseline_failure_ledger.py` all
+import `_section_body` from `test_pytest_configuration.py` rather than keeping
+their own copy of the fence-aware section bound, which exists because the naive
+heading regex was measured wrong — on §10.4's own blocks, whose opening comment
+sits at column 0 and reads as a heading. A change to that helper's name or
+behaviour breaks all four guards, so it is not the private detail its underscore
+suggests.
 
 Plus `test_worker_launch_args_redaction.py` for the subprocess command line — the
 same class of guard, one layer down.

--- a/.system_design/BASELINE_FAILURES.md
+++ b/.system_design/BASELINE_FAILURES.md
@@ -1,0 +1,196 @@
+# Baseline failures — the ledger
+
+**Status:** As Is. This file records the suite's red baseline exactly as it is
+today, one node id at a time, so that the repairs in E1-2 through E1-5 can be
+checked rather than believed.
+
+`TEST_SUITE.md` §1.1 quotes the baseline as counts. A count is not a checkpoint:
+`12 failed` before a repair and `11 failed` after it is equally consistent with
+"one test was fixed" and with "two were fixed and a third was broken". Only the
+set of failing node ids distinguishes those, so the set is what this file holds
+and what `tests/test_baseline_failure_ledger.py` asserts against a live run.
+
+## How this file drains
+
+Every entry below is a test that fails today and is expected to. **E1-2 through
+E1-5 each delete exactly the ids they repair and add none.** E1-6 — the
+suite-green milestone — is reached when both blocks are empty, at which point the
+guard is asserting that a real run has no failures at all. The document and the
+milestone are therefore the same fact, checked once.
+
+**An id may leave this ledger only by passing.** Deleting a test, renaming its
+class or marking it skipped removes it from the failing set too, and all three
+look exactly like a repair from the outside. The guard therefore records the
+child run's *collected* and *skipped* sets as well as its failing one, and names
+those three outcomes separately. This is the direction that will actually be
+tripped: a repair step rewriting eight stale tests can lose one by accident far
+more easily than it can invent a new failure.
+
+Adding an id here is not a way to make a new failure acceptable. A new red test
+is a regression; this ledger names the pre-existing twelve, and a change that
+grows it needs a reason stated in its pull request.
+
+**The guard outlives the milestone.** Once drained, it is the cheapest available
+assertion that the suite is green — an empty ledger compared against an empty
+failing set — so it is kept rather than deleted with E1-6. Its cost is one extra
+child run of the suite, roughly doubling wall time; that is accepted because the
+alternative is trusting twelve repaired tests to stay repaired with nothing
+watching them.
+
+## What is asserted and what is provenance
+
+`tests/test_baseline_failure_ledger.py` asserts **the set of failing node ids**
+for the platform it is running on, and, on every platform, that each block is
+sorted, free of duplicates, consistent with the failure count on its **Result**
+line, and different from the other platform's block only in the ways the
+difference section below explains.
+
+It deliberately does **not** assert the passing, skipped or subtest counts. Those
+move whenever any step adds a test, so asserting them would turn every ordinary
+test-adding pull request red for a reason unrelated to what it changed. **They
+are frozen to the commit named on each Result line and are not expected to match
+a later run** — this very change adds tests, so the first run after it merges
+already reports a higher passing count than the figures below. That is correct
+and is not to be "fixed".
+
+The failure count *is* asserted, against the length of the block. The two agree
+only while no test fails more than once; a test whose subtests fail several times
+counts once here and several times in pytest's own total, and a ledger recording
+such a run must say so on the Result line.
+
+On a platform with no section here — macOS, say — the live comparison **skips**
+with a stated reason. The ledger claims nothing about a platform nobody measured,
+and a guard that silently passed there would be worse than one that says so. For
+the same reason a platform is either measured and listed, or absent: there is no
+empty-because-unknown state, because an empty block already means *drained* and
+one symbol cannot mean both.
+
+The baseline is defined for one canonical interpreter and dependency set per
+platform, named on each Result line. §10.3's CI matrix also varies the Python
+version and the `mcp` bound; this ledger makes no claim about those legs and
+should be drained before they exist.
+
+## The measurement command
+
+A failing set means nothing without the selection that produced it. The guard
+runs exactly this, and asserts this block against the argv it builds, so any
+later change to the selection — the `live`, `chromium` and `package` markers
+arrive in a later workstream — is a deliberate edit here rather than a silent
+redefinition of the baseline.
+
+```console
+python -m pytest -p no:cacheprovider -p tests._baseline_probe -c <repo>/pyproject.toml --ignore=tests/test_baseline_failure_ledger.py --baseline-probe-json=<tempfile> -q --tb=no
+```
+
+Both runs recorded below predate this guard and were plain `pytest -q` on a clean
+checkout. That is not a discrepancy: the flags above add a plugin, exclude the
+guard's own module and pin the configuration, none of which changes *which* tests
+fail — and the Linux comparison passes against the ids recorded from the plain
+run, which is the check rather than the claim.
+
+The child's environment is swept of everything this project reads —
+`KINDLY_*`, the provider credentials, `PYTEST_*`, `COVERAGE_*` and the rest — so
+the numbers below are the **offline** baseline and are reproducible regardless of
+what a developer has exported. That is not cosmetic: measured on Linux at commit
+`3af0563`, exporting `RUN_LIVE_TESTS=1` alone adds a thirteenth failure,
+`tests/test_serper_live.py::TestSerperLive::test_serper_search_live`, which
+reaches the network and fails on the dummy credential `tests/conftest.py`
+installs. Without the sweep the guard would be red on any machine configured for
+live tests.
+
+The results are read from a plugin (`tests/_baseline_probe.py`), not from
+pytest's short summary. On pytest 9.1.1 a failing `unittest` subtest prints a
+*passing* dot in the progress line and a `SUBFAILED(i=2) <nodeid>` line in the
+summary — never the word `FAILED`. A guard parsing `FAILED` lines would report
+an empty failing set on a red suite, and two of this repository's three
+`subTest` sites are in `tests/test_universal_html_loader.py`, one of the files
+this ledger tracks.
+
+## What the twelve are
+
+Grouped by cause, so a reviewer can tell which repair step owns which id. The
+grouping is by module rather than per id, because the blocks are sorted and so
+already group by module — a per-id table would restate the block and could drift
+from it.
+
+| Module | Ids | Cause | Repaired by |
+|---|---|---|---|
+| `test_nodriver_worker_sandbox.py` | 8 | `_fetch_html` grew five required keyword-only arguments; the callers were never updated | E1-2 (flags and defaults to L1), then E1-3 (retry and cleanup) |
+| `test_universal_html_loader.py` | 3 | `fetch_html_via_nodriver` streams `proc.stdout`; `_FakeProc` never grew one | E1-4 |
+| `test_server.py` | 1 | asserts a Windows concurrency cap that `_resolve_web_search_max_concurrency` no longer has | E1-5 |
+
+## Why the two platforms differ
+
+`test_forces_sandbox_off_when_running_as_root` skips on Windows, where
+`os.geteuid` does not exist (`test_nodriver_worker_sandbox.py:199`), so it can
+fail only on POSIX. That is the whole of the difference; every other id fails on
+both. The guard asserts this block against the actual difference between the two
+blocks above, which is what catches a repair that drains one platform and
+forgets the other — there is no Windows lane in CI until a later workstream, so
+nothing else would.
+
+```text
+linux: tests/test_nodriver_worker_sandbox.py::TestNodriverWorkerSandbox::test_forces_sandbox_off_when_running_as_root
+```
+
+## Linux
+
+- **Measured:** 2026-08-31 · commit `3af0563` · Ubuntu 24.04.4 LTS ·
+  Linux 6.8.0-138 · CPython 3.13.15 · pytest 9.1.1 · pytest-asyncio 1.4.0 ·
+  mcp 1.29.1 · starlette 1.6.0 · uvicorn 0.52.4 · nodriver 0.50.3
+- **Result:** 12 failed, 303 passed, 2 skipped, 9 subtests passed
+
+This is the figure §1.1 predicted from source and labelled unmeasured. It is now
+measured, and it matches: twelve, being the eight stale `_fetch_html` callers,
+the three stale loader tests and the one obsolete Windows concurrency test.
+
+```text
+tests/test_nodriver_worker_sandbox.py::TestNodriverWorkerSandbox::test_allows_enabling_sandbox_via_env
+tests/test_nodriver_worker_sandbox.py::TestNodriverWorkerSandbox::test_disables_sandbox_by_default
+tests/test_nodriver_worker_sandbox.py::TestNodriverWorkerSandbox::test_errors_when_no_browser_found
+tests/test_nodriver_worker_sandbox.py::TestNodriverWorkerSandbox::test_forces_sandbox_off_when_running_as_root
+tests/test_nodriver_worker_sandbox.py::TestNodriverWorkerSandbox::test_resolves_browser_executable_from_path
+tests/test_nodriver_worker_sandbox.py::TestNodriverWorkerSandbox::test_retries_and_terminates_on_devtools_timeout
+tests/test_nodriver_worker_sandbox.py::TestNodriverWorkerSandbox::test_retries_on_failed_to_connect_to_browser
+tests/test_nodriver_worker_sandbox.py::TestNodriverWorkerSandbox::test_uses_ignore_cleanup_errors_for_profile_dir
+tests/test_server.py::TestWebSearchTool::test_web_search_concurrency_defaults_on_windows
+tests/test_universal_html_loader.py::TestUniversalHtmlLoader::test_fetch_html_passes_browser_executable_path_when_set
+tests/test_universal_html_loader.py::TestUniversalHtmlLoader::test_fetch_html_sets_no_proxy_for_loopback
+tests/test_universal_html_loader.py::TestUniversalHtmlLoader::test_fetch_html_spawns_worker_subprocess
+```
+
+## Windows
+
+- **Measured:** 2026-08-31 · commit `3af0563` · Windows Server 2025
+  (10.0.26100) · CPython 3.13.15 · pytest 9.1.1 · pytest-asyncio 1.4.0 ·
+  mcp 1.29.1 · starlette 1.6.0 · uvicorn 0.52.4 · nodriver 0.50.3
+- **Result:** 11 failed, 303 passed, 3 skipped, 9 subtests passed
+
+Measured on a GitHub Actions `windows-latest` runner, from a temporary workflow
+on a branch of its own that was deleted once the numbers were recorded. It
+touched neither `ci.yml` nor any of the workflow regions §1.3 serialises, and it
+is not the Windows CI lane — that arrives with the CI epic. It was an instrument,
+used once.
+
+The count confirms §1.1's prediction rather than merely repeating it: eleven, and
+the eleven ids below are the Linux twelve minus the root-detection case, which
+Windows skips. The two runs also reconcile arithmetically — 303 passed on both,
+with the twelfth test counting as a failure on Linux and as the third skip here.
+
+The **11 failed** total equals the number of ids listed, which is the check worth
+making on any recorded run: a larger total than the list would mean a test failed
+more than once, through subtests the summary reports under a different word.
+
+```text
+tests/test_nodriver_worker_sandbox.py::TestNodriverWorkerSandbox::test_allows_enabling_sandbox_via_env
+tests/test_nodriver_worker_sandbox.py::TestNodriverWorkerSandbox::test_disables_sandbox_by_default
+tests/test_nodriver_worker_sandbox.py::TestNodriverWorkerSandbox::test_errors_when_no_browser_found
+tests/test_nodriver_worker_sandbox.py::TestNodriverWorkerSandbox::test_resolves_browser_executable_from_path
+tests/test_nodriver_worker_sandbox.py::TestNodriverWorkerSandbox::test_retries_and_terminates_on_devtools_timeout
+tests/test_nodriver_worker_sandbox.py::TestNodriverWorkerSandbox::test_retries_on_failed_to_connect_to_browser
+tests/test_nodriver_worker_sandbox.py::TestNodriverWorkerSandbox::test_uses_ignore_cleanup_errors_for_profile_dir
+tests/test_server.py::TestWebSearchTool::test_web_search_concurrency_defaults_on_windows
+tests/test_universal_html_loader.py::TestUniversalHtmlLoader::test_fetch_html_passes_browser_executable_path_when_set
+tests/test_universal_html_loader.py::TestUniversalHtmlLoader::test_fetch_html_sets_no_proxy_for_loopback
+tests/test_universal_html_loader.py::TestUniversalHtmlLoader::test_fetch_html_spawns_worker_subprocess
+```

--- a/.system_design/BASELINE_FAILURES.md
+++ b/.system_design/BASELINE_FAILURES.md
@@ -89,7 +89,9 @@ fail — and the Linux comparison passes against the ids recorded from the plain
 run, which is the check rather than the claim.
 
 The child's environment is swept of everything this project reads —
-`KINDLY_*`, the provider credentials, `PYTEST_*`, `COVERAGE_*` and the rest — so
+`KINDLY_*`, `PYTHON*`, `PYTEST_*`, `COVERAGE_*` and the other project prefixes,
+plus the provider credentials, the proxy variables and the browser-path
+variables that carry no common prefix — so
 the numbers below are the **offline** baseline and are reproducible regardless of
 what a developer has exported. That is not cosmetic: measured on Linux at commit
 `3af0563`, exporting `RUN_LIVE_TESTS=1` alone adds a thirteenth failure,
@@ -97,6 +99,18 @@ what a developer has exported. That is not cosmetic: measured on Linux at commit
 reaches the network and fails on the dummy credential `tests/conftest.py`
 installs. Without the sweep the guard would be red on any machine configured for
 live tests.
+
+The sweep is held honest by a check that scans the source tree for every string
+literal shaped like an environment variable name and asserts none survives.
+Anchoring that scan on `os.environ.get("...")` call sites was tried and measured
+wrong: `CHROME_BIN`, `CHROME_PATH`, `BROWSER_EXECUTABLE_PATH` and `no_proxy` are
+read through a *loop variable* over a tuple of literals, and others through
+`_get_int_env(key, ...)` helpers, so no call-site pattern can see them. The shape
+scan over-collects instead — the safe direction, since a false positive costs one
+allow-list entry while a false negative costs a silently steerable baseline. Two
+of those browser-path variables steer `_resolve_browser_executable_path`, whose
+tests are two of the twelve ids below, so the gap would have become a real
+divergence the moment those repairs landed on a machine with `CHROME_BIN` set.
 
 The results are read from a plugin (`tests/_baseline_probe.py`), not from
 pytest's short summary. On pytest 9.1.1 a failing `unittest` subtest prints a

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -33,9 +33,21 @@ On the environment above: **11 failed, 169 passed, 3 skipped, 9 subtests passed.
 `test_nodriver_worker_sandbox.py` contains **eight** stale `_fetch_html` callers.
 The eighth, `test_forces_sandbox_off_when_running_as_root`, skips on Windows
 because `os.geteuid` does not exist there (`test_nodriver_worker_sandbox.py:199`),
-so POSIX should show **12** failures. *That POSIX figure is read from source, not
-executed;* §8 makes measuring it a task. Baselines are quoted per platform, from
-real runs, or not quoted.
+so POSIX should show **12** failures.
+
+**Measured, and it does.** On Ubuntu 24.04.4 LTS · CPython 3.13.15 · `pytest`
+9.1.1, repo at `3af0563`: **12 failed, 303 passed, 2 skipped, 9 subtests
+passed** — the same twelve, with the root-detection case that Windows skips. The
+passing count differs from the Windows run above only because four bootstrap
+steps landed between the two commits and added guard tests; the failing set did
+not move. Baselines are quoted per platform, from real runs, or not quoted.
+
+**The counts above are not the artefact that matters.** A count cannot tell a
+repaired test from a repaired test alongside a newly broken one, so the failing
+**node ids** are recorded per platform in `BASELINE_FAILURES.md` and asserted
+against a live child run by `tests/test_baseline_failure_ledger.py`. E1-2 through
+E1-5 each delete exactly the ids they repair; E1-6 is reached when the ledger is
+empty, which is the same statement as the guard finding no failures.
 
 ### 1.2 What is actually uncovered
 
@@ -633,7 +645,10 @@ policy-enforcing proxy of §13.1's candidate list.
 no framework migration mixed in, so a failure means a stale test, not a
 conversion bug.
 
-1. Measure the baseline on Linux; record both platforms.
+1. Measure the baseline on Linux; record both platforms — as node ids in
+   `BASELINE_FAILURES.md`, not only as counts, and guarded against a live child
+   run by `tests/test_baseline_failure_ledger.py`. Steps 2-4 below each delete
+   exactly the ids they repair, so the ledger drains to empty as they land.
 2. Split the 8 stale sandbox tests: flag and default resolution moves to L1
    (§3.1); retry and cleanup orchestration stays as narrow autospecced tests
    around `_fetch_html` (§5.2).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,9 +134,9 @@ asyncio_mode = "auto"
 # release, and it would land on E11, the step that converts the whole suite.
 # "function" is the announced future default, chosen so the flip is a no-op.
 asyncio_default_fixture_loop_scope = "function"
-# All seven of §10.5. `slow` is registered ahead of its first real user and is
-# currently exercised only as the control case in
-# `tests/test_pytest_configuration.py`; it is not dead.
+# All seven of §10.5. `slow` now has a real user --
+# `tests/test_baseline_failure_ledger.py`, which spawns a child run of the whole
+# suite -- alongside the control case in `tests/test_pytest_configuration.py`.
 markers = [
     "live: hits the real network; needs KINDLY_RUN_LIVE_TESTS=1",
     "subsystem: needs a real socket or child process; portable",

--- a/tests/_baseline_probe.py
+++ b/tests/_baseline_probe.py
@@ -47,13 +47,27 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
 
 
-def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+def pytest_collection_finish(session: pytest.Session) -> None:
     """Record every node id that survived selection.
 
+    ``pytest_collection_finish``, not ``pytest_collection_modifyitems``, for the
+    reason ``tests/conftest.py`` already records about its own hook: ``modifyitems``
+    receives the collected list *before* mark-based deselection. Measured on
+    pytest 9.1.1 with ``-m "not slow"`` over two tests, ``modifyitems`` sees two
+    items and ``session.items`` sees one.
+
+    It matters for what a deselected test is called. The child passes no ``-m``
+    today, but the ledger's own measurement command gains marker selection in a
+    later workstream. Under ``modifyitems``, a documented test that was
+    *deselected* would appear as collected, not failing and not skipped -- which
+    is the guard's signature for "ran and passed, delete the id". That is the one
+    diagnosis the ledger exists to prevent.
+
     Args:
-        items: The selected items, injected by pytest after deselection.
+        session: The collection session, injected by pytest. Its ``items`` are the
+            tests that will actually run.
     """
-    _collected.update(item.nodeid for item in items)
+    _collected.update(item.nodeid for item in session.items)
 
 
 def pytest_runtest_logreport(report: pytest.TestReport) -> None:

--- a/tests/_baseline_probe.py
+++ b/tests/_baseline_probe.py
@@ -1,0 +1,98 @@
+"""Child-process pytest plugin recording one run's outcomes as JSON.
+
+Loaded with ``-p`` by :mod:`tests.test_baseline_failure_ledger` into the child
+process it spawns, and by nothing else. It exists because the human-readable
+short summary is not a usable channel for this: measured on pytest 9.1.1, a
+failing ``unittest`` subtest prints a **passing** dot in the progress line and a
+``SUBFAILED(i=2) <nodeid>`` line in the summary, never the word ``FAILED``. A
+guard reading ``FAILED`` lines therefore sees an empty failure set on a red
+suite -- and two of the three ``subTest`` sites in this repository sit in
+``tests/test_universal_html_loader.py``, one of the files the ledger tracks.
+
+Reporting the collected and skipped sets alongside the failing one is what lets
+the guard tell a repaired test from a deleted, renamed or newly skipped one.
+Those look identical in a failure set -- the id simply stops appearing -- and
+only one of them is good news.
+
+The module is deliberately not named ``test_*``, so pytest does not collect it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_collected: set[str] = set()
+_failed: set[str] = set()
+_skipped: set[str] = set()
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Register the option naming the file this plugin writes.
+
+    An option rather than an environment variable: the guard scrubs whole
+    environment prefixes before spawning, and a channel that a scrubbing rule
+    could silently remove is the wrong channel. As argv it is visible in any
+    failure message that quotes the child's command line.
+
+    Args:
+        parser: pytest's option parser, injected by pytest.
+    """
+    parser.addoption(
+        "--baseline-probe-json",
+        default=None,
+        help="Write this run's collected/failed/skipped node ids to this path.",
+    )
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Record every node id that survived selection.
+
+    Args:
+        items: The selected items, injected by pytest after deselection.
+    """
+    _collected.update(item.nodeid for item in items)
+
+
+def pytest_runtest_logreport(report: pytest.TestReport) -> None:
+    """Record the outcome of one test phase.
+
+    Every phase is inspected, not only ``call``: a fixture that raises reports a
+    ``failed`` setup phase, which pytest prints as ``ERROR`` and which is just as
+    much a red test as an assertion failure. Subtest reports arrive through this
+    same hook carrying the parent test's node id, which is the whole reason the
+    plugin exists.
+
+    Args:
+        report: The phase report, injected by pytest.
+    """
+    if report.failed:
+        _failed.add(report.nodeid)
+    elif report.skipped:
+        _skipped.add(report.nodeid)
+
+
+def pytest_sessionfinish(session: pytest.Session) -> None:
+    """Write the recorded sets to the path the option named.
+
+    Args:
+        session: The finished session, injected by pytest.
+    """
+    destination = session.config.getoption("--baseline-probe-json")
+    if destination is None:
+        return
+    # Sorted so the file is stable to diff by hand when a guard failure needs
+    # investigating.
+    Path(destination).write_text(
+        json.dumps(
+            {
+                "collected": sorted(_collected),
+                "failed": sorted(_failed),
+                "skipped": sorted(_skipped),
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )

--- a/tests/test_baseline_failure_ledger.py
+++ b/tests/test_baseline_failure_ledger.py
@@ -649,17 +649,24 @@ def test_child_environment_drops_every_variable_the_project_reads() -> None:
     # cover either.
     os.environ.update({name: "planted" for name in names})
     os.environ.update({name.lower(): "planted" for name in names})
+    # Planted explicitly rather than relied upon: the scan's shape is upper case
+    # only, so `no_proxy` never arrives through `names`, and reading it from the
+    # ambient environment would make the control fire only on a machine that
+    # happens to export it -- passing vacuously everywhere else, which is the
+    # failure mode this whole check exists to prevent.
+    os.environ["no_proxy"] = "planted"
     try:
-        surviving = {name.upper() for name in _child_environment()}
+        child = _child_environment()
+        surviving = {name.upper() for name in child}
         survivors = sorted(names & surviving)
+        lowercase_survived = "no_proxy" in child
     finally:
         os.environ.clear()
         os.environ.update(original)
-    # An explicit control for the case that motivated the case-insensitive match.
-    # The scan's shape is upper case only, so `no_proxy` can never arrive through
-    # `names`; naming it here means the one lower-case variable this project
-    # actually reads has a test of its own rather than incidental coverage.
-    assert "no_proxy" not in _child_environment(), (
+    # The control for the case that motivated matching case-insensitively: the
+    # one lower-case variable this project reads gets a check of its own rather
+    # than incidental coverage.
+    assert not lowercase_survived, (
         "`no_proxy` survives the sweep. It is read at scrape/nodriver_worker.py "
         "and scrape/universal_html.py alongside `NO_PROXY`, and the sweep is "
         "case-insensitive precisely so that listing the upper-case name covers "

--- a/tests/test_baseline_failure_ledger.py
+++ b/tests/test_baseline_failure_ledger.py
@@ -1,0 +1,732 @@
+"""Guard the baseline failure ledger against what a real run actually does.
+
+``.system_design/BASELINE_FAILURES.md`` names, one node id at a time, every test
+that fails on this repository today. This module holds that document and the
+suite in agreement.
+
+The document exists because ``TEST_SUITE.md`` §1.1 quotes the baseline as
+*counts*, and a count is not a checkpoint: ``12 failed`` before a repair and
+``11 failed`` after it is equally consistent with "one test was fixed" and with
+"two were fixed and a third was broken". Only the *set* of failing node ids
+separates those, which is what the ledger records and what this module asserts.
+
+Three kinds of check live here, and none implies another:
+
+* **structural**, which read only the document -- that every platform the guard
+  knows has a section, that each block is sorted and free of duplicates, and
+  that each block agrees with the failure count on its own ``Result`` line.
+  These run wherever the suite runs, so the section for the platform you are
+  *not* on is still held to its format, and they are exercised against synthetic
+  documents so that each rejection stays a test rather than a one-time
+  observation;
+* **cross-platform**, which holds the two blocks to the difference the document
+  itself explains. Only one platform's live comparison can run on any given
+  machine and there is no Windows lane in CI yet, so without this a repair that
+  drains one block and forgets the other passes every check that executes;
+* **behavioural**, which runs the suite in a child process and compares the live
+  outcome to the documented one. This is the check that does the real work, and
+  it runs only on a platform the ledger covers.
+
+An id may leave the ledger **only by passing**. Deleting a test, renaming its
+class, or marking it skipped also removes it from the failing set, and all three
+look exactly like a repair. The child therefore reports its collected and
+skipped sets as well, and this module names those outcomes separately -- see
+:func:`test_live_outcome_matches_the_ledger`.
+
+The ledger drains as E1-2 through E1-5 land, each deleting exactly the ids it
+repairs. When both blocks are empty, the behavioural check is asserting that a
+real run has no failures at all -- so the E1-6 milestone and this guard are the
+same fact, checked once rather than twice. The guard outlives that milestone: a
+drained ledger is then the cheapest available "the suite is green" assertion,
+and deleting it would give the twelve repaired tests room to rot again.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.test_pytest_configuration import _section_body
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
+LEDGER_PATH = REPO_ROOT / ".system_design" / "BASELINE_FAILURES.md"
+
+# This module's path as pytest spells it, derived rather than written out. The
+# child run must not collect this module -- one guard invocation has to spawn
+# exactly one child, not a chain of them -- and deriving the path from
+# ``__file__`` means renaming the module cannot silently disarm the exclusion and
+# turn the guard into a fork bomb. ``as_posix`` because pytest takes forward
+# slashes on both platforms.
+GUARD_RELATIVE_PATH = Path(__file__).resolve().relative_to(REPO_ROOT).as_posix()
+
+# ``sys.platform`` to the ledger heading that covers it. The mapping is the
+# guard's own table and is asserted against the document in both directions, so
+# neither a section without an entry nor an entry without a section can pass
+# unnoticed. A platform absent from this table -- macOS, say -- has no measured
+# baseline, and the behavioural check skips there rather than inventing one.
+LEDGER_PLATFORMS: dict[str, str] = {
+    "linux": "## Linux",
+    "win32": "## Windows",
+}
+
+DIFFERENCE_HEADING = "## Why the two platforms differ"
+COMMAND_HEADING = "## The measurement command"
+
+# Environment prefixes and names the child run does not inherit. A failing set is
+# only reproducible if the run that produced it cannot be steered from outside,
+# and this repository reads roughly fifty variables. Two are the live-test
+# opt-ins, and the hazard is measured rather than theoretical: on Linux at commit
+# 3af0563, exporting ``RUN_LIVE_TESTS=1`` alone adds a thirteenth failure
+# (``test_serper_live.py::TestSerperLive::test_serper_search_live``, which reaches
+# the network and fails on the dummy credential ``conftest.py`` installs).
+# ``PYTEST_*`` covers an inherited ``PYTEST_ADDOPTS`` that would re-select the
+# child's tests, and ``COVERAGE_*`` stops a parent running under ``coverage run``
+# from enrolling the child in its own measurement.
+#
+# A hand-written list of a moving target rots, so
+# :func:`test_child_environment_drops_every_variable_the_project_reads` recovers
+# the variables the source tree actually reads and asserts that none survives
+# this sweep. That is what keeps the sweep honest as variables are added.
+CLEARED_ENVIRONMENT_PREFIXES = (
+    "KINDLY_",
+    "SEARXNG_",
+    "FASTMCP_",
+    "MCP_",
+    "STACKEXCHANGE_",
+    "GITHUB_",
+    "WIKIPEDIA_",
+    "ARXIV_",
+    "PYTEST_",
+    "COVERAGE_",
+)
+CLEARED_ENVIRONMENT_NAMES = (
+    "RUN_LIVE_TESTS",
+    "SERPER_API_KEY",
+    "SERPBASE_API_KEY",
+    "SOFYA_API_KEY",
+    "TAVILY_API_KEY",
+    "LOG_LEVEL",
+    "NO_PROXY",
+)
+
+# Matches the three forms this repository reads an environment variable through.
+ENVIRONMENT_READ_PATTERN = re.compile(
+    r"""os\.(?:environ\.get|getenv)\(["']([A-Z][A-Z0-9_]*)["']"""
+    r"""|os\.environ\[["']([A-Z][A-Z0-9_]*)["']"""
+)
+
+# Generous next to the 120 seconds the other child-process guards allow, because
+# this child runs the *whole* suite rather than a one-case throwaway module. On
+# the measuring machine it takes about fourteen seconds; the margin is for a
+# loaded CI runner. Only the direct child is killed on expiry -- the suite spawns
+# grandchildren of its own -- which is accepted rather than solved: cross-platform
+# process-group teardown is real machinery, and this path is reached only when
+# something is already badly wrong.
+CHILD_TIMEOUT_SECONDS = 300
+
+
+def _ledger_text() -> str:
+    """Read the ledger document.
+
+    Returns:
+        The whole of ``.system_design/BASELINE_FAILURES.md`` as text.
+
+    Raises:
+        AssertionError: When the document is missing. It is the subject of every
+            check here, so its absence is a failure of this guard rather than an
+            error to let propagate as a bare :class:`FileNotFoundError`.
+    """
+    assert LEDGER_PATH.is_file(), (
+        f"{LEDGER_PATH} is missing. Every check in this module reads it; without "
+        "it the suite's red baseline is recorded nowhere."
+    )
+    return LEDGER_PATH.read_text(encoding="utf-8")
+
+
+def _documented_platform_headings(text: str) -> set[str]:
+    """Return the headings of the document's platform sections.
+
+    A platform section is identified by carrying a ``Result`` line -- the summary
+    of the run it records -- rather than by matching its title against a pattern.
+    That keeps the prose sections out without requiring them to avoid any
+    particular wording, and it means a new platform section is recognised the
+    moment someone adds one, which is what lets
+    :func:`test_ledger_documents_every_platform_the_guard_knows` fail.
+
+    Args:
+        text: The whole document.
+
+    Returns:
+        Every level-2 heading whose section carries a ``Result`` line.
+    """
+    headings = [line for line in text.splitlines() if line.startswith("## ")]
+    return {
+        heading
+        for heading in headings
+        if re.search(
+            r"^\s*-\s+\*\*Result:\*\*", _section_body(text, heading), re.MULTILINE
+        )
+    }
+
+
+def _fenced_block(text: str, heading: str, language: str) -> str:
+    """Return the single fenced block of one language inside one section.
+
+    The search is bounded to the section and requires exactly one block,
+    following the shape set by :mod:`tests.test_pytest_configuration`: an
+    unbounded search would start comparing against some later section's block the
+    day one is added, and would do it silently.
+
+    Args:
+        text: The whole document.
+        heading: The section's heading line.
+        language: The fence's language tag, ``text`` or ``console``.
+
+    Returns:
+        The block's contents, fences excluded.
+
+    Raises:
+        AssertionError: When the heading is absent, or the section does not hold
+            exactly one block of that language.
+    """
+    assert heading in text.splitlines(), (
+        f"{LEDGER_PATH.name} no longer contains '{heading}'. This guard parses "
+        "that section; renaming it would silently disable the check."
+    )
+    section = _section_body(text, heading)
+    blocks = re.findall(rf"```{language}\n(.*?)```", section, re.DOTALL)
+    assert len(blocks) == 1, (
+        f"Section '{heading}' of {LEDGER_PATH.name} contains {len(blocks)} "
+        f"fenced ```{language} blocks; this guard requires exactly one."
+    )
+    return blocks[0]
+
+
+def _ledger_node_ids(text: str, heading: str) -> list[str]:
+    """Parse one platform section's node-id block.
+
+    Args:
+        text: The whole document.
+        heading: The platform section's heading line.
+
+    Returns:
+        The node ids listed under ``heading``, in the order written, with blank
+        lines dropped. An empty list is a legitimate answer: it is what the
+        ledger says once every repair has landed.
+    """
+    block = _fenced_block(text, heading, "text")
+    return [line.strip() for line in block.splitlines() if line.strip()]
+
+
+def _recorded_failure_count(text: str, heading: str) -> int:
+    """Parse the failure count from one platform section's ``Result`` line.
+
+    Read from the same line that carries the passing and skipped counts, rather
+    than written out separately, so the number this guard checks is the number
+    the recorded run actually produced. A separate field could be edited to match
+    the list while the run it claims to summarise said something else.
+
+    Args:
+        text: The whole document.
+        heading: The platform section's heading line.
+
+    Returns:
+        The ``N`` in the section's ``**Result:** N failed, ...`` line.
+
+    Raises:
+        AssertionError: When the section has no such line, or more than one.
+    """
+    section = _section_body(text, heading)
+    counts = re.findall(
+        r"^\s*-\s+\*\*Result:\*\*\s+(\d+) failed\b", section, re.MULTILINE
+    )
+    assert len(counts) == 1, (
+        f"Section '{heading}' of {LEDGER_PATH.name} has {len(counts)} lines of "
+        "the form '- **Result:** N failed, ...'; this guard requires exactly one."
+    )
+    return int(counts[0])
+
+
+def _documented_platform_only_ids(text: str, platform: str) -> list[str]:
+    """Parse the ids the document says fail on one platform and not the other.
+
+    Args:
+        text: The whole document.
+        platform: The ``sys.platform`` key whose exclusive ids are wanted.
+
+    Returns:
+        The node ids listed for ``platform`` in the difference section, sorted.
+    """
+    block = _fenced_block(text, DIFFERENCE_HEADING, "text")
+    prefix = f"{platform}:"
+    return sorted(
+        line.strip().removeprefix(prefix).strip()
+        for line in block.splitlines()
+        if line.strip().startswith(prefix)
+    )
+
+
+def _child_command(probe_path: Path) -> list[str]:
+    """Build the child run's argv.
+
+    Args:
+        probe_path: Where the probe plugin writes its JSON result.
+
+    Returns:
+        The full command line, ``sys.executable`` first.
+    """
+    return [
+        sys.executable,
+        "-m",
+        "pytest",
+        "-p",
+        "no:cacheprovider",
+        "-p",
+        "tests._baseline_probe",
+        "-c",
+        str(PYPROJECT_PATH),
+        f"--ignore={GUARD_RELATIVE_PATH}",
+        f"--baseline-probe-json={probe_path}",
+        "-q",
+        "--tb=no",
+    ]
+
+
+def _normalised_child_command(probe_path: Path) -> str:
+    """Render the child's argv in the form the ledger documents.
+
+    Three tokens vary by machine and would make a literal comparison against the
+    document meaningless: the interpreter, the absolute path to
+    ``pyproject.toml`` and the temporary file the probe writes. Each is replaced
+    by a stable placeholder, so what remains -- the selection, the plugins, the
+    exclusion -- is exactly the part that defines which run the baseline
+    describes.
+
+    Args:
+        probe_path: The path used in this invocation, replaced by a placeholder.
+
+    Returns:
+        One line, suitable for comparing against the document's block.
+    """
+    rendered = " ".join(_child_command(probe_path))
+    rendered = rendered.replace(sys.executable, "python", 1)
+    rendered = rendered.replace(str(PYPROJECT_PATH), "<repo>/pyproject.toml", 1)
+    return rendered.replace(str(probe_path), "<tempfile>", 1)
+
+
+def _child_environment() -> dict[str, str]:
+    """Build the child's environment.
+
+    A cleaned copy, not a cleared one: the child still needs ``PATH``, ``HOME``
+    and the rest of the ambient environment to start an interpreter at all. What
+    it must not inherit is anything that steers this project -- see
+    :data:`CLEARED_ENVIRONMENT_PREFIXES`.
+
+    Returns:
+        The environment the child is spawned with.
+    """
+    environment = {
+        name: value
+        for name, value in os.environ.items()
+        if not name.startswith(CLEARED_ENVIRONMENT_PREFIXES)
+        and name not in CLEARED_ENVIRONMENT_NAMES
+    }
+    environment["PYTHONIOENCODING"] = "utf-8"
+    return environment
+
+
+def _environment_variables_the_project_reads() -> set[str]:
+    """Recover the environment variable names the source tree reads.
+
+    Args:
+        None.
+
+    Returns:
+        Every name appearing in an ``os.environ.get``, ``os.getenv`` or
+        ``os.environ[...]`` expression under ``src/`` or ``tests/``.
+    """
+    sources = (*(REPO_ROOT / "src").rglob("*.py"), *(REPO_ROOT / "tests").rglob("*.py"))
+    names: set[str] = set()
+    for source in sources:
+        for getter, subscript in ENVIRONMENT_READ_PATTERN.findall(
+            source.read_text(encoding="utf-8")
+        ):
+            names.add(getter or subscript)
+    return names
+
+
+def _run_suite_in_child(probe_path: Path) -> subprocess.CompletedProcess[str]:
+    """Run the whole suite in a child process, excluding this module.
+
+    The child is pointed at the committed ``pyproject.toml`` with ``-c`` and run
+    from the repository root, so it collects the same tests an ordinary
+    ``pytest`` invocation does. ``encoding`` is stated rather than left to the
+    locale, which on Windows is cp1252 and has undefined bytes; the child is told
+    to write UTF-8, so the parent must be told to read it.
+
+    Args:
+        probe_path: Where the probe plugin writes its JSON result.
+
+    Returns:
+        The completed child, with ``stdout`` and ``stderr`` captured as text.
+
+    Raises:
+        Failed: When the child has not exited within
+            :data:`CHILD_TIMEOUT_SECONDS`. Reported through :func:`pytest.fail`
+            rather than as a bare :class:`subprocess.TimeoutExpired` traceback,
+            so the one path here that can hang still explains itself.
+    """
+    try:
+        return subprocess.run(
+            _child_command(probe_path),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            cwd=REPO_ROOT,
+            env=_child_environment(),
+            timeout=CHILD_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as expired:
+        pytest.fail(
+            f"The child pytest run did not finish within {CHILD_TIMEOUT_SECONDS}s; "
+            "it normally takes about fourteen. Partial output:\n"
+            f"{expired.stdout or ''}\n{expired.stderr or ''}"
+        )
+
+
+def _probe_results(probe_path: Path) -> dict[str, set[str]]:
+    """Read the probe plugin's JSON output.
+
+    Args:
+        probe_path: The file the child was told to write.
+
+    Returns:
+        The ``collected``, ``failed`` and ``skipped`` node-id sets.
+
+    Raises:
+        AssertionError: When the child produced no file, which means the plugin
+            never loaded and every comparison below would be vacuous.
+    """
+    assert probe_path.is_file(), (
+        f"The child run wrote no probe output to {probe_path}. The "
+        "'tests._baseline_probe' plugin did not load, so this guard has nothing "
+        "to compare and must not report success."
+    )
+    recorded = json.loads(probe_path.read_text(encoding="utf-8"))
+    return {key: set(value) for key, value in recorded.items()}
+
+
+def _synthetic_ledger(
+    node_ids: list[str], *, recorded: int | None = None, extra_block: bool = False
+) -> str:
+    """Build a minimal document for exercising the parsers.
+
+    The structural checks are properties of the parsers, and a property nothing
+    executes is an observation someone once made. Feeding the parsers documents
+    built here keeps each rejection a test.
+
+    Args:
+        node_ids: The ids to place in the block.
+        recorded: The failure count to state; defaults to ``len(node_ids)``.
+        extra_block: When true, add a second fenced block to the section.
+
+    Returns:
+        A document with a single ``## Linux`` platform section.
+    """
+    stated = len(node_ids) if recorded is None else recorded
+    listing = "\n".join(node_ids)
+    second = "\n```text\nstray\n```\n" if extra_block else ""
+    return (
+        "# Synthetic\n\n## Linux\n\n"
+        f"- **Result:** {stated} failed, 1 passed\n\n"
+        f"```text\n{listing}\n```\n{second}"
+    )
+
+
+def _assert_block_is_sorted_and_unique(text: str, heading: str) -> None:
+    """Assert one platform's block is a set written in one canonical order.
+
+    Sorted order is required so that a repair step's diff shows exactly the lines
+    it removed. An unsorted list reorders under editing and buries a one-line
+    change in a whole-block rewrite.
+
+    Shared by the check that runs against the real document and the one that runs
+    against synthetic documents, so the synthetic cases exercise the shipped
+    assertion rather than a restatement of it that could drift from it.
+
+    Args:
+        text: The whole document.
+        heading: The platform section's heading line.
+
+    Raises:
+        AssertionError: When the block is unsorted or holds a duplicate.
+    """
+    node_ids = _ledger_node_ids(text, heading)
+    assert node_ids == sorted(set(node_ids)), (
+        f"Section '{heading}' of {LEDGER_PATH.name} must list its node ids "
+        "sorted and without duplicates. Expected:\n" + "\n".join(sorted(set(node_ids)))
+    )
+
+
+def _assert_count_matches_node_ids(text: str, heading: str) -> None:
+    """Assert one platform's stated failure count equals the length of its list.
+
+    The count comes from the recorded run and the list is maintained by hand, so
+    they drift the moment someone deletes an id without touching the summary --
+    which is exactly what the repair steps will be doing.
+
+    Args:
+        text: The whole document.
+        heading: The platform section's heading line.
+
+    Raises:
+        AssertionError: When the ``Result`` line and the block disagree.
+    """
+    node_ids = _ledger_node_ids(text, heading)
+    recorded = _recorded_failure_count(text, heading)
+    assert recorded == len(node_ids), (
+        f"Section '{heading}' of {LEDGER_PATH.name} records {recorded} failures "
+        f"but lists {len(node_ids)} node ids."
+    )
+
+
+def test_ledger_documents_every_platform_the_guard_knows() -> None:
+    """Assert the document's platform sections match this module's table.
+
+    Checked in both directions. A section removed from the document would
+    otherwise leave the platform it covered silently unguarded, and a section
+    added without a table entry would never be compared against anything.
+    """
+    documented = _documented_platform_headings(_ledger_text())
+    expected = set(LEDGER_PLATFORMS.values())
+    assert documented == expected, (
+        f"{LEDGER_PATH.name} documents platform sections {sorted(documented)} "
+        f"but this guard knows {sorted(expected)}. Sections and table entries "
+        "are added together, or one of them guards nothing."
+    )
+
+
+@pytest.mark.parametrize("heading", sorted(LEDGER_PLATFORMS.values()))
+def test_ledger_block_is_sorted_and_free_of_duplicates(heading: str) -> None:
+    """Assert one platform's block is sorted and holds no duplicate.
+
+    Args:
+        heading: The platform section to check, injected by parametrisation.
+    """
+    _assert_block_is_sorted_and_unique(_ledger_text(), heading)
+
+
+@pytest.mark.parametrize("heading", sorted(LEDGER_PLATFORMS.values()))
+def test_ledger_count_matches_its_node_ids(heading: str) -> None:
+    """Assert one platform's stated failure count matches its list.
+
+    Args:
+        heading: The platform section to check, injected by parametrisation.
+    """
+    _assert_count_matches_node_ids(_ledger_text(), heading)
+
+
+def test_documented_platform_difference_explains_the_two_blocks() -> None:
+    """Assert the two platforms' blocks differ by exactly what the document says.
+
+    The blocks overlap by construction -- the same stale tests fail on both -- so
+    every repair must delete its ids from both. Only one block's live comparison
+    can run on any one machine, and there is no Windows lane in CI, so a repair
+    that drains Linux and forgets Windows would otherwise pass every check that
+    actually executes. This one runs everywhere.
+    """
+    text = _ledger_text()
+    linux = set(_ledger_node_ids(text, LEDGER_PLATFORMS["linux"]))
+    windows = set(_ledger_node_ids(text, LEDGER_PLATFORMS["win32"]))
+    for platform, exclusive in (("linux", linux - windows), ("win32", windows - linux)):
+        documented = _documented_platform_only_ids(text, platform)
+        assert sorted(exclusive) == documented, (
+            f"The ledger's blocks differ on {platform} by {sorted(exclusive)}, "
+            f"but '{DIFFERENCE_HEADING}' explains {documented}. Every difference "
+            "between the two platforms needs a stated reason, or a half-drained "
+            "repair reads as a platform quirk."
+        )
+
+
+def test_ledger_documents_the_measurement_command(tmp_path: Path) -> None:
+    """Assert the document records the exact run the baseline describes.
+
+    A failing set means nothing without the selection that produced it. Today an
+    unfiltered run is the whole suite, but later workstreams apply the ``live``,
+    ``chromium`` and ``package`` markers, at which point a different selection
+    yields a different baseline. Recording the argv makes any such change a
+    visible, deliberate edit to this document rather than a silent redefinition.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory, used only to supply a
+            placeholder path to the renderer.
+    """
+    documented = _fenced_block(_ledger_text(), COMMAND_HEADING, "console").strip()
+    actual = _normalised_child_command(tmp_path / "probe.json")
+    assert documented == actual, (
+        f"Section '{COMMAND_HEADING}' of {LEDGER_PATH.name} records\n"
+        f"  {documented}\nbut this guard runs\n  {actual}"
+    )
+
+
+def test_child_environment_drops_every_variable_the_project_reads() -> None:
+    """Assert the sweep covers every environment variable the source tree reads.
+
+    The sweep is a deny-list over a surface of roughly fifty variables, and a
+    hand-written deny-list of a moving target rots. Rather than trust it, the
+    names are recovered from the source and each is required to be absent from
+    the environment the child would be given. Each is planted first, so the check
+    fails on a clean machine too rather than only on one that happens to export
+    the variable in question.
+    """
+    names = _environment_variables_the_project_reads()
+    assert names, (
+        "No environment reads were found under src/ or tests/. The scan pattern "
+        "has stopped matching, so this check would pass vacuously."
+    )
+    original = os.environ.copy()
+    os.environ.update({name: "planted" for name in names})
+    try:
+        survivors = sorted(names & set(_child_environment()))
+    finally:
+        os.environ.clear()
+        os.environ.update(original)
+    assert not survivors, (
+        "The child run would inherit project environment variables "
+        f"{survivors}, so its failing set is steerable from outside. Add each to "
+        "CLEARED_ENVIRONMENT_PREFIXES or CLEARED_ENVIRONMENT_NAMES."
+    )
+
+
+@pytest.mark.parametrize(
+    ("text", "expectation"),
+    [
+        pytest.param(_synthetic_ledger(["b::t", "a::t"]), "sorted", id="unsorted"),
+        pytest.param(_synthetic_ledger(["a::t", "a::t"]), "sorted", id="duplicated"),
+        pytest.param(
+            _synthetic_ledger(["a::t"], recorded=9), "records 9", id="count-mismatch"
+        ),
+        pytest.param(
+            _synthetic_ledger(["a::t"], extra_block=True),
+            "requires exactly one",
+            id="two-blocks",
+        ),
+        pytest.param(
+            "# Synthetic\n\n## Windows\n\n- **Result:** 0 failed\n\n```text\n```\n",
+            "no longer contains",
+            id="missing-heading",
+        ),
+    ],
+)
+def test_parsers_reject_a_malformed_section(text: str, expectation: str) -> None:
+    """Assert each malformed document shape is rejected, with a legible message.
+
+    These are the shapes a repair step will actually produce -- a deleted id
+    without a count change, a hand-reordered block -- so they are exercised
+    against synthetic documents rather than confirmed once by hand against the
+    real one.
+
+    Args:
+        text: The synthetic document.
+        expectation: A phrase the rejection message must contain.
+    """
+    heading = "## Linux"
+    with pytest.raises(AssertionError, match=expectation):
+        _assert_block_is_sorted_and_unique(text, heading)
+        _assert_count_matches_node_ids(text, heading)
+
+
+def test_parsers_accept_a_drained_section() -> None:
+    """Assert an empty block with a zero count is valid.
+
+    The drained state occurs exactly once, at the milestone, when it matters
+    most. A parser that rejected it would turn the moment the suite goes green
+    into a debugging session.
+    """
+    text = _synthetic_ledger([])
+    _assert_block_is_sorted_and_unique(text, "## Linux")
+    _assert_count_matches_node_ids(text, "## Linux")
+    assert _ledger_node_ids(text, "## Linux") == []
+
+
+@pytest.mark.subsystem
+@pytest.mark.slow
+def test_live_outcome_matches_the_ledger(tmp_path: Path) -> None:
+    """Assert a real run fails at exactly the node ids the ledger names.
+
+    The check the whole file exists for. It runs the suite in a child process and
+    compares, so it is measuring behaviour rather than re-reading the document.
+
+    Four outcomes are reported separately because they call for opposite fixes,
+    and a single set-inequality message would be the wrong thing to read at three
+    in the morning: a failure the ledger does not list is a regression; a listed
+    id that no longer exists is a deleted or renamed test, not a repair; a listed
+    id that now skips is a test that stopped running; and only a listed id that
+    ran and passed is a repair whose entry should be deleted.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory, where the child's probe
+            output is written.
+    """
+    # Nothing to compare against on a platform nobody measured. Skipping loudly
+    # beats passing silently: a guard that cannot fail is indistinguishable from
+    # no guard.
+    if sys.platform not in LEDGER_PLATFORMS:
+        pytest.skip(
+            f"{LEDGER_PATH.name} records no baseline for sys.platform="
+            f"{sys.platform!r}; it covers {sorted(LEDGER_PLATFORMS)}."
+        )
+
+    probe_path = tmp_path / "probe.json"
+    completed = _run_suite_in_child(probe_path)
+    # Exit 0 means the ledger should be empty and exit 1 means it should not;
+    # both are compared below. Any other code -- 2 for a collection error, 3 for
+    # an internal error, 4 for a usage error -- means the child never produced a
+    # comparable result, so it is reported as itself rather than as a mismatch.
+    assert completed.returncode in (0, 1), (
+        f"The child pytest run exited {completed.returncode}, so it produced no "
+        "comparable outcome.\n"
+        f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+    )
+
+    outcome = _probe_results(probe_path)
+    # Exit 1 means pytest counted at least one failure, so a recording that found
+    # none has gone blind -- which is exactly how an earlier, summary-parsing
+    # version of this guard missed subtest failures entirely. Cheap, and it fails
+    # loudly rather than reporting an empty set as good news.
+    assert (completed.returncode == 1) == bool(outcome["failed"]), (
+        f"The child exited {completed.returncode} but the probe recorded "
+        f"{len(outcome['failed'])} failing node ids. The two disagree, so the "
+        "recording path is broken and its result must not be trusted.\n"
+        f"stdout:\n{completed.stdout}"
+    )
+
+    documented = set(_ledger_node_ids(_ledger_text(), LEDGER_PLATFORMS[sys.platform]))
+    complaints = {
+        "Failing but not in the ledger (a regression; fix the test, do not add "
+        "the id)": sorted(outcome["failed"] - documented),
+        "In the ledger but no longer collected (deleted or renamed, not "
+        "repaired; an id may leave this ledger only by passing)": sorted(
+            documented - outcome["collected"]
+        ),
+        "In the ledger and now skipped (it stopped running; that is not a "
+        "repair either)": sorted(documented & outcome["skipped"]),
+        "In the ledger, ran, and passed (a repair; delete the id)": sorted(
+            documented & outcome["collected"] - outcome["failed"] - outcome["skipped"]
+        ),
+    }
+    reported = {title: ids for title, ids in complaints.items() if ids}
+    assert not reported, (
+        f"The live run disagrees with {LEDGER_PATH.name} on {sys.platform}.\n"
+        + "\n".join(
+            f"{title}:\n  " + "\n  ".join(ids) for title, ids in reported.items()
+        )
+    )

--- a/tests/test_baseline_failure_ledger.py
+++ b/tests/test_baseline_failure_ledger.py
@@ -43,11 +43,13 @@ and deleting it would give the twelve repaired tests room to rot again.
 
 from __future__ import annotations
 
+import ast
 import json
 import os
 import re
 import subprocess
 import sys
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -95,6 +97,7 @@ COMMAND_HEADING = "## The measurement command"
 # the variables the source tree actually reads and asserts that none survives
 # this sweep. That is what keeps the sweep honest as variables are added.
 CLEARED_ENVIRONMENT_PREFIXES = (
+    "PYTHON",
     "KINDLY_",
     "SEARXNG_",
     "FASTMCP_",
@@ -114,12 +117,46 @@ CLEARED_ENVIRONMENT_NAMES = (
     "TAVILY_API_KEY",
     "LOG_LEVEL",
     "NO_PROXY",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "BROWSER_EXECUTABLE_PATH",
+    "CHROME_BIN",
+    "CHROME_PATH",
 )
 
-# Matches the three forms this repository reads an environment variable through.
-ENVIRONMENT_READ_PATTERN = re.compile(
-    r"""os\.(?:environ\.get|getenv)\(["']([A-Z][A-Z0-9_]*)["']"""
-    r"""|os\.environ\[["']([A-Z][A-Z0-9_]*)["']"""
+# An environment variable name, by shape: upper case with at least one
+# underscore. Every string literal in the tree of this shape is treated as a
+# candidate, rather than only those appearing inside an ``os.environ.get("...")``
+# call. Anchoring on the call form was measured wrong: this repository reads
+# ``CHROME_BIN``, ``CHROME_PATH``, ``BROWSER_EXECUTABLE_PATH`` and ``no_proxy``
+# through a *loop variable* over a tuple of literals, and reads others through
+# ``_get_int_env(key, ...)`` helpers, so no call-site pattern can see them. A
+# shape scan over-collects instead, which is the safe direction: a name that is
+# not an environment variable costs one allow-list entry, while a name that is
+# and was missed costs a silently steerable baseline.
+ENVIRONMENT_NAME_SHAPE = re.compile(r"^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+$")
+
+# Literals of that shape which are not environment variables. Each has to be
+# named here deliberately, which is what makes the scan un-rottable: a new
+# environment variable added to the tree is either swept or fails the check, and
+# the only way to silence it is to claim in this list that it is not one.
+NOT_ENVIRONMENT_VARIABLES = frozenset(
+    {
+        # Windows process-creation and ShowWindow constants.
+        "CREATE_NEW_PROCESS_GROUP",
+        "CREATE_NO_WINDOW",
+        "STARTF_USESHOWWINDOW",
+        "SW_HIDE",
+        # A GitHub reaction name.
+        "THUMBS_UP",
+        # Fixture values in the diagnostics-masking and GitHub tests.
+        "AUTH_BEARER",
+        "SOME_URL",
+        "C_1",
+        "D_1",
+        "R_1",
+    }
 )
 
 # Generous next to the 120 seconds the other child-process guards allow, because
@@ -332,34 +369,41 @@ def _child_environment() -> dict[str, str]:
     Returns:
         The environment the child is spawned with.
     """
+    # Matched upper-cased: ``nodriver_worker`` reads both ``NO_PROXY`` and
+    # ``no_proxy``, and a case-sensitive sweep would drop one and keep the other.
     environment = {
         name: value
         for name, value in os.environ.items()
-        if not name.startswith(CLEARED_ENVIRONMENT_PREFIXES)
-        and name not in CLEARED_ENVIRONMENT_NAMES
+        if not name.upper().startswith(CLEARED_ENVIRONMENT_PREFIXES)
+        and name.upper() not in CLEARED_ENVIRONMENT_NAMES
     }
     environment["PYTHONIOENCODING"] = "utf-8"
     return environment
 
 
 def _environment_variables_the_project_reads() -> set[str]:
-    """Recover the environment variable names the source tree reads.
+    """Recover the environment variable names the source tree could read.
 
-    Args:
-        None.
+    Parsed rather than grepped, so a name inside a comment cannot register while
+    one built across a line continuation goes missing.
 
     Returns:
-        Every name appearing in an ``os.environ.get``, ``os.getenv`` or
-        ``os.environ[...]`` expression under ``src/`` or ``tests/``.
+        Every string literal under ``src/`` or ``tests/`` shaped like an
+        environment variable name, less those declared in
+        :data:`NOT_ENVIRONMENT_VARIABLES`.
     """
     sources = (*(REPO_ROOT / "src").rglob("*.py"), *(REPO_ROOT / "tests").rglob("*.py"))
     names: set[str] = set()
     for source in sources:
-        for getter, subscript in ENVIRONMENT_READ_PATTERN.findall(
-            source.read_text(encoding="utf-8")
-        ):
-            names.add(getter or subscript)
-    return names
+        tree = ast.parse(source.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Constant)
+                and isinstance(node.value, str)
+                and ENVIRONMENT_NAME_SHAPE.match(node.value)
+            ):
+                names.add(node.value)
+    return names - NOT_ENVIRONMENT_VARIABLES
 
 
 def _run_suite_in_child(probe_path: Path) -> subprocess.CompletedProcess[str]:
@@ -389,6 +433,7 @@ def _run_suite_in_child(probe_path: Path) -> subprocess.CompletedProcess[str]:
             capture_output=True,
             text=True,
             encoding="utf-8",
+            errors="replace",
             cwd=REPO_ROOT,
             env=_child_environment(),
             timeout=CHILD_TIMEOUT_SECONDS,
@@ -593,9 +638,13 @@ def test_child_environment_drops_every_variable_the_project_reads() -> None:
         "has stopped matching, so this check would pass vacuously."
     )
     original = os.environ.copy()
+    # Both cases, since the reads are not all upper case and the sweep claims to
+    # cover either.
     os.environ.update({name: "planted" for name in names})
+    os.environ.update({name.lower(): "planted" for name in names})
     try:
-        survivors = sorted(names & set(_child_environment()))
+        surviving = {name.upper() for name in _child_environment()}
+        survivors = sorted(names & surviving)
     finally:
         os.environ.clear()
         os.environ.update(original)
@@ -607,26 +656,43 @@ def test_child_environment_drops_every_variable_the_project_reads() -> None:
 
 
 @pytest.mark.parametrize(
-    ("text", "expectation"),
+    ("text", "check", "expectation"),
     [
-        pytest.param(_synthetic_ledger(["b::t", "a::t"]), "sorted", id="unsorted"),
-        pytest.param(_synthetic_ledger(["a::t", "a::t"]), "sorted", id="duplicated"),
         pytest.param(
-            _synthetic_ledger(["a::t"], recorded=9), "records 9", id="count-mismatch"
+            _synthetic_ledger(["b::t", "a::t"]),
+            _assert_block_is_sorted_and_unique,
+            "sorted",
+            id="unsorted",
+        ),
+        pytest.param(
+            _synthetic_ledger(["a::t", "a::t"]),
+            _assert_block_is_sorted_and_unique,
+            "sorted",
+            id="duplicated",
+        ),
+        pytest.param(
+            _synthetic_ledger(["a::t"], recorded=9),
+            _assert_count_matches_node_ids,
+            "records 9",
+            id="count-mismatch",
         ),
         pytest.param(
             _synthetic_ledger(["a::t"], extra_block=True),
+            _assert_block_is_sorted_and_unique,
             "requires exactly one",
             id="two-blocks",
         ),
         pytest.param(
             "# Synthetic\n\n## Windows\n\n- **Result:** 0 failed\n\n```text\n```\n",
+            _assert_block_is_sorted_and_unique,
             "no longer contains",
             id="missing-heading",
         ),
     ],
 )
-def test_parsers_reject_a_malformed_section(text: str, expectation: str) -> None:
+def test_parsers_reject_a_malformed_section(
+    text: str, check: Callable[[str, str], None], expectation: str
+) -> None:
     """Assert each malformed document shape is rejected, with a legible message.
 
     These are the shapes a repair step will actually produce -- a deleted id
@@ -634,14 +700,17 @@ def test_parsers_reject_a_malformed_section(text: str, expectation: str) -> None
     against synthetic documents rather than confirmed once by hand against the
     real one.
 
+    The assertion under test is a parameter rather than a call chain: with both
+    helpers invoked in sequence, only the count case ever reached the second, and
+    nothing said so.
+
     Args:
         text: The synthetic document.
+        check: The assertion this shape is expected to trip.
         expectation: A phrase the rejection message must contain.
     """
-    heading = "## Linux"
     with pytest.raises(AssertionError, match=expectation):
-        _assert_block_is_sorted_and_unique(text, heading)
-        _assert_count_matches_node_ids(text, heading)
+        check(text, "## Linux")
 
 
 def test_parsers_accept_a_drained_section() -> None:
@@ -718,7 +787,7 @@ def test_live_outcome_matches_the_ledger(tmp_path: Path) -> None:
             documented - outcome["collected"]
         ),
         "In the ledger and now skipped (it stopped running; that is not a "
-        "repair either)": sorted(documented & outcome["skipped"]),
+        "repair either)": sorted(documented & outcome["skipped"] - outcome["failed"]),
         "In the ledger, ran, and passed (a repair; delete the id)": sorted(
             documented & outcome["collected"] - outcome["failed"] - outcome["skipped"]
         ),

--- a/tests/test_baseline_failure_ledger.py
+++ b/tests/test_baseline_failure_ledger.py
@@ -126,7 +126,14 @@ CLEARED_ENVIRONMENT_NAMES = (
 )
 
 # An environment variable name, by shape: upper case with at least one
-# underscore. Every string literal in the tree of this shape is treated as a
+# underscore. Upper case **only**, deliberately. Widening the shape to lower case
+# was measured before being rejected: it admits 139 more literals, of which 137
+# have no upper-case counterpart anywhere in the tree and are ordinary dictionary
+# keys and field names. That would trade a precise check for a 137-entry
+# allow-list nobody maintains -- rot arriving faster than the rot it prevents.
+# The lower-case reads this project does have (``no_proxy``) are covered from the
+# other side instead: :func:`_child_environment` matches upper-cased, so one
+# listed name covers both spellings, and the check below plants both. Every string literal in the tree of this shape is treated as a
 # candidate, rather than only those appearing inside an ``os.environ.get("...")``
 # call. Anchoring on the call form was measured wrong: this repository reads
 # ``CHROME_BIN``, ``CHROME_PATH``, ``BROWSER_EXECUTABLE_PATH`` and ``no_proxy``
@@ -648,6 +655,16 @@ def test_child_environment_drops_every_variable_the_project_reads() -> None:
     finally:
         os.environ.clear()
         os.environ.update(original)
+    # An explicit control for the case that motivated the case-insensitive match.
+    # The scan's shape is upper case only, so `no_proxy` can never arrive through
+    # `names`; naming it here means the one lower-case variable this project
+    # actually reads has a test of its own rather than incidental coverage.
+    assert "no_proxy" not in _child_environment(), (
+        "`no_proxy` survives the sweep. It is read at scrape/nodriver_worker.py "
+        "and scrape/universal_html.py alongside `NO_PROXY`, and the sweep is "
+        "case-insensitive precisely so that listing the upper-case name covers "
+        "both spellings."
+    )
     assert not survivors, (
         "The child run would inherit project environment variables "
         f"{survivors}, so its failing set is steerable from outside. Add each to "

--- a/tests/test_pytest_configuration.py
+++ b/tests/test_pytest_configuration.py
@@ -485,9 +485,11 @@ def test_registered_marker_is_collected(tmp_path: Path) -> None:
     """Assert a registered marker still runs -- the control for the case above
 
     Without this, :func:`test_unregistered_marker_fails_collection` would pass
-    against a configuration that broke collection for any reason at all. It is
-    also the only user of the ``slow`` marker until the suite grows a test that
-    earns it.
+    against a configuration that broke collection for any reason at all. It was
+    the only user of the ``slow`` marker until
+    :func:`tests.test_baseline_failure_ledger.test_live_outcome_matches_the_ledger`
+    earned one by spawning a child run of the whole suite; it remains the only
+    synthetic one.
 
     Args:
         tmp_path: pytest's per-test temporary directory.


### PR DESCRIPTION
## Context for the Product Owner

This project's test suite has twelve tests that have been failing for a long
time. The team has learned to read past the red, which is a slow-acting problem:
once a suite is permanently red, a *new* breakage looks exactly like the old
noise, and nothing stops it merging.

Four upcoming tickets each repair a slice of that. The difficulty is that "twelve
failures went to nine" does not prove three were fixed — it is equally consistent
with four fixed and one newly broken. A count cannot tell those apart.

This PR builds the accounting record that can: a ledger naming each failing test
individually, per operating system, plus an automatic check that compares the
ledger against a real run every time the suite executes. From here on, each
repair must delete exactly the tests it fixed and no others, and the check
enforces it. When the ledger empties, the suite is green — those are the same
statement, so the milestone verifies itself rather than needing a separate
inspection.

One deliberate cost: the suite now takes about 26 seconds instead of 12, because
the check runs the suite a second time in a child process. That trade-off is
recorded in the ledger rather than left for someone to discover.

---

## What plan step E1-1 asked for

Measure the baseline on Linux — the design document predicted it from source but
had never run it — and record both platforms as **exact failing test ids**, not
counts.

## What was measured

Both platforms, at commit `3af0563`:

| Platform | Result |
|---|---|
| Linux (Ubuntu 24.04, CPython 3.13.15) | **12 failed**, 303 passed, 2 skipped |
| Windows (Server 2025, CPython 3.13.15) | **11 failed**, 303 passed, 3 skipped |

The prediction holds. Windows is the Linux twelve minus the root-detection test
it skips, and the two runs reconcile arithmetically: the same 303 passing, with
that one test counting as a failure on Linux and as the third skip on Windows.

The Windows number came from a throwaway `windows-latest` workflow on a branch of
its own, deleted as soon as the numbers were recorded. It touched neither
`ci.yml` nor any workflow region §1.3 serialises. **It is not the Windows CI
lane** — that belongs to the CI epic. It was an instrument, used once.

## What is in the diff

| File | Role |
|---|---|
| `.system_design/BASELINE_FAILURES.md` | The ledger — ids, counts, environment, commit, and the reasoning behind each choice |
| `tests/test_baseline_failure_ledger.py` | 15 checks; the load-bearing one re-runs the suite in a child process and compares |
| `tests/_baseline_probe.py` | Child-side plugin recording the run's outcomes |
| `.system_design/TEST_SUITE.md` | §1.1's POSIX figure changed from predicted to measured; §8 points at the ledger |
| `.github/review/rules/python-tests.md` | New guard registered as load-bearing; count corrected to eight |
| `pyproject.toml` | The `slow` marker's comment no longer claims it has no real user |

## Two findings from review that changed the design

**The first version could go green on a red suite.** It read results from
pytest's short summary. On pytest 9.1.1 a failing `unittest` subtest prints a
*passing* dot in the progress line and a `SUBFAILED` line in the summary — never
the word `FAILED`. A summary parser therefore reports an empty failing set while
the suite is red, in exactly the drained end-state this guard exists to certify.
Two of this repository's three `subTest` sites sit in a file the ledger tracks.
Results now come from a plugin reading pytest's own report objects, and the
child's exit code is cross-checked against what the plugin recorded, so the same
class of blindness fails loudly instead of passing quietly.

**An id could leave the ledger without being repaired.** Deleting a test,
renaming its class, or marking it skipped all remove it from the failing set and
all look identical to a fix. The child now reports its collected and skipped sets
too, and those three outcomes are named separately from a genuine repair.

## How the checks were shown to work

Every check was watched failing before being accepted, by mutating either the
document or the guard: deleting an id, adding one that does not exist, corrupting
the count, unsorting a block, dropping a platform section, half-draining a repair
across the two platforms, drifting the documented command, dropping a name from
the environment sweep, removing the probe plugin, skipping a documented test, and
polluting the parent environment.

That last one is not hypothetical: with `RUN_LIVE_TESTS=1` exported, an
un-normalised child run picks up a thirteenth failure from a live network test.
The child's environment is swept of everything this project reads, and a check
recovers those variable names from the source tree so the sweep cannot quietly
rot as variables are added.

## Verification

- Failing set **unchanged** from the pre-change baseline — the sorted `FAILED`
  lines diff clean. Counts move only by the 15 passing tests this PR adds:
  `12 failed, 318 passed, 2 skipped`.
- The review system's own 482 tests pass.
- `ruff check` clean on both new modules; `ruff format` clean.
- `scripts/check_plan_dag.py` exits 0.
