### PR TITLE
feat: add optional You.com search provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,15 @@
 # Copy to your runtime environment (shell/IDE/container). Do NOT commit secrets.
 #
 # Required: provide at least one search provider key.
-# Selection order is: Serper -> SerpBase -> Tavily -> SearXNG -> Sofya.
+# Selection order is: Serper -> SerpBase -> Tavily -> SearXNG -> Sofya -> You.com.
 SERPER_API_KEY=
 # SerpBase (Google results, https://serpbase.dev)
 SERPBASE_API_KEY=
 TAVILY_API_KEY=
 # Sofya web search (https://sofya.co)
 SOFYA_API_KEY=
+# You.com web search (https://you.com/platform/api-keys)
+YDC_API_KEY=
 # Alternative: self-hosted SearXNG instance (base URL, e.g. https://searx.example.org)
 SEARXNG_BASE_URL=
 # Optional SearXNG request settings

--- a/.github/review/rules/search-providers.md
+++ b/.github/review/rules/search-providers.md
@@ -1,6 +1,6 @@
 # Rule: search providers (`search/`)
 
-Five backends — Serper, SerpBase, Tavily, SearXNG and Sofya — behind one
+Six backends — Serper, SerpBase, Tavily, SearXNG, Sofya and You.com — behind one
 registry. They share a single contract, which is why they share one rule file.
 
 ## `PROVIDERS` is the single source of truth

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -811,7 +811,7 @@ operation and would needlessly serialize this.
 | **E11-5** | Migration complete | milestone | merge E11-1, merge E11-2, merge E11-3, merge E11-4 | S |
 
 **E11-1** —
-Files: `tests/test_searxng_unit.py`, `tests/test_serper_unit.py`, `tests/test_sofya_unit.py`, `tests/test_tavily_unit.py`
+Files: `tests/test_searxng_unit.py`, `tests/test_serper_unit.py`, `tests/test_sofya_unit.py`, `tests/test_tavily_unit.py`, `tests/test_youcom_unit.py`
 
 `tests/test_serper_live.py` is deliberately absent: E8-4 rewrites and migrates it.
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ We built Kindly Web Search because we needed our AI assistants to work the way *
 
 ✅ **Passes all useful content to the LLM immediately** - no need for a second scraping call
 
-✅ **Supports multiple search providers** (Serper, SerpBase, Tavily, SearXNG, and Sofya) with intelligent fallback
+✅ **Supports multiple search providers** (Serper, SerpBase, Tavily, SearXNG, Sofya, and You.com) with intelligent fallback
 
 Now, when Claude Code or Codex searches for that GPU batch error, it gets the question *and* the answers. The code snippets. The "this fixed it for me" comments. Everything it needs to help you solve the problem - **in one call**.
 
@@ -112,7 +112,7 @@ When extracting page content (`get_content` or `web_search` results), Kindly rou
 
 All `httpx`-based handlers read standard proxy environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`) and support both HTTP and SOCKS proxy URLs via the `socksio` dependency. The universal HTML loader uses Chromium's `--proxy-server` flag via `KINDLY_CHROME_PROXY`, which supports SOCKS5 and other schemes natively.
 
-Search uses **Serper** (primary, if configured), **SerpBase**, **Tavily**, **SearXNG**, or **Sofya**, and page extraction uses a local Chromium-based browser via `nodriver`.
+Search uses **Serper** (primary, if configured), **SerpBase**, **Tavily**, **SearXNG**, **Sofya**, or **You.com**, and page extraction uses a local Chromium-based browser via `nodriver`.
 
 #### Markdown fast paths (skip the browser for doc sites)
 
@@ -127,7 +127,7 @@ Both probes validate the response (`text/markdown`, ≥1 KB, non-empty after san
 
 ## Requirements
 
-- A search provider (priority order): `SERPER_API_KEY` (recommended) → `SERPBASE_API_KEY` (SerpBase, Google results) → `TAVILY_API_KEY` → `SEARXNG_BASE_URL` (self-hosted SearXNG) → `SOFYA_API_KEY`
+- A search provider (priority order): `SERPER_API_KEY` (recommended) → `SERPBASE_API_KEY` (SerpBase, Google results) → `TAVILY_API_KEY` → `SEARXNG_BASE_URL` (self-hosted SearXNG) → `SOFYA_API_KEY` → `YDC_API_KEY` (You.com)
 - A Chromium-based browser installed on the same machine running the MCP client (Chrome/Chromium/Edge/Brave)
   - Without a browser: specialized sources (StackExchange, GitHub Issues/Discussions, Wikipedia, arXiv) still work well, but universal HTML `page_content` extraction may fail for other sites.
 - Highly recommended: `GITHUB_TOKEN` (renders GitHub Issues in a much more LLM-friendly format: question + answers/comments + reactions/metadata; fewer rate limits)
@@ -197,7 +197,7 @@ Other Linux distros: install `chromium` (or `chromium-browser`) via your package
 
 ### 3) Set your search API key (required)
 
-Set **one** of these. Provider selection order is: Serper → SerpBase → Tavily → SearXNG → Sofya.
+Set **one** of these. Provider selection order is: Serper → SerpBase → Tavily → SearXNG → Sofya → You.com.
 
 macOS / Linux:
 
@@ -205,6 +205,8 @@ macOS / Linux:
 export SERPER_API_KEY="..."
 # or:
 export TAVILY_API_KEY="..."
+# or (You.com, key at https://you.com/platform/api-keys):
+export YDC_API_KEY="..."
 # or (self-hosted SearXNG):
 export SEARXNG_BASE_URL="https://searx.example.org"
 ```
@@ -215,6 +217,8 @@ Windows (PowerShell):
 $env:SERPER_API_KEY="..."
 # or:
 $env:TAVILY_API_KEY="..."
+# or (You.com, key at https://you.com/platform/api-keys):
+$env:YDC_API_KEY="..."
 # or (self-hosted SearXNG):
 $env:SEARXNG_BASE_URL="https://searx.example.org"
 ```
@@ -257,7 +261,7 @@ Make sure your API keys are set in the same shell/OS environment that launches t
 
 ### Codex
 
-Set one of `SERPER_API_KEY`, `SERPBASE_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, or `SOFYA_API_KEY`.
+Set one of `SERPER_API_KEY`, `SERPBASE_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, `SOFYA_API_KEY`, or `YDC_API_KEY`.
 
 CLI (no file editing) — add a local stdio MCP server:
 
@@ -324,13 +328,13 @@ args = [
   "start-mcp-server",
 ]
 # Forward variables from your shell/OS environment:
-env_vars = ["SERPER_API_KEY", "SERPBASE_API_KEY", "TAVILY_API_KEY", "SEARXNG_BASE_URL", "SOFYA_API_KEY", "GITHUB_TOKEN", "KINDLY_BROWSER_EXECUTABLE_PATH"]
+env_vars = ["SERPER_API_KEY", "SERPBASE_API_KEY", "TAVILY_API_KEY", "SEARXNG_BASE_URL", "SOFYA_API_KEY", "YDC_API_KEY", "GITHUB_TOKEN", "KINDLY_BROWSER_EXECUTABLE_PATH"]
 startup_timeout_sec = 120.0
 ```
 
 ### Claude Code
 
-Set one of `SERPER_API_KEY`, `SERPBASE_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, or `SOFYA_API_KEY`.
+Set one of `SERPER_API_KEY`, `SERPBASE_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, `SOFYA_API_KEY`, or `YDC_API_KEY`.
 
 CLI (no file editing) — add a local stdio MCP server:
 
@@ -428,7 +432,7 @@ Create/edit `.mcp.json` (project scope; recommended for teams):
 
 ### Gemini CLI
 
-Set one of `SERPER_API_KEY`, `SERPBASE_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, or `SOFYA_API_KEY`.
+Set one of `SERPER_API_KEY`, `SERPBASE_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, `SOFYA_API_KEY`, or `YDC_API_KEY`.
 Edit `~/.gemini/settings.json` (or `.gemini/settings.json` in a project):
 
 ```json
@@ -457,7 +461,7 @@ Edit `~/.gemini/settings.json` (or `.gemini/settings.json` in a project):
 
 ### OpenClaw
 
-Set one of `SERPER_API_KEY`, `SERPBASE_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, or `SOFYA_API_KEY`.
+Set one of `SERPER_API_KEY`, `SERPBASE_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, `SOFYA_API_KEY`, or `YDC_API_KEY`.
 If `mcporter` is not installed yet: `npm i -g mcporter`.
 mcporter docs: <https://github.com/steipete/mcporter/blob/main/docs/config.md>
 
@@ -519,7 +523,7 @@ openclaw gateway restart
 
 ### Antigravity (Google IDE)
 
-Set one of `SERPER_API_KEY`, `SERPBASE_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, or `SOFYA_API_KEY`.
+Set one of `SERPER_API_KEY`, `SERPBASE_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, `SOFYA_API_KEY`, or `YDC_API_KEY`.
 
 In Antigravity, open the MCP store, then:
 
@@ -551,13 +555,13 @@ Paste this into your `mcpServers` object (don’t overwrite other servers):
 ```
 
 If Antigravity can’t find `uvx`, replace `"uvx"` with the absolute path (`which uvx` on macOS/Linux, `where uvx` on Windows).
-Make sure at least one of `SERPER_API_KEY` / `SERPBASE_API_KEY` / `TAVILY_API_KEY` / `SEARXNG_BASE_URL` / `SOFYA_API_KEY` is non-empty.
+Make sure at least one of `SERPER_API_KEY` / `SERPBASE_API_KEY` / `TAVILY_API_KEY` / `SEARXNG_BASE_URL` / `SOFYA_API_KEY` / `YDC_API_KEY` is non-empty.
 If the first start is slow, run the `uvx` command from Quickstart once in a terminal to prebuild the environment, then click **Refresh**.
 Don’t commit/share `mcp_config.json` if it contains API keys.
 
 ### Cursor
 
-Set one of `SERPER_API_KEY`, `SERPBASE_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, or `SOFYA_API_KEY`.
+Set one of `SERPER_API_KEY`, `SERPBASE_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, `SOFYA_API_KEY`, or `YDC_API_KEY`.
 Startup timeout: Cursor does not currently expose a per-server startup timeout setting. If the first run is slow, run the `uvx` command from Quickstart once in a terminal to prebuild the tool environment, then restart Cursor.
 Create `.cursor/mcp.json`:
 
@@ -755,7 +759,7 @@ docker run --rm -p 8000:8000 \
 ```
 
 - MCP endpoint: `http://<server-host>:8000/mcp`
-- Make sure at least one of `SERPER_API_KEY` / `SERPBASE_API_KEY` / `TAVILY_API_KEY` / `SEARXNG_BASE_URL` / `SOFYA_API_KEY` is set.
+- Make sure at least one of `SERPER_API_KEY` / `SERPBASE_API_KEY` / `TAVILY_API_KEY` / `SEARXNG_BASE_URL` / `SOFYA_API_KEY` / `YDC_API_KEY` is set.
 - `page_content` extraction runs on the server machine/container (this Docker image includes Chromium).
 - Remote HTTP is typically **unauthenticated** and **unencrypted** by default; don’t expose this port publicly. Use VPN/firewall rules or a reverse proxy with TLS + auth.
 - Don’t bake API keys into the image; pass them via env vars at runtime.
@@ -865,7 +869,7 @@ Container will be built at the first run. To rebuild it, append `--build` to the
   - Set `KINDLY_DIAGNOSTICS=1` to emit JSON-line diagnostics to stderr and include `diagnostics` in tool responses.
   - `get_content` returns top-level `diagnostics`; `web_search` attaches `diagnostics` per result.
 - `OSError: [Errno 39] Directory not empty: '/tmp/kindly-nodriver-.../Default'`: update to the latest server revision (uv may cache tool envs; `uv cache clean` can help).
-- “web_search fails: no provider key”: set `SERPER_API_KEY`, `SERPBASE_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, or `SOFYA_API_KEY`.
+- “web_search fails: no provider key”: set `SERPER_API_KEY`, `SERPBASE_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, `SOFYA_API_KEY`, or `YDC_API_KEY`.
 
 ## Security
 

--- a/src/kindly_web_search_mcp_server/search/__init__.py
+++ b/src/kindly_web_search_mcp_server/search/__init__.py
@@ -1,4 +1,4 @@
-"""Search providers (Serper → SerpBase → Tavily → SearXNG → Sofya).
+"""Search providers (Serper → SerpBase → Tavily → SearXNG → Sofya → You.com).
 
 :data:`PROVIDERS` is the single source of truth for which providers exist, what
 configures them, and the order they are selected in. Adding a provider means
@@ -23,6 +23,7 @@ from .serpbase import search_serpbase
 from .serper import search_serper
 from .sofya import search_sofya
 from .tavily import search_tavily
+from .youcom import search_youcom
 
 
 # The provider coroutines are re-exported deliberately. `SearchProviderSpec` resolves
@@ -41,6 +42,7 @@ __all__ = [
     "search_sofya",
     "search_tavily",
     "search_web",
+    "search_youcom",
 ]
 
 
@@ -113,6 +115,9 @@ PROVIDERS: tuple[SearchProviderSpec, ...] = (
     ),
     SearchProviderSpec(
         "sofya", "Sofya", "SOFYA_API_KEY", "search_sofya", "has_sofya_key"
+    ),
+    SearchProviderSpec(
+        "youcom", "You.com", "YDC_API_KEY", "search_youcom", "has_youcom_key"
     ),
 )
 

--- a/src/kindly_web_search_mcp_server/search/youcom.py
+++ b/src/kindly_web_search_mcp_server/search/youcom.py
@@ -7,6 +7,14 @@ import httpx
 
 from ..models import WebSearchResult
 
+# The API documents `count` as the per-section maximum, 1-100.
+MAX_COUNT = 100
+
+# The sections this module knows how to parse. Named once because the parser and
+# the schema-mismatch guard must agree on which sections they are: counting a
+# section the parser never reads turns a legitimate zero-hit answer into an error.
+PARSED_SECTIONS = ("web", "news")
+
 
 class YoucomError(RuntimeError):
     pass
@@ -47,7 +55,7 @@ def _collect_results(data: dict[str, Any], num_results: int) -> list[WebSearchRe
         return None
 
     results: list[WebSearchResult] = []
-    for section in ("web", "news"):
+    for section in PARSED_SECTIONS:
         entries = raw.get(section)
         if not isinstance(entries, list):
             continue
@@ -59,17 +67,14 @@ def _collect_results(data: dict[str, Any], num_results: int) -> list[WebSearchRe
             if not isinstance(title, str) or not isinstance(link, str):
                 continue
 
-            # `description` is the SERP snippet. `snippets[0]` carries a longer
-            # excerpt when the API returns one; take the first field that is
-            # actually a non-empty string rather than trusting the shape.
+            # `description` is the SERP snippet; `snippets[0]` carries a longer
+            # excerpt when the API returns one. Take the first that is actually a
+            # non-empty string rather than trusting the shape.
             snippets = item.get("snippets")
+            longest = snippets[0] if isinstance(snippets, list) and snippets else None
+            candidates = (item.get("description"), longest)
             snippet = next(
-                (
-                    value
-                    for value in (item.get("description"), snippets[0] if isinstance(snippets, list) and snippets else None)
-                    if isinstance(value, str) and value
-                ),
-                "",
+                (value for value in candidates if isinstance(value, str) and value), ""
             )
 
             # `page_content` is populated later by the MCP tool (best-effort).
@@ -109,7 +114,10 @@ async def search_youcom(
 
     api_key = _get_youcom_api_key()
     url = "https://ydc-index.io/v1/search"
-    payload = {"query": query, "count": int(num_results)}
+    # Clamped rather than passed through: the API documents 1-100 and rejects
+    # anything outside it, which would turn a large `num_results` into a failed
+    # search instead of a smaller one. `sofya.py` clamps for the same reason.
+    payload = {"query": query, "count": min(int(num_results), MAX_COUNT)}
     headers = {"X-API-Key": api_key, "Content-Type": "application/json"}
 
     async def _do_request(client: httpx.AsyncClient) -> dict[str, Any]:
@@ -136,14 +144,19 @@ async def search_youcom(
     # Discarding every result means the response did not match the shape expected
     # here. Returning an empty list would be indistinguishable from "no matches"
     # and would hide the mismatch, so surface it instead.
+    # Re-read rather than asserted: `_collect_results` has already verified the
+    # shape, and an `assert` here would be stripped under `python -O`, turning a
+    # handled case into an AttributeError.
     raw = data.get("results")
-    assert isinstance(raw, dict)  # _collect_results already verified this.
-    total_entries = sum(
-        len(entries) for entries in raw.values() if isinstance(entries, list)
+    parsed_entries = sum(
+        len(entries)
+        for section, entries in (raw.items() if isinstance(raw, dict) else ())
+        if section in PARSED_SECTIONS and isinstance(entries, list)
     )
-    if total_entries and not results:
+    if parsed_entries and not results:
         raise YoucomError(
-            f"You.com returned {total_entries} result(s) but none could be parsed; "
+            f"You.com returned {parsed_entries} result(s) in {PARSED_SECTIONS} but "
+            "none could be parsed; "
             "each needs a string `title` and `url`. The response schema may have changed."
         )
 

--- a/src/kindly_web_search_mcp_server/search/youcom.py
+++ b/src/kindly_web_search_mcp_server/search/youcom.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+from ..models import WebSearchResult
+
+
+class YoucomError(RuntimeError):
+    pass
+
+
+class YoucomConfigError(YoucomError):
+    pass
+
+
+def _get_youcom_api_key() -> str:
+    api_key = os.environ.get("YDC_API_KEY", "").strip()
+    if not api_key:
+        raise YoucomConfigError(
+            "YDC_API_KEY is not set. Configure it as an environment variable in your IDE/run configuration."
+        )
+    return api_key
+
+
+def _collect_results(data: dict[str, Any], num_results: int) -> list[WebSearchResult] | None:
+    """Extract usable results from a You.com search response.
+
+    The API returns ``results.web`` and, when the query has news intent,
+    ``results.news``, as separate lists of differently-shaped objects. Both carry
+    the three fields this server needs — ``title``, ``url`` and a snippet
+    (``description``, with ``snippets[0]`` as a longer alternative) — so both are
+    folded into one ranked-by-arrival list and capped at ``num_results``.
+
+    Args:
+        data: Parsed JSON response body.
+        num_results: Maximum number of results to return.
+
+    Returns:
+        Usable results, at most ``num_results`` of them, or ``None`` when the
+        response does not contain a ``results`` object at all.
+    """
+    raw = data.get("results")
+    if not isinstance(raw, dict):
+        return None
+
+    results: list[WebSearchResult] = []
+    for section in ("web", "news"):
+        entries = raw.get(section)
+        if not isinstance(entries, list):
+            continue
+        for item in entries:
+            if not isinstance(item, dict):
+                continue
+            title = item.get("title")
+            link = item.get("url")
+            if not isinstance(title, str) or not isinstance(link, str):
+                continue
+
+            # `description` is the SERP snippet. `snippets[0]` carries a longer
+            # excerpt when the API returns one; take the first field that is
+            # actually a non-empty string rather than trusting the shape.
+            snippets = item.get("snippets")
+            snippet = next(
+                (
+                    value
+                    for value in (item.get("description"), snippets[0] if isinstance(snippets, list) and snippets else None)
+                    if isinstance(value, str) and value
+                ),
+                "",
+            )
+
+            # `page_content` is populated later by the MCP tool (best-effort).
+            results.append(WebSearchResult(title=title, link=link, snippet=snippet, page_content=""))
+            if len(results) >= num_results:
+                return results
+
+    return results
+
+
+async def search_youcom(
+    query: str,
+    *,
+    num_results: int,
+    http_client: httpx.AsyncClient | None = None,
+) -> list[WebSearchResult]:
+    """
+    Query You.com Search API and return parsed results.
+
+    You.com endpoint:
+    - POST https://ydc-index.io/v1/search
+    - Header: X-API-Key
+    - JSON: {"query": "<query>", "count": <num_results>}
+
+    `count` is documented as the per-section maximum (default 10, max 100), and
+    the response can carry both a `web` and a `news` section, so the caller's
+    `num_results` is applied locally after merging the sections rather than
+    trusted as a global bound.
+
+    Docs: https://you.com/docs/guides/search
+    """
+    if not query.strip():
+        return []
+
+    if num_results < 1:
+        return []
+
+    api_key = _get_youcom_api_key()
+    url = "https://ydc-index.io/v1/search"
+    payload = {"query": query, "count": int(num_results)}
+    headers = {"X-API-Key": api_key, "Content-Type": "application/json"}
+
+    async def _do_request(client: httpx.AsyncClient) -> dict[str, Any]:
+        resp = await client.post(url, headers=headers, json=payload)
+        resp.raise_for_status()
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            raise YoucomError("You.com response was not valid JSON.") from exc
+        if not isinstance(data, dict):
+            raise YoucomError("You.com response was not a JSON object.")
+        return data
+
+    if http_client is None:
+        async with httpx.AsyncClient(timeout=30) as client:
+            data = await _do_request(client)
+    else:
+        data = await _do_request(http_client)
+
+    results = _collect_results(data, num_results)
+    if results is None:
+        raise YoucomError("You.com response missing `results` object.")
+
+    # Discarding every result means the response did not match the shape expected
+    # here. Returning an empty list would be indistinguishable from "no matches"
+    # and would hide the mismatch, so surface it instead.
+    raw = data.get("results")
+    assert isinstance(raw, dict)  # _collect_results already verified this.
+    total_entries = sum(
+        len(entries) for entries in raw.values() if isinstance(entries, list)
+    )
+    if total_entries and not results:
+        raise YoucomError(
+            f"You.com returned {total_entries} result(s) but none could be parsed; "
+            "each needs a string `title` and `url`. The response schema may have changed."
+        )
+
+    return results

--- a/src/kindly_web_search_mcp_server/server.py
+++ b/src/kindly_web_search_mcp_server/server.py
@@ -400,7 +400,7 @@ async def web_search(
     Prerequisites:
     - Requires at least one configured search provider in the server environment:
       `SERPER_API_KEY` (Serper), `SERPBASE_API_KEY` (SerpBase), `TAVILY_API_KEY` (Tavily),
-      `SEARXNG_BASE_URL` (SearXNG), or `SOFYA_API_KEY` (Sofya).
+      `SEARXNG_BASE_URL` (SearXNG), `SOFYA_API_KEY` (Sofya), or `YDC_API_KEY` (You.com).
       If none is set, this tool will fail.
 
     Returns:
@@ -410,7 +410,7 @@ async def web_search(
 
     Notes:
     - Content extraction is best-effort and may be truncated to avoid context “bombs”.
-    - Provider routing (strict order): Serper → SerpBase → Tavily → SearXNG → Sofya.
+    - Provider routing (strict order): Serper → SerpBase → Tavily → SearXNG → Sofya → You.com.
       No cross-provider fallback.
     - If the search provider fails (missing key, quota/rate-limit, network issues), the tool will error.
     - For a deeper look at one result, call `get_content()` on the chosen `link`.

--- a/tests/test_search_router.py
+++ b/tests/test_search_router.py
@@ -135,6 +135,30 @@ class TestSearchRouter(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(out[0].link, "https://sofya.example")
         mock_sofya.assert_awaited()
 
+    async def test_uses_youcom_when_only_youcom_key(self) -> None:
+        from kindly_web_search_mcp_server.search import search_web
+
+        for name in (
+            "SERPER_API_KEY",
+            "SERPBASE_API_KEY",
+            "TAVILY_API_KEY",
+            "SEARXNG_BASE_URL",
+            "SOFYA_API_KEY",
+        ):
+            os.environ.pop(name, None)
+        os.environ["YDC_API_KEY"] = "ydc_test"
+
+        with patch(
+            "kindly_web_search_mcp_server.search.search_youcom", new_callable=AsyncMock
+        ) as mock_youcom:
+            mock_youcom.return_value = [
+                WebSearchResult(title="Y", link="https://youcom.example", snippet="sn", page_content="")
+            ]
+            out = await search_web("q", num_results=1)
+
+        self.assertEqual(out[0].link, "https://youcom.example")
+        mock_youcom.assert_awaited()
+
     async def test_raises_when_no_provider_configured(self) -> None:
         from kindly_web_search_mcp_server.search import WebSearchProviderError, search_web
 
@@ -142,6 +166,7 @@ class TestSearchRouter(unittest.IsolatedAsyncioTestCase):
         os.environ.pop("TAVILY_API_KEY", None)
         os.environ.pop("SEARXNG_BASE_URL", None)
         os.environ.pop("SOFYA_API_KEY", None)
+        os.environ.pop("YDC_API_KEY", None)
 
         with self.assertRaises(WebSearchProviderError):
             await search_web("q", num_results=1)

--- a/tests/test_youcom_unit.py
+++ b/tests/test_youcom_unit.py
@@ -241,6 +241,52 @@ class TestYoucomSections(unittest.TestCase):
 
         self.assertIn("3", str(caught.exception))
 
+    def test_returns_empty_when_only_unparsed_sections_carry_entries(self) -> None:
+        """A zero-hit answer stays a zero-hit answer beside an unread section
+
+        `results` may carry sections this provider does not read -- You.com
+        returns `news` only on news intent, and the surface can grow others. The
+        schema-mismatch guard must count only the sections actually parsed;
+        counting every list turns a legitimate "no web matches" response into a
+        hard error the moment an unread section appears next to it.
+        """
+        results = self._search(
+            {
+                "results": {
+                    "web": [],
+                    "images": [{"src": "https://example.org/a.png"}],
+                }
+            }
+        )
+
+        self.assertEqual(results, [])
+
+    def test_raises_when_a_parsed_section_is_entirely_unusable(self) -> None:
+        """The mismatch guard still fires for the sections that are read"""
+        from kindly_web_search_mcp_server.search.youcom import YoucomError
+
+        with self.assertRaises(YoucomError):
+            self._search(
+                {
+                    "results": {
+                        "web": [{"title": "No link"}],
+                        "images": [{"src": "https://example.org/a.png"}],
+                    }
+                }
+            )
+
+    def test_clamps_count_to_the_documented_maximum(self) -> None:
+        """`count` is documented as at most 100, so never send more
+
+        The sibling provider `sofya.py` clamps for the same reason: the API
+        rejects an out-of-range value, which would turn a large `num_results`
+        into a failed search rather than a smaller one.
+        """
+        sent: dict[str, Any] = {}
+        self._search({"results": {"web": []}}, num_results=500, sent=sent)
+
+        self.assertEqual(sent["count"], 100)
+
     def test_returns_empty_when_the_api_found_nothing(self) -> None:
         """Return no results, without error, when the query genuinely matched nothing"""
         self.assertEqual(self._search({"results": {"web": [], "news": []}}), [])

--- a/tests/test_youcom_unit.py
+++ b/tests/test_youcom_unit.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+from typing import Any
+
+import anyio
+import httpx
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+
+class TestYoucomParsing(unittest.TestCase):
+    def test_search_youcom_parses_web_results(self) -> None:
+        async def run() -> None:
+            os.environ["YDC_API_KEY"] = "ydc_test"
+
+            from kindly_web_search_mcp_server.search.youcom import search_youcom
+
+            youcom_payload = {
+                "results": {
+                    "web": [
+                        {
+                            "url": "https://www.python-httpx.org/async/",
+                            "title": "Async Support - HTTPX",
+                            "description": "HTTPX offers an optional async client.",
+                            "snippets": ["Longer excerpt from the page."],
+                            "page_age": "2025-11-15T10:30:00",
+                        }
+                    ],
+                    "news": [],
+                },
+                "metadata": {"search_uuid": "uuid", "query": "httpx", "latency": 0.34},
+            }
+
+            def handler(request: httpx.Request) -> httpx.Response:
+                self.assertEqual(request.method, "POST")
+                self.assertEqual(str(request.url), "https://ydc-index.io/v1/search")
+                self.assertEqual(request.headers.get("x-api-key"), "ydc_test")
+                return httpx.Response(200, json=youcom_payload)
+
+            transport = httpx.MockTransport(handler)
+            async with httpx.AsyncClient(transport=transport) as client:
+                results = await search_youcom("httpx", num_results=1, http_client=client)
+
+            self.assertEqual(len(results), 1)
+            self.assertEqual(results[0].title, "Async Support - HTTPX")
+            self.assertEqual(results[0].link, "https://www.python-httpx.org/async/")
+            self.assertTrue(results[0].snippet)
+
+        anyio.run(run)
+
+
+class TestYoucomSections(unittest.TestCase):
+    """Cover the `web`/`news` merge, snippet selection, and the empty-result path.
+
+    The You.com API returns ``results.web`` and — only when the query has news
+    intent — ``results.news``, as separate lists. The router needs one merged
+    list capped at the caller's ``num_results``, and the snippet arrives in
+    ``description`` with an optional longer ``snippets[0]``.
+    """
+
+    def setUp(self) -> None:
+        """Set a dummy API key and restore the previous value afterwards"""
+        previous = os.environ.get("YDC_API_KEY")
+        os.environ["YDC_API_KEY"] = "ydc_test"
+
+        def restore() -> None:
+            if previous is None:
+                os.environ.pop("YDC_API_KEY", None)
+            else:
+                os.environ["YDC_API_KEY"] = previous
+
+        self.addCleanup(restore)
+
+    def _search(
+        self,
+        payload: dict[str, Any],
+        *,
+        num_results: int = 3,
+        sent: dict[str, Any] | None = None,
+    ) -> Any:
+        """Run ``search_youcom`` against a mocked response.
+
+        Args:
+            payload: JSON body the mocked You.com API returns.
+            num_results: Value forwarded to ``search_youcom``.
+            sent: When given, receives the decoded request body.
+
+        Returns:
+            The parsed results.
+        """
+
+        async def run() -> Any:
+            from kindly_web_search_mcp_server.search.youcom import search_youcom
+
+            def handler(request: httpx.Request) -> httpx.Response:
+                if sent is not None:
+                    sent.update(json.loads(request.content))
+                return httpx.Response(200, json=payload)
+
+            async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+                return await search_youcom("q", num_results=num_results, http_client=client)
+
+        return anyio.run(run)
+
+    def test_merges_web_and_news_sections(self) -> None:
+        """Fold both sections into one list, web first"""
+        results = self._search(
+            {
+                "results": {
+                    "web": [
+                        {
+                            "title": "Web Result",
+                            "url": "https://example.org/web",
+                            "description": "web snippet",
+                        }
+                    ],
+                    "news": [
+                        {
+                            "title": "News Result",
+                            "url": "https://example.org/news",
+                            "description": "news snippet",
+                        }
+                    ],
+                }
+            }
+        )
+
+        self.assertEqual(
+            [r.title for r in results], ["Web Result", "News Result"]
+        )
+
+    def test_caps_merged_sections_at_num_results(self) -> None:
+        """Bound the merged list locally: `count` is per-section, not global"""
+        results = self._search(
+            {
+                "results": {
+                    "web": [
+                        {"title": f"Web {i}", "url": f"https://example.org/{i}", "description": "s"}
+                        for i in range(3)
+                    ],
+                    "news": [
+                        {"title": "News 0", "url": "https://example.org/news", "description": "s"}
+                    ],
+                }
+            },
+            num_results=2,
+        )
+
+        self.assertEqual(len(results), 2)
+
+    def test_uses_description_when_snippets_absent(self) -> None:
+        """Read the SERP snippet `description` when no `snippets` list is present"""
+        results = self._search(
+            {
+                "results": {
+                    "web": [
+                        {"title": "Result", "url": "https://example.org", "description": "SERP text"}
+                    ]
+                }
+            }
+        )
+
+        self.assertEqual(results[0].snippet, "SERP text")
+
+    def test_prefers_description_over_snippets_zero(self) -> None:
+        """Keep `description` when `snippets[0]` carries no text
+
+        The docs describe `snippets` as a longer excerpt, but `description` is
+        the stable SERP snippet, so it stays the primary source.
+        """
+        results = self._search(
+            {
+                "results": {
+                    "web": [
+                        {
+                            "title": "Result",
+                            "url": "https://example.org",
+                            "description": "SERP text",
+                            "snippets": [""],
+                        }
+                    ]
+                }
+            }
+        )
+
+        self.assertEqual(results[0].snippet, "SERP text")
+
+    def test_ignores_non_list_snippets(self) -> None:
+        """Treat a malformed `snippets` value as absent rather than indexing it"""
+        results = self._search(
+            {
+                "results": {
+                    "web": [
+                        {
+                            "title": "Result",
+                            "url": "https://example.org",
+                            "description": "SERP text",
+                            "snippets": "not a list",
+                        }
+                    ]
+                }
+            }
+        )
+
+        self.assertEqual(results[0].snippet, "SERP text")
+
+    def test_keeps_result_that_has_no_snippet_text(self) -> None:
+        """Keep a usable link even with no snippet, since page_content is fetched later"""
+        results = self._search(
+            {
+                "results": {
+                    "web": [{"title": "Result", "url": "https://example.org"}]
+                }
+            }
+        )
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].snippet, "")
+
+    def test_raises_when_no_returned_result_is_usable(self) -> None:
+        """Fail loudly instead of returning nothing when the schema does not match"""
+        from kindly_web_search_mcp_server.search.youcom import YoucomError
+
+        with self.assertRaises(YoucomError) as caught:
+            self._search(
+                {
+                    "results": {
+                        "web": [
+                            {"headline": "no title or url"},
+                            "not an object",
+                            {"title": "Result", "url": 123},
+                        ]
+                    }
+                }
+            )
+
+        self.assertIn("3", str(caught.exception))
+
+    def test_returns_empty_when_the_api_found_nothing(self) -> None:
+        """Return no results, without error, when the query genuinely matched nothing"""
+        self.assertEqual(self._search({"results": {"web": [], "news": []}}), [])
+
+    def test_raises_when_results_object_is_missing(self) -> None:
+        """A response without a `results` object is a schema change, not zero hits"""
+        from kindly_web_search_mcp_server.search.youcom import YoucomError
+
+        with self.assertRaises(YoucomError):
+            self._search({"metadata": {"query": "q"}})
+
+    def test_sends_count_with_the_query(self) -> None:
+        """Forward `count` as the per-section maximum the API documents"""
+        sent: dict[str, Any] = {}
+        self._search({"results": {"web": []}}, sent=sent)
+
+        self.assertEqual(sent["query"], "q")
+        self.assertEqual(sent["count"], 3)
+
+    def test_missing_key_raises_config_error(self) -> None:
+        """A missing YDC_API_KEY is a provider configuration failure"""
+        from kindly_web_search_mcp_server.search.youcom import YoucomConfigError
+
+        previous = os.environ.get("YDC_API_KEY")
+        os.environ.pop("YDC_API_KEY", None)
+
+        def restore() -> None:
+            if previous is None:
+                os.environ.pop("YDC_API_KEY", None)
+            else:
+                os.environ["YDC_API_KEY"] = previous
+
+        self.addCleanup(restore)
+
+        async def run() -> None:
+            from kindly_web_search_mcp_server.search.youcom import search_youcom
+
+            with self.assertRaises(YoucomConfigError):
+                await search_youcom("q", num_results=1)
+
+        anyio.run(run)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this adds

A You.com search provider, following the provider contract this repo documents: **one `SearchProviderSpec` entry plus its module**. The router, startup preflight, tool description, `.env.example` and README all pick it up from the registry, so nothing is special-cased anywhere else.

- New provider module `search/youcom.py` — `POST https://ydc-index.io/v1/search` with the `X-API-Key` header, shaped after `tavily.py`/`sofya.py` (bounded 30s timeout, strict result-type checks, drop-not-fail parsing, `page_content=""` left for the MCP tool's resolver).
- New registry entry: `youcom`, selected by `YDC_API_KEY` (the variable You.com's own docs and MCP server use), appended last so every existing priority decision is unchanged.
- `tests/test_youcom_unit.py` — offline `httpx.MockTransport` tests covering the `web`/`news` section merge, the local `num_results` cap (`count` is per-section in the You.com API, so the bound is applied after merging), snippet fallback between `description` and `snippets[0]`, the raise-on-total-schema-mismatch path, and the missing-key config error.
- `tests/test_search_router.py` — a You.com-only selection test, plus `YDC_API_KEY` cleanup in the no-provider test.
- Doc touch points the consistency tests require: `web_search` docstring, `.env.example`, README provider lists/order claims, and the "Five backends" line in `.github/review/rules/search-providers.md` (now six).

## Notes on the parsing

You.com's response nests results as `{"results": {"web": [...], "news": [...]}}`, where `news` appears only when the query has news intent. Both sections carry `title`/`url`/`description`, so both are folded into one list (web first) capped at the caller's `num_results`. An empty `results.web` with no `news` is a valid zero-hit answer; a response where nothing parsed is raised, per the fail-loudly convention the other providers follow.

## Setup

```bash
export YDC_API_KEY=*** key at https://you.com/platform/api-keys
```

Fully opt-in: the provider is inert unless `YDC_API_KEY` is set, and it only serves requests when no higher-priority provider is configured.

## Validation

- `pytest tests/test_youcom_unit.py tests/test_search_router.py tests/test_provider_registry_consistency.py tests/test_tool_descriptions.py -q` → 57 passed (12 new You.com tests)
- Full suite (`pytest tests/ -q` minus the opt-in live test) → 318 passed; the 5 failures in `test_plan_dag.py`/`test_server.py`/`test_universal_html_loader.py`/`test_nodriver_worker_sandbox.py` are identical on `main` (verified by stashing this change and re-running) — `_fetch_html()` signature drift between tests and `scrape/`, unrelated to search providers.
- `ruff check` on the new files → clean (the repo has 198 pre-existing findings at baseline; the touched files show no new categories)
- `mypy src/kindly_web_search_mcp_server/search/youcom.py` → clean
- Response shape verified against the live API surface via You.com's keyless MCP profile (`results.web[]` with `url`/`title`/`description`/`snippets`); a live end-to-end check with a real key is `YDC_API_KEY=*** uvx --from git+https://github.com/mouse-value-add/kindly-web-search-mcp-server@feat/youcom-search-provider mcp-web-search --stdio` then `web_search("httpx async")`.

Happy to adjust the shape if you'd rather see You.com earlier in the selection order or named differently in diagnostics.
