### PR TITLE
Rebuild the browser-startup orchestration tests on autospec doubles (plan step E1-3)

### DIFF
--- a/.system_design/BASELINE_FAILURES.md
+++ b/.system_design/BASELINE_FAILURES.md
@@ -50,13 +50,30 @@ one is a dropped claim, whatever the pull request calls it.
 E1-2 evidenced the table by hand, running the guard in the intermediate state —
 tests deleted, ledger not yet drained — so that it named those five ids as *no
 longer collected* and named nothing else. That is a real proof and it is also a
-one-off: nothing re-runs it. E1-3 and E1-4 rewrite their tests rather than
-relocate them, so their ids change too and they hit the same wall. **Whichever
-of them lands first should make this table machine-readable** — a fenced block
-of `<deleted id> -> <replacement id>` — and assert that every replacement is in
-the child run's *collected* set and absent from its *failed* set. The guard
-already holds both sets; the cost is one assertion, and it converts this
-section from a promise into a check.
+one-off: nothing re-runs it.
+
+**E1-2 predicted that E1-3 and E1-4 would hit the same wall. They do not, and
+the reason is worth keeping.** A step that *rewrites a test in place* keeps its
+node id, so the id leaves this ledger by passing and the rule holds natively
+with no exception and nothing to take on trust. E1-3 rewrote three test bodies
+under their existing names and the guard reported all three under *"In the
+ledger, ran, and passed"* — the strongest of its four categories, and the one
+that needs no supporting document. E1-4 replaces a fixture, so it is in the same
+position.
+
+**The step to watch is E1-5**, which rewrites the concurrency test to be
+OS-neutral. Its id is `test_web_search_concurrency_defaults_on_windows`, and a
+name that still says `on_windows` would be wrong afterwards — so that step
+probably *will* rename, and its id will leave by deletion. It is the remaining
+candidate for making this table machine-readable: a fenced block of
+`<deleted id> -> <replacement id>`, asserted to be in the child run's *collected*
+set and absent from its *failed* set. The guard already holds both sets. If
+E1-5 keeps the name instead, no such machinery is needed at all.
+
+**The rule that generalises: prefer rewriting in place to relocating.** Not for
+tidiness — it is the difference between an id that leaves this ledger under a
+machine-checked category and one that leaves under a promise in a pull request.
+Relocate only when the layer itself is the defect, as it was for E1-2.
 
 Adding an id here is not a way to make a new failure acceptable. A new red test
 is a regression; this ledger names what is left of the pre-existing twelve, and
@@ -179,7 +196,7 @@ an empty failing set on a red suite, and two of this repository's three
 `subTest` sites are in `tests/test_universal_html_loader.py`, one of the files
 this ledger tracks.
 
-## What the remaining seven are
+## What the remaining four are
 
 Grouped by cause, so a reviewer can tell which repair step owns which id. The
 grouping is by module rather than per id, because the blocks are sorted and so
@@ -188,9 +205,12 @@ from it.
 
 | Module | Ids | Cause | Repaired by |
 |---|---|---|---|
-| `test_nodriver_worker_sandbox.py` | 3 | `_fetch_html` grew five required keyword-only arguments; the callers were never updated | E1-3 (retry and cleanup). Its other five ids were the flag-and-default half and left with E1-2 |
 | `test_universal_html_loader.py` | 3 | `fetch_html_via_nodriver` streams `proc.stdout`; `_FakeProc` never grew one | E1-4 |
 | `test_server.py` | 1 | asserts a Windows concurrency cap that `_resolve_web_search_max_concurrency` no longer has | E1-5 |
+
+`test_nodriver_worker_sandbox.py` has left this table entirely: its five
+flag-and-default ids relocated with E1-2 and its three orchestration ids were
+repaired in place by E1-3.
 
 ## Why the two platforms differ
 
@@ -226,7 +246,7 @@ claim awaiting its lane.
   Linux 6.8.0-138 · CPython 3.13.15 · pytest 9.1.1 · pytest-asyncio 1.4.0 ·
   mcp 1.29.1 · starlette 1.6.0 · uvicorn 0.52.4 · nodriver 0.50.3
 - **Result:** 12 failed, 303 passed, 2 skipped, 9 subtests passed
-- **Remaining:** 7 failed
+- **Remaining:** 4 failed
 
 This is the figure §1.1 predicted from source and labelled unmeasured. It was
 measured, and it matched: twelve, being the eight stale `_fetch_html` callers,
@@ -237,9 +257,6 @@ seven remaining, listed below. The **Result** line keeps saying twelve because
 that is what the run said.
 
 ```text
-tests/test_nodriver_worker_sandbox.py::TestNodriverWorkerSandbox::test_retries_and_terminates_on_devtools_timeout
-tests/test_nodriver_worker_sandbox.py::TestNodriverWorkerSandbox::test_retries_on_failed_to_connect_to_browser
-tests/test_nodriver_worker_sandbox.py::TestNodriverWorkerSandbox::test_uses_ignore_cleanup_errors_for_profile_dir
 tests/test_server.py::TestWebSearchTool::test_web_search_concurrency_defaults_on_windows
 tests/test_universal_html_loader.py::TestUniversalHtmlLoader::test_fetch_html_passes_browser_executable_path_when_set
 tests/test_universal_html_loader.py::TestUniversalHtmlLoader::test_fetch_html_sets_no_proxy_for_loopback
@@ -252,7 +269,7 @@ tests/test_universal_html_loader.py::TestUniversalHtmlLoader::test_fetch_html_sp
   (10.0.26100) · CPython 3.13.15 · pytest 9.1.1 · pytest-asyncio 1.4.0 ·
   mcp 1.29.1 · starlette 1.6.0 · uvicorn 0.52.4 · nodriver 0.50.3
 - **Result:** 11 failed, 303 passed, 3 skipped, 9 subtests passed
-- **Remaining:** 7 failed
+- **Remaining:** 4 failed
 
 Measured on a GitHub Actions `windows-latest` runner, from a temporary workflow
 on a branch of its own that was deleted once the numbers were recorded. It
@@ -277,9 +294,6 @@ mode the two-line split exists to prevent. There is no Windows lane in CI until
 the CI epic, so this section cannot be re-measured here.
 
 ```text
-tests/test_nodriver_worker_sandbox.py::TestNodriverWorkerSandbox::test_retries_and_terminates_on_devtools_timeout
-tests/test_nodriver_worker_sandbox.py::TestNodriverWorkerSandbox::test_retries_on_failed_to_connect_to_browser
-tests/test_nodriver_worker_sandbox.py::TestNodriverWorkerSandbox::test_uses_ignore_cleanup_errors_for_profile_dir
 tests/test_server.py::TestWebSearchTool::test_web_search_concurrency_defaults_on_windows
 tests/test_universal_html_loader.py::TestUniversalHtmlLoader::test_fetch_html_passes_browser_executable_path_when_set
 tests/test_universal_html_loader.py::TestUniversalHtmlLoader::test_fetch_html_sets_no_proxy_for_loopback

--- a/.system_design/BASELINE_FAILURES.md
+++ b/.system_design/BASELINE_FAILURES.md
@@ -252,8 +252,9 @@ This is the figure §1.1 predicted from source and labelled unmeasured. It was
 measured, and it matched: twelve, being the eight stale `_fetch_html` callers,
 the three stale loader tests and the one obsolete Windows concurrency test.
 
-Five have since left with E1-2, the flag-and-default half of the eight — hence
-seven remaining, listed below. The **Result** line keeps saying twelve because
+Five have since left with E1-2, the flag-and-default half of the eight, and
+three more with E1-3, which repaired the orchestration half in place — hence
+four remaining, listed below. The **Result** line keeps saying twelve because
 that is what the run said.
 
 ```text
@@ -286,8 +287,8 @@ check worth making on any recorded run: a larger total than the list would mean
 a test failed more than once, through subtests the summary reports under a
 different word.
 
-Four of those eleven left with E1-2, hence seven remaining. **The frozen
-`3 skipped` is now stale by one:** the third skip *was*
+Four of those eleven left with E1-2 and three more with E1-3, hence four
+remaining. **The frozen `3 skipped` is now stale by one:** the third skip *was*
 `test_forces_sandbox_off_when_running_as_root`, which E1-2 deleted. It is left
 as measured, because editing a measurement to keep it plausible is the failure
 mode the two-line split exists to prevent. There is no Windows lane in CI until

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -402,6 +402,30 @@ These complement the L1 flag tests of §3.1 — a fixture child cannot assert wh
 Chromium flags were chosen, and a resolver test cannot assert a process tree
 died.
 
+**Open: which job runs the orchestration group.** §9 routes "Worker
+retry/termination orchestration" to the `subsystem` job, but §10.5 registers
+that marker as *"needs a real socket or child process"* — and orchestration
+tests written correctly need neither. E1-3 built them with every collaborator
+doubled: no socket, no child, ~1 s for the module. Left **unmarked** they fall
+into the `fast` job instead.
+
+That is not only a routing question. `.coveragerc-gate` omits
+`scrape/nodriver_worker.py`, and §10.4's control 1 requires every omitted module
+to show non-zero coverage in the **observational L3 report**, which the
+`subsystem` and `chromium` jobs produce and `fast` does not. So an unmarked
+orchestration group leaves that module's only evidence of being exercised in a
+report nothing collects.
+
+Three ways out, for the CI workstream to choose between rather than for a
+repair step to settle by hand: widen the `subsystem` description to cover
+"drives a subsystem's orchestration, with or without real infrastructure"; add a
+distinct marker; or have control 1 read the `fast` report too. E1-3 deliberately
+changed nothing here — the marker list is a contract guarded by
+`tests/test_pytest_configuration.py` against this document, the control that
+depends on it does not exist yet, and widening a registered meaning on
+speculation is the wrong direction. Resolve it with E4-1, whose job definitions
+force the answer anyway.
+
 ### 5.3 Chromium-specific — Linux container
 
 `ChromiumPool`: slot acquisition and release, reuse

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -398,6 +398,16 @@ have. It does *not* declare instance attributes: `create_autospec` on
 (§8A step 3), so the process double is pinned by a Protocol instead. Use each for
 the failure it actually catches.
 
+**The Protocol half applies to the lifecycle group, not the orchestration one.**
+Only the lifecycle tests *consume* a process — they read its streams and its
+exit status. The orchestration tests pass it through: `_fetch_html` holds the
+object and hands it to `_terminate_process` and `_wait_for_devtools_ready`,
+both of which those tests double, so nothing reads an attribute off it. E1-3
+therefore uses a plain identifiable stub and E2-1 owns the typed definition, in
+`scrape/types.py`, in production. That ordering is deliberate: a Protocol
+declared in a test module now would be the second definition of a shape E2-1
+exists to give exactly one, which is the drift it is there to prevent.
+
 These complement the L1 flag tests of §3.1 — a fixture child cannot assert which
 Chromium flags were chosen, and a resolver test cannot assert a process tree
 died.
@@ -437,7 +447,7 @@ Plus one real fetch through `_fetch_html` against a locally served page.
 
 ### 5.4 Anti-flake and cleanup requirements
 
-Every test in §5.2 and §5.3 must:
+Every test in §5.2 and §5.3 that starts something real must:
 
 - Use a **readiness handshake**, never a sleep — wait for a known line or an
   accepting port, with a timeout.
@@ -448,6 +458,19 @@ Every test in §5.2 and §5.3 must:
   for processes named `chrome`, which is vulnerable to PID reuse and would kill a
   developer's own browser.
 - Capture and attach child stdout/stderr on failure.
+
+**Four of those five do not bind a fully-doubled test**, and saying so is not a
+loophole — it is what stops the list reading as ignored. A test that starts no
+process has no endpoint to hand-shake with, no port to allocate, no pid to reap
+and no child output to capture. The **per-test timeout does still bind**, and
+harder than elsewhere: the orchestration group drives a retry loop containing
+sleeps, so an unbounded call hangs the suite instead of failing.
+
+A wall-clock bound is necessary there and not sufficient. Measured in E1-3: with
+the loop mutated to spin, a 10 s bound fired and the test still took 47 s to
+report, because mock doubles record every call and a zero-backoff loop records
+millions. Bound the *work* as well as the clock — cap the number of attempts a
+double will serve, and fail with a sentence naming the loop.
 
 ---
 
@@ -831,7 +854,7 @@ The **Today** column describes *test coverage*, not implementation status.
 | MCP tool schema stability | gap | L2 | `fast` | |
 | Parent ⇄ worker frame format | gap | L2 | `fast` | |
 | Worker lifecycle and cleanup | gap — stale | L3 portable | `subsystem` | |
-| Worker retry/termination orchestration | gap — stale | L3 portable | `subsystem` | |
+| Worker retry/termination orchestration | covered — unmarked, see §5.2 | L3 portable | `subsystem` (open) | |
 | ChromiumPool | gap — no tests | L3 Chromium | `chromium` | |
 | CLI entrypoints and `--` forwarding | covered | L1 | `fast` | |
 | Wheel build, install, console entrypoints | gap | L4 | `package` | |

--- a/tests/test_nodriver_worker_sandbox.py
+++ b/tests/test_nodriver_worker_sandbox.py
@@ -16,7 +16,16 @@ collaborator with a bare ``AsyncMock``, which accepts any arguments at all, and
 that is exactly why giving `_fetch_html` five new required keyword-only
 arguments disabled eight tests at once without one of them objecting. An
 autospec double raises :class:`TypeError` on a wrong-arity call, so the next
-signature change fails loudly here.
+signature change fails here rather than passing.
+
+Two details of that, both measured. Autospec of an ``async def`` runs its
+signature check *inside* the coroutine body, so the check fires only when the
+call is awaited -- fine for `_fetch_html`, which awaits all of them, but a
+future assertion-only test would get no check at all. And the
+`_terminate_process` call inside `_cleanup` sits under ``except Exception:
+pass``, so a :class:`TypeError` raised there is swallowed: those tests still
+fail, on the terminated-process comparison, but not with the signature error
+that caused it.
 
 **One double is weaker than the rest, and it is worth knowing which.**
 :func:`nodriver.start` ends in ``**kwargs``, so its autospec accepts any keyword
@@ -59,6 +68,12 @@ from kindly_web_search_mcp_server.scrape import nodriver_worker
 #: Cleared before each case so a case declares the whole of its own input. Four
 #: of them are browser paths that CI images and developers commonly export, and
 #: ``KINDLY_USER_AGENT`` is the one whose *absence* costs a real subprocess.
+#:
+#: This is not the whole of the ambient state, and the harness does not pretend
+#: it is: `os.geteuid`, `shutil.which` and the module's diagnostics global are
+#: pinned separately below, because none of them is an environment variable.
+#: ``TMPDIR`` steers the real temporary directory and is deliberately left
+#: alone -- the profile assertion reads a basename, so the location is free.
 READ_ENVIRONMENT_VARIABLES = (
     "KINDLY_NODRIVER_SANDBOX",
     "KINDLY_NODRIVER_RETRY_ATTEMPTS",
@@ -83,10 +98,34 @@ READ_ENVIRONMENT_VARIABLES = (
 #: timing of these tests depend on where the developer's Chromium came from.
 BROWSER_PATH = "/usr/bin/chromium-for-tests"
 
-#: A ceiling on any single `_fetch_html` call. The cases take about 0.1 s; this
-#: exists so a regression that fails to terminate the retry loop fails the test
-#: instead of hanging the suite.
-PER_TEST_TIMEOUT_SECONDS = 10.0
+#: A browser path that `_is_snap_browser` classifies as snap-packaged. It is
+#: fabricated rather than the real `/snap/bin/chromium`, and that is worth a
+#: sentence: on Ubuntu `/snap/bin/chromium` is a symlink to `/usr/bin/snap`, and
+#: `_is_snap_browser` calls `os.path.realpath` first -- so it answers **False**
+#: for the single most common way to have a snap Chromium (measured on Ubuntu
+#: 24.04). A non-existent path under `/snap/` has no symlink to follow and is
+#: classified correctly. The production defect that implies is reported, not
+#: fixed here; a test that used the real path would silently assert the
+#: non-snap branch, which is what the previous version of this file did.
+SNAP_BROWSER_PATH = "/snap/bin/chromium-for-tests"
+
+#: A ceiling on any single `_fetch_html` call, guarding a hang that makes no
+#: progress -- an await that never resolves. Five seconds is fifty times the
+#: ~0.1 s these cases take.
+#:
+#: It is **not** what catches a runaway retry loop; :data:`MAX_LAUNCHES` is.
+#: Measured: with the retry loop mutated to spin forever, a wall-clock bound
+#: alone took 47 s to report one failure against a 10 s budget, because every
+#: doubled call is recorded and a loop with zero backoff records millions of
+#: them. A timeout that fires and then takes five times its own budget to
+#: unwind is the outcome a timeout exists to prevent.
+PER_TEST_TIMEOUT_SECONDS = 5.0
+
+#: The most browser launches any case here legitimately needs; the highest
+#: attempt budget in this module is three. Exceeding it means the retry loop is
+#: not terminating, and failing at once with that sentence is both faster and
+#: more legible than waiting for a clock.
+MAX_LAUNCHES = 10
 
 
 class StubChromiumProcess:
@@ -114,6 +153,11 @@ class StubChromiumProcess:
     """
 
     def __init__(self, pid: int) -> None:
+        """Record the identifying pid.
+
+        Args:
+            pid: The process id to report.
+        """
         self.pid = pid
         self.returncode: int | None = None
 
@@ -170,6 +214,7 @@ class Doubles:
     """
 
     def __init__(self) -> None:
+        """Create an empty record; :func:`orchestration_harness` fills it in."""
         self.launch: Any = None
         self.wait_ready: Any = None
         self.terminate: Any = None
@@ -202,7 +247,6 @@ class Doubles:
         return [call.args[0] for call in self.terminate.call_args_list]
 
 
-
 @contextlib.contextmanager
 def orchestration_harness(
     *,
@@ -224,13 +268,19 @@ def orchestration_harness(
     so the case can read the keyword arguments it was given. A mock in its place
     would make the profile-cleanup case assert against itself.
 
-    ``asyncio.sleep`` is deliberately **not** patched. The retry backoff is
-    driven to zero through ``KINDLY_NODRIVER_RETRY_BACKOFF_SECONDS``, which is a
-    real seam and exercises the real backoff arithmetic; patching
-    :func:`asyncio.sleep` would replace it on the global module for the duration
-    and reach far past the code under test. The one sleep that remains is the
-    fixed 100 ms `_cleanup` waits for Chromium to flush profile writes, which is
-    behaviour under test rather than a wait for a condition.
+    ``asyncio.sleep`` is deliberately **not** patched here. The retry backoff is
+    driven to zero through ``KINDLY_NODRIVER_RETRY_BACKOFF_SECONDS``, a real
+    seam; patching :func:`asyncio.sleep` would replace it on the global module
+    for the duration and reach far past the code under test. Driving it to zero
+    does **not** exercise the backoff arithmetic -- zero times anything is zero,
+    and gutting the expression survives every case that uses this default. The
+    one case that asserts the arithmetic patches :func:`asyncio.sleep` for
+    itself and says so.
+
+    The other sleep that remains is the fixed 100 ms `_cleanup` waits for
+    Chromium to flush profile writes before the profile directory is removed.
+    It is about 0.4 s of this module's runtime and is asserted by that same
+    case; the rest pay it without observing it.
 
     :func:`shutil.which` is pinned to "nothing installed" even though four of
     the five cases hand `_fetch_html` an explicit executable and never reach the
@@ -259,7 +309,23 @@ def orchestration_harness(
     os.environ.update(environment or {})
 
     def _new_process(*_args: object, **_kwargs: object) -> StubChromiumProcess:
-        """Hand out a distinctly-identified process for each launch."""
+        """Hand out a distinctly-identified process for each launch.
+
+        Returns:
+            A stub process whose pid identifies the attempt that launched it.
+
+        Raises:
+            AssertionError: Once :data:`MAX_LAUNCHES` is exceeded, which means
+                the retry loop is not terminating. Raised here rather than left
+                to the wall-clock bound because the doubles record every call:
+                a spinning loop is an unbounded sink that takes far longer to
+                unwind than the bound it broke.
+        """
+        if len(doubles.processes) >= MAX_LAUNCHES:
+            raise AssertionError(
+                f"_fetch_html launched a browser more than {MAX_LAUNCHES} times; "
+                "the retry loop is not terminating."
+            )
         process = StubChromiumProcess(pid=9000 + len(doubles.processes))
         doubles.processes.append(process)
         return process
@@ -281,6 +347,16 @@ def orchestration_harness(
             patch.object(
                 nodriver_worker.shutil, "which", autospec=True, return_value=None
             ) as which,
+            # `_resolve_sandbox_enabled` and the failure message both read the
+            # effective uid. Inert today -- the sandbox default is off either
+            # way -- but the resolver module pins it for the same reason and a
+            # container running as root would make it live the moment anything
+            # here asserts a sandbox decision.
+            patch.object(nodriver_worker.os, "geteuid", return_value=1000, create=True),
+            # `_emit_diag` reads a module global, not the environment: clearing
+            # `KINDLY_DIAGNOSTICS` does not reach it, because only the worker's
+            # own entry point assigns it.
+            patch.object(nodriver_worker, "_DIAG_ENABLED", False),
         ):
             launch.side_effect = _new_process
             pick_port.return_value = 9222
@@ -429,7 +505,7 @@ class TestNodriverWorkerSandbox(unittest.IsolatedAsyncioTestCase):
 
             html = await fetch_html()
 
-            _, chromium_args = doubles.launch.call_args.args
+            executable, chromium_args = doubles.launch.call_args.args
             profile_flags = [a for a in chromium_args if a.startswith("--user-data-dir=")]
 
         self.assertIn("ok", html)
@@ -445,6 +521,20 @@ class TestNodriverWorkerSandbox(unittest.IsolatedAsyncioTestCase):
         # cleaned up if it is gone once the context manager has exited.
         self.assertEqual(len(profile_flags), 1, chromium_args)
         profile_dir = profile_flags[0].removeprefix("--user-data-dir=")
+        # The port and the executable must reach all three collaborators as the
+        # *same* values. Nothing else here checks that, and an independently
+        # drawn mutation battery walked straight through it: connecting on a
+        # port other than the one Chromium was launched on is exactly the fault
+        # this module's retry loop exists to handle, and every case stayed green
+        # against it.
+        port = doubles.pick_port.return_value
+        self.assertIn(f"--remote-debugging-port={port}", chromium_args)
+        self.assertEqual(executable, BROWSER_PATH)
+        self.assertEqual(doubles.wait_ready.call_args.kwargs["port"], port)
+        self.assertEqual(doubles.start.call_args.kwargs["port"], port)
+        self.assertEqual(
+            doubles.start.call_args.kwargs["browser_executable_path"], BROWSER_PATH
+        )
         self.assertTrue(os.path.basename(profile_dir).startswith("kindly-nodriver-"))
         self.assertFalse(
             os.path.exists(profile_dir),
@@ -538,6 +628,60 @@ class TestNodriverWorkerSandbox(unittest.IsolatedAsyncioTestCase):
             doubles.call_sequence(),
             ["launch", "wait_ready", "terminate", "launch", "wait_ready", "terminate"],
         )
+        # A port is picked per attempt, not once for the run. Hoisting the pick
+        # out of the loop would send a retry at the port the previous, still
+        # dying browser is holding -- which is the failure it is retrying from.
+        self.assertEqual(doubles.pick_port.call_count, 2)
+
+    async def test_backoff_grows_with_each_attempt_and_scales_for_snap(self) -> None:
+        """Wait longer after each failed attempt, and longer again for a snap browser
+
+        The backoff is `base * 2**attempt * snap_multiplier`. Every other case
+        here sets the base to zero, which makes the whole expression zero and
+        leaves the arithmetic unasserted -- measured: gutting it survives them
+        all. So this case sets a real base and reads the durations back.
+
+        A snap-packaged Chromium is slower to open its DevTools endpoint, which
+        is why it gets its own multiplier; the two factors are asserted together
+        because one case can distinguish all three mutations -- dropping the
+        exponent, dropping the multiplier, and dropping both.
+
+        See :data:`SNAP_BROWSER_PATH` for why the snap path here is fabricated
+        rather than the real `/snap/bin/chromium`: the real one is classified
+        **non**-snap by the code under test, which is a production defect this
+        case would otherwise have papered over.
+
+        This is the only case that patches :func:`asyncio.sleep`. It is a global
+        and the harness avoids it for that reason, but a duration cannot be
+        observed without either replacing the clock or actually waiting 4.5 s.
+        """
+        recorded: list[float] = []
+
+        async def _record(delay: float) -> None:
+            recorded.append(delay)
+
+        with orchestration_harness(
+            environment={
+                "KINDLY_NODRIVER_RETRY_ATTEMPTS": "3",
+                "KINDLY_NODRIVER_RETRY_BACKOFF_SECONDS": "0.5",
+                "KINDLY_NODRIVER_SNAP_BACKOFF_MULTIPLIER": "3",
+            }
+        ) as doubles:
+            doubles.wait_ready.side_effect = RuntimeError(
+                "DevTools endpoint did not become ready in time"
+            )
+
+            with (
+                patch.object(nodriver_worker.asyncio, "sleep", _record),
+                self.assertRaises(RuntimeError),
+            ):
+                await fetch_html(browser_executable_path=SNAP_BROWSER_PATH)
+
+        self.assertEqual(doubles.launch.call_count, 3)
+        # 0.5 * 2**0 * 3, then 0.5 * 2**1 * 3. There is no third: the last
+        # attempt raises instead of backing off. The trailing 0.1 is the profile
+        # flush `_cleanup` waits for before removing the directory.
+        self.assertEqual(recorded, [1.5, 3.0, 0.1])
 
     async def test_does_not_retry_a_non_retryable_error(self) -> None:
         """Surface an unrecognised startup failure at once instead of retrying it
@@ -581,14 +725,19 @@ class TestNodriverWorkerSandbox(unittest.IsolatedAsyncioTestCase):
         -- that it returns ``None`` -- is asserted at component level; the
         translation into advice happens here and is asserted here.
         """
-        with orchestration_harness() as doubles:
-            # The harness pins `shutil.which` to find nothing for every case.
-            # This is the case that depends on it, so it states the dependency
-            # rather than inheriting a default silently.
-            self.assertIsNone(doubles.which("chromium"))
+        with (
+            orchestration_harness() as doubles,
+            self.assertRaises(RuntimeError) as raised,
+        ):
+            await fetch_html(browser_executable_path=None)
 
-            with self.assertRaises(RuntimeError) as raised:
-                await fetch_html(browser_executable_path=None)
+        # The resolver really did fall through to the `PATH` probe, rather than
+        # this case having been satisfied by some earlier branch. Asserting the
+        # pinned `shutil.which` returns None would only restate the fixture;
+        # asserting the code under test consulted it is an observation.
+        self.assertGreater(
+            doubles.which.call_count, 0, "the resolver never probed PATH"
+        )
 
         message = str(raised.exception)
         self.assertIn("KINDLY_BROWSER_EXECUTABLE_PATH", message)

--- a/tests/test_nodriver_worker_sandbox.py
+++ b/tests/test_nodriver_worker_sandbox.py
@@ -64,9 +64,17 @@ import nodriver
 
 from kindly_web_search_mcp_server.scrape import nodriver_worker
 
-#: Every environment variable `_fetch_html` and the resolvers it calls consult.
+#: Every environment variable this worker module reads — a deliberate **superset**
+#: of what `_fetch_html` itself consults. Two are read only by the module's own
+#: entry point and never on any path reachable from `_fetch_html`:
+#: ``KINDLY_HTML_TOTAL_TIMEOUT_SECONDS`` (via ``_resolve_worker_timeout_details``)
+#: and ``KINDLY_DIAGNOSTICS`` (via ``_diagnostics_enabled``). They are cleared
+#: anyway because over-clearing errs in the safe direction, and because a future
+#: change that routes either into `_fetch_html` should not quietly make these
+#: cases steerable. Do not read the list as the set `_fetch_html` exercises.
+#:
 #: Cleared before each case so a case declares the whole of its own input. Four
-#: of them are browser paths that CI images and developers commonly export, and
+#: entries are browser paths that CI images and developers commonly export, and
 #: ``KINDLY_USER_AGENT`` is the one whose *absence* costs a real subprocess.
 #:
 #: This is not the whole of the ambient state, and the harness does not pretend

--- a/tests/test_nodriver_worker_sandbox.py
+++ b/tests/test_nodriver_worker_sandbox.py
@@ -1,10 +1,333 @@
+"""Cover the nodriver worker's browser-startup orchestration.
+
+`_fetch_html` runs in the *child* process and owns the sequence that brings a
+browser up: pick a port, launch Chromium, wait for its DevTools endpoint,
+connect nodriver to it, retry a transient failure, terminate the process of any
+attempt that failed, and remove the temporary profile directory on the way out.
+Those claims are about *sequencing and cleanup*, so no resolver test can make
+them -- they stay at this layer permanently. The flag and default decisions that
+used to be asserted here moved to
+:mod:`tests.test_nodriver_worker_launch_resolvers`; nothing in this module should
+assert one again.
+
+**Every double is built with autospec**, from the real callable. That is the
+whole point of this module's rewrite: the previous version patched each
+collaborator with a bare ``AsyncMock``, which accepts any arguments at all, and
+that is exactly why giving `_fetch_html` five new required keyword-only
+arguments disabled eight tests at once without one of them objecting. An
+autospec double raises :class:`TypeError` on a wrong-arity call, so the next
+signature change fails loudly here.
+
+**The real `nodriver` package is used, with only `nodriver.start` patched.** The
+previous version installed a stand-in module built with
+``type("X", (), {"start": ...})``. That could never have worked even with the
+signature repaired: `_fetch_html` executes ``cdp = uc.cdp`` immediately after
+importing, before any branch, and the stand-in has no ``cdp``. `nodriver` is an
+unconditional runtime dependency of this project, so the real module is always
+importable and there is nothing to gain by faking it.
+
+Nothing here starts a browser, a subprocess or a socket, and every environment
+variable `_fetch_html` reads is pinned -- including ``KINDLY_USER_AGENT``, whose
+absence sends `_resolve_user_agent` into `_detect_chrome_version`, which runs
+``<browser> --version`` as a real subprocess.
+"""
+
 from __future__ import annotations
 
+import asyncio
+import contextlib
+import os
+import tempfile
 import unittest
-from unittest.mock import AsyncMock, patch
+from collections.abc import Iterator
+from typing import Any, Protocol, runtime_checkable
+from unittest.mock import create_autospec, patch
+
+import nodriver
+
+from kindly_web_search_mcp_server.scrape import nodriver_worker
+
+#: Every environment variable `_fetch_html` and the resolvers it calls consult.
+#: Cleared before each case so a case declares the whole of its own input. Four
+#: of them are browser paths that CI images and developers commonly export, and
+#: ``KINDLY_USER_AGENT`` is the one whose *absence* costs a real subprocess.
+READ_ENVIRONMENT_VARIABLES = (
+    "KINDLY_NODRIVER_SANDBOX",
+    "KINDLY_NODRIVER_RETRY_ATTEMPTS",
+    "KINDLY_NODRIVER_RETRY_BACKOFF_SECONDS",
+    "KINDLY_NODRIVER_SNAP_BACKOFF_MULTIPLIER",
+    "KINDLY_NODRIVER_DEVTOOLS_READY_TIMEOUT_SECONDS",
+    "KINDLY_HTML_TOTAL_TIMEOUT_SECONDS",
+    "KINDLY_USER_AGENT",
+    "KINDLY_DIAGNOSTICS",
+    "KINDLY_BROWSER_EXECUTABLE_PATH",
+    "BROWSER_EXECUTABLE_PATH",
+    "CHROME_BIN",
+    "CHROME_PATH",
+    "KINDLY_CHROME_PROXY",
+    "KINDLY_CHROME_PROXY_BYPASS",
+)
+
+#: A browser path the tests hand to `_fetch_html` directly, so the executable
+#: resolver short-circuits on its first branch and no `PATH` probe happens.
+BROWSER_PATH = "/usr/bin/chromium-for-tests"
+
+
+@runtime_checkable
+class ChromiumProcess(Protocol):
+    """The surface a launched Chromium process must present to the worker.
+
+    `_terminate_process` reads ``pid`` and ``returncode``, and
+    `_wait_for_devtools_ready` reads ``returncode`` to notice a browser that
+    died before its endpoint came up. Both are doubled in this module, so
+    nothing here exercises those reads -- the Protocol exists to keep the stub
+    honest anyway, because a double that has silently lost an attribute its real
+    collaborators need is a double that will keep passing after the code stops
+    working.
+
+    It is a Protocol rather than an autospec of
+    :class:`asyncio.subprocess.Process` for a measured reason, pinned by
+    :meth:`TestProcessDoubleShape.test_autospec_of_a_process_omits_its_streams`.
+    """
+
+    pid: int
+    returncode: int | None
+
+
+class StubChromiumProcess:
+    """A launched-Chromium stand-in that satisfies :class:`ChromiumProcess`.
+
+    Args:
+        pid: The process id to report. Distinct per attempt in the retry cases,
+            so an assertion can tell *which* attempt's process was terminated
+            rather than only how many terminations happened.
+    """
+
+    def __init__(self, pid: int) -> None:
+        self.pid = pid
+        self.returncode: int | None = None
+
+    def __repr__(self) -> str:
+        """Return a form that names the attempt in an assertion message."""
+        return f"<StubChromiumProcess pid={self.pid}>"
+
+
+class StubPage:
+    """A browser tab that returns fixed content.
+
+    Args:
+        html: The document `get_content` returns.
+    """
+
+    def __init__(self, html: str) -> None:
+        self.html = html
+        self.closed = False
+
+    def get_content(self) -> str:
+        """Return the page's HTML, the way nodriver's synchronous accessor does."""
+        return self.html
+
+    async def close(self) -> None:
+        """Record that the worker closed this tab."""
+        self.closed = True
+
+
+class StubBrowser:
+    """A connected browser that hands out one :class:`StubPage`.
+
+    Args:
+        html: The document every tab returns.
+    """
+
+    def __init__(self, html: str = "<html><body>ok</body></html>") -> None:
+        self.html = html
+        self.pages: list[StubPage] = []
+        self.stopped = False
+
+    async def get(self, _url: str) -> StubPage:
+        """Open a tab and return it.
+
+        Args:
+            _url: Ignored; navigation targets are not this module's subject.
+
+        Returns:
+            A new stub tab.
+        """
+        page = StubPage(self.html)
+        self.pages.append(page)
+        return page
+
+    async def stop(self) -> None:
+        """Record that the worker stopped the browser."""
+        self.stopped = True
+
+
+class Doubles:
+    """The autospec doubles installed around one `_fetch_html` call.
+
+    Attributes:
+        launch: Stands in for `_launch_chromium`; returns a fresh
+            :class:`StubChromiumProcess` per attempt.
+        wait_ready: Stands in for `_wait_for_devtools_ready`.
+        terminate: Stands in for `_terminate_process`.
+        pick_port: Stands in for `_pick_free_port`, which otherwise binds a real
+            socket.
+        start: Stands in for :func:`nodriver.start`, the browser-connect call.
+        temporary_directory: Wraps the real :class:`tempfile.TemporaryDirectory`
+            so its keyword arguments can be inspected without losing the real
+            create-and-remove behaviour.
+        processes: Every process the launch double handed out, in order.
+    """
+
+    def __init__(self) -> None:
+        self.launch: Any = None
+        self.wait_ready: Any = None
+        self.terminate: Any = None
+        self.pick_port: Any = None
+        self.start: Any = None
+        self.temporary_directory: Any = None
+        self.processes: list[StubChromiumProcess] = []
+
+    def terminated_processes(self) -> list[Any]:
+        """Return the process object of each `_terminate_process` call, in order.
+
+        Returns:
+            The first positional argument of every recorded call.
+        """
+        return [call.args[0] for call in self.terminate.call_args_list]
+
+
+
+@contextlib.contextmanager
+def orchestration_harness(
+    *,
+    environment: dict[str, str] | None = None,
+) -> Iterator[Doubles]:
+    """Install autospec doubles around everything `_fetch_html` would really do.
+
+    Doubles exactly the four collaborators that would otherwise touch the
+    machine -- launching Chromium, probing its DevTools port over HTTP, killing
+    a process, and binding a socket to pick a port -- plus the browser-connect
+    call. Everything else inside `_fetch_html` runs for real, which is the
+    point: the orchestration is the subject.
+
+    Every double is created with ``autospec=True``, so a call with the wrong
+    arity raises :class:`TypeError` inside the code under test rather than being
+    silently recorded. That is the property this whole module exists to restore.
+
+    The real :class:`tempfile.TemporaryDirectory` still runs; it is only wrapped
+    so the case can read the keyword arguments it was given. A mock in its place
+    would make the profile-cleanup case assert against itself.
+
+    ``asyncio.sleep`` is deliberately **not** patched. The retry backoff is
+    driven to zero through ``KINDLY_NODRIVER_RETRY_BACKOFF_SECONDS``, which is a
+    real seam and exercises the real backoff arithmetic; patching
+    :func:`asyncio.sleep` would replace it on the global module for the duration
+    and reach far past the code under test. The one sleep that remains is the
+    fixed 100 ms `_cleanup` waits for Chromium to flush profile writes, which is
+    behaviour under test rather than a wait for a condition.
+
+    Args:
+        environment: Variables to set for the duration, on top of a cleared
+            slate. Anything in :data:`READ_ENVIRONMENT_VARIABLES` and not named
+            here is removed.
+
+    Yields:
+        The installed :class:`Doubles`.
+    """
+    doubles = Doubles()
+    # A cleared slate: every variable the worker reads is removed, then only
+    # what the case asked for is set. Without this a developer's `CHROME_BIN`,
+    # or a CI image's, steers the run.
+    saved = {name: os.environ.get(name) for name in READ_ENVIRONMENT_VARIABLES}
+    for name in READ_ENVIRONMENT_VARIABLES:
+        os.environ.pop(name, None)
+    os.environ["KINDLY_USER_AGENT"] = "kindly-test-agent"
+    os.environ["KINDLY_NODRIVER_RETRY_BACKOFF_SECONDS"] = "0"
+    os.environ.update(environment or {})
+
+    def _new_process(*_args: object, **_kwargs: object) -> StubChromiumProcess:
+        """Hand out a distinctly-identified process for each launch."""
+        process = StubChromiumProcess(pid=9000 + len(doubles.processes))
+        doubles.processes.append(process)
+        return process
+
+    real_temporary_directory = tempfile.TemporaryDirectory
+    try:
+        with (
+            patch.object(nodriver_worker, "_launch_chromium", autospec=True) as launch,
+            patch.object(nodriver_worker, "_wait_for_devtools_ready", autospec=True) as wait_ready,
+            patch.object(nodriver_worker, "_terminate_process", autospec=True) as terminate,
+            patch.object(nodriver_worker, "_pick_free_port", autospec=True) as pick_port,
+            patch.object(nodriver, "start", autospec=True) as start,
+            patch.object(
+                nodriver_worker.tempfile,
+                "TemporaryDirectory",
+                autospec=True,
+                side_effect=real_temporary_directory,
+            ) as temporary_directory,
+        ):
+            launch.side_effect = _new_process
+            pick_port.return_value = 9222
+            doubles.launch = launch
+            doubles.wait_ready = wait_ready
+            doubles.terminate = terminate
+            doubles.pick_port = pick_port
+            doubles.start = start
+            doubles.temporary_directory = temporary_directory
+            yield doubles
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
+async def fetch_html(**overrides: Any) -> str:
+    """Call `_fetch_html` with the arguments a non-pooled fetch supplies.
+
+    Written out rather than splatted from a dict so the call stays checkable:
+    this module's subject is signature drift, and a helper that silences the
+    type checker on its own call to the function under test would be
+    self-defeating.
+
+    Args:
+        **overrides: Replacements for the defaults below.
+
+    Returns:
+        The HTML `_fetch_html` produced.
+    """
+    kwargs: dict[str, Any] = {
+        "referer": None,
+        "user_agent": "kindly-test-agent",
+        "wait_seconds": 0.0,
+        "browser_executable_path": BROWSER_PATH,
+        "reuse_browser": False,
+        "remote_host": None,
+        "remote_port": None,
+        "user_data_dir": None,
+        "overall_timeout_seconds": 30.0,
+    }
+    kwargs.update(overrides)
+    url = kwargs.pop("url", "https://example.com")
+    return await nodriver_worker._fetch_html(
+        url,
+        referer=kwargs["referer"],
+        user_agent=kwargs["user_agent"],
+        wait_seconds=kwargs["wait_seconds"],
+        browser_executable_path=kwargs["browser_executable_path"],
+        reuse_browser=kwargs["reuse_browser"],
+        remote_host=kwargs["remote_host"],
+        remote_port=kwargs["remote_port"],
+        user_data_dir=kwargs["user_data_dir"],
+        overall_timeout_seconds=kwargs["overall_timeout_seconds"],
+    )
 
 
 class TestNodriverWorkerSandbox(unittest.IsolatedAsyncioTestCase):
+    """Assert the browser-startup sequence `_fetch_html` owns."""
+
     async def test_devtools_probe_ignores_proxy_env(self) -> None:
         from kindly_web_search_mcp_server.scrape import nodriver_worker
 
@@ -47,134 +370,165 @@ class TestNodriverWorkerSandbox(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(captured["trust_env"])
 
     async def test_uses_ignore_cleanup_errors_for_profile_dir(self) -> None:
-        from kindly_web_search_mcp_server.scrape import nodriver_worker
+        """Remove the temporary profile without letting its removal fail the request
 
-        class _FakePage:
-            def get_content(self):
-                return "<html><body>ok</body></html>"
+        Chromium may still be flushing profile writes when the worker tears the
+        directory down, so the request must not fail because a temp directory
+        could not be deleted. Two halves: the flag that grants that tolerance is
+        actually passed, and the directory really is created and really is gone
+        afterwards. The real :class:`tempfile.TemporaryDirectory` runs -- a mock
+        in its place would leave the second half asserting against itself.
+        """
+        with orchestration_harness() as doubles:
+            doubles.start.return_value = StubBrowser()
 
-            async def close(self):
-                return None
+            html = await fetch_html()
 
-        class _FakeBrowser:
-            async def get(self, _url: str):
-                return _FakePage()
-
-            async def stop(self):
-                return None
-
-        fake_start = AsyncMock(return_value=_FakeBrowser())
-        captured: dict[str, object] = {}
-        fake_launch = AsyncMock()
-        fake_wait_devtools = AsyncMock()
-        fake_terminate = AsyncMock()
-
-        class _TempDir:
-            def __init__(self, *args, **kwargs):
-                captured["kwargs"] = dict(kwargs)
-
-            def __enter__(self):
-                return "/tmp/kindly-nodriver-test"
-
-            def __exit__(self, exc_type, exc, tb):
-                return False
-
-        with (
-            patch.dict("sys.modules", {"nodriver": type("X", (), {"start": fake_start})}),
-            patch.dict("os.environ", {}, clear=False),
-            patch("shutil.which", return_value="/usr/bin/chromium"),
-            patch.object(nodriver_worker.tempfile, "TemporaryDirectory", _TempDir),
-            patch.object(nodriver_worker.asyncio, "sleep", AsyncMock()),
-            patch.object(nodriver_worker, "_pick_free_port", return_value=9222),
-            patch.object(nodriver_worker, "_launch_chromium", fake_launch),
-            patch.object(nodriver_worker, "_wait_for_devtools_ready", fake_wait_devtools),
-            patch.object(nodriver_worker, "_terminate_process", fake_terminate),
-        ):
-            html = await nodriver_worker._fetch_html(
-                "https://example.com",
-                referer=None,
-                user_agent="ua",
-                wait_seconds=0.0,
-                browser_executable_path=None,
-            )
+            _, chromium_args = doubles.launch.call_args.args
+            profile_flags = [a for a in chromium_args if a.startswith("--user-data-dir=")]
 
         self.assertIn("ok", html)
-        kwargs = captured.get("kwargs") or {}
-        self.assertTrue(kwargs.get("ignore_cleanup_errors"))
+        kwargs = doubles.temporary_directory.call_args.kwargs
+        self.assertIs(
+            kwargs.get("ignore_cleanup_errors"),
+            True,
+            "The temporary profile directory must tolerate cleanup errors; "
+            "without it a browser still flushing writes fails the request.",
+        )
+        self.assertEqual(kwargs.get("prefix"), "kindly-nodriver-")
+        # The directory is only real if Chromium was pointed at it, and only
+        # cleaned up if it is gone once the context manager has exited.
+        self.assertEqual(len(profile_flags), 1, chromium_args)
+        profile_dir = profile_flags[0].removeprefix("--user-data-dir=")
+        self.assertTrue(os.path.basename(profile_dir).startswith("kindly-nodriver-"))
+        self.assertFalse(
+            os.path.exists(profile_dir),
+            f"{profile_dir} outlived the fetch; the profile directory leaks.",
+        )
 
     async def test_retries_on_failed_to_connect_to_browser(self) -> None:
-        from kindly_web_search_mcp_server.scrape.nodriver_worker import _fetch_html
+        """Retry a transient connect failure and return the page from the retry
 
-        class _FakePage:
-            def get_content(self):
-                return "<html><body>ok</body></html>"
+        The first attempt fails with the message nodriver raises when Chromium
+        is up but not yet accepting DevTools connections -- the case the retry
+        loop exists for. The second succeeds, and the caller sees HTML rather
+        than the failure.
 
-            async def close(self):
-                return None
+        The attempt budget is **three**, deliberately, while only two attempts
+        are expected. With a budget of two the second attempt is also the last,
+        so the loop ends whether or not it stops on success -- and deleting the
+        ``break`` after a successful connect changed nothing, measured. A spare
+        attempt makes "stopped retrying" a distinct, observable fact from "ran
+        out of attempts": without the break a third browser is launched.
+        """
+        browser = StubBrowser()
+        with orchestration_harness(
+            environment={"KINDLY_NODRIVER_RETRY_ATTEMPTS": "3"}
+        ) as doubles:
+            doubles.start.side_effect = [
+                RuntimeError("Failed to connect to browser"),
+                browser,
+            ]
 
-        class _FakeBrowser:
-            async def get(self, _url: str):
-                return _FakePage()
-
-            async def stop(self):
-                return None
-
-        fake_start = AsyncMock(side_effect=[RuntimeError("Failed to connect to browser"), _FakeBrowser()])
-
-        fake_terminate = AsyncMock()
-        with (
-            patch.dict("sys.modules", {"nodriver": type("X", (), {"start": fake_start})}),
-            patch.dict("os.environ", {"KINDLY_NODRIVER_RETRY_ATTEMPTS": "2"}, clear=False),
-            patch("shutil.which", return_value="/snap/bin/chromium"),
-            patch("kindly_web_search_mcp_server.scrape.nodriver_worker._pick_free_port", return_value=9222),
-            patch("kindly_web_search_mcp_server.scrape.nodriver_worker._launch_chromium", AsyncMock()),
-            patch("kindly_web_search_mcp_server.scrape.nodriver_worker._wait_for_devtools_ready", AsyncMock()),
-            patch("kindly_web_search_mcp_server.scrape.nodriver_worker._terminate_process", fake_terminate),
-            patch("kindly_web_search_mcp_server.scrape.nodriver_worker.asyncio.sleep", AsyncMock()),
-        ):
-            html = await _fetch_html(
-                "https://example.com",
-                referer=None,
-                user_agent="ua",
-                wait_seconds=0.0,
-                browser_executable_path=None,
-            )
+            html = await fetch_html()
 
         self.assertIn("ok", html)
-        self.assertEqual(fake_start.call_count, 2)
-        # One termination for the failed attempt, one for the successful attempt cleanup.
-        self.assertEqual(fake_terminate.call_count, 2)
+        self.assertEqual(doubles.start.call_count, 2)
+        self.assertEqual(
+            doubles.launch.call_count,
+            2,
+            "a third launch means the loop kept going after a successful "
+            "connect, which strands a browser process",
+        )
+        # Both processes are terminated and in launch order: the first attempt's
+        # before the retry begins, the second attempt's by the final cleanup.
+        # Comparing the objects rather than counting them is what distinguishes
+        # "each attempt was cleaned up" from "one was cleaned up twice".
+        self.assertEqual(doubles.terminated_processes(), doubles.processes)
+        self.assertTrue(browser.stopped, "the browser was left running")
 
     async def test_retries_and_terminates_on_devtools_timeout(self) -> None:
-        from kindly_web_search_mcp_server.scrape.nodriver_worker import _fetch_html
+        """Terminate every attempt whose DevTools endpoint never came up
 
-        fake_start = AsyncMock()
-        fake_launch = AsyncMock()
-        fake_wait = AsyncMock(side_effect=RuntimeError("DevTools endpoint did not become ready in time"))
-        fake_terminate = AsyncMock()
+        A Chromium that starts but never opens its endpoint is the leak this
+        guards: without the terminate in the failure path each retry would strand
+        a browser process, and the worker exits without reaping it.
+        """
+        with orchestration_harness(
+            environment={"KINDLY_NODRIVER_RETRY_ATTEMPTS": "2"}
+        ) as doubles:
+            doubles.wait_ready.side_effect = RuntimeError(
+                "DevTools endpoint did not become ready in time"
+            )
 
+            with self.assertRaisesRegex(
+                RuntimeError, r"Failed to connect to browser after 2 attempt"
+            ):
+                await fetch_html()
+
+        self.assertEqual(doubles.launch.call_count, 2)
+        self.assertEqual(
+            doubles.start.call_count,
+            0,
+            "the browser-connect call must not be reached when the endpoint "
+            "never became ready",
+        )
+        self.assertEqual(doubles.terminated_processes(), doubles.processes)
+
+    async def test_does_not_retry_a_non_retryable_error(self) -> None:
+        """Surface an unrecognised startup failure at once instead of retrying it
+
+        The retry loop asks `_is_retryable_browser_connect_error` before trying
+        again. Nothing exercised the false branch, so deleting that question
+        would have turned every failure -- a bad profile, a missing shared
+        library -- into three slow attempts and a message blaming the connection.
+        The attempt budget is three here so a retry would be visible.
+        """
+        with orchestration_harness(
+            environment={"KINDLY_NODRIVER_RETRY_ATTEMPTS": "3"}
+        ) as doubles:
+            doubles.start.side_effect = RuntimeError(
+                "chromium exited with a corrupt profile"
+            )
+
+            with self.assertRaises(RuntimeError) as raised:
+                await fetch_html()
+
+        self.assertEqual(doubles.start.call_count, 1)
+        self.assertEqual(doubles.launch.call_count, 1)
+        self.assertEqual(doubles.terminated_processes(), doubles.processes)
+        # The original diagnosis must reach the caller. Asserting the
+        # attempts-exhausted wording is *absent* is the half that discriminates:
+        # a retried-to-exhaustion run also raises RuntimeError.
+        self.assertIn("corrupt profile", str(raised.exception))
+        self.assertNotIn("Failed to connect to browser after", str(raised.exception))
+
+    async def test_missing_browser_executable_names_the_override_variable(self) -> None:
+        """Tell the user how to fix a missing browser instead of failing obscurely
+
+        When nothing is configured and nothing is on ``PATH``, this message is
+        the only actionable guidance anyone gets: the alternative is a failure
+        from inside Chromium, or none at all. The resolver's half of this claim
+        -- that it returns ``None`` -- is asserted at component level; the
+        translation into advice happens here and is asserted here.
+        """
         with (
-            patch.dict("sys.modules", {"nodriver": type("X", (), {"start": fake_start})}),
-            patch.dict("os.environ", {"KINDLY_NODRIVER_RETRY_ATTEMPTS": "2"}, clear=False),
-            patch("shutil.which", return_value="/snap/bin/chromium"),
-            patch("kindly_web_search_mcp_server.scrape.nodriver_worker._pick_free_port", return_value=9222),
-            patch("kindly_web_search_mcp_server.scrape.nodriver_worker._launch_chromium", fake_launch),
-            patch("kindly_web_search_mcp_server.scrape.nodriver_worker._wait_for_devtools_ready", fake_wait),
-            patch("kindly_web_search_mcp_server.scrape.nodriver_worker._terminate_process", fake_terminate),
-            patch("kindly_web_search_mcp_server.scrape.nodriver_worker.asyncio.sleep", AsyncMock()),
+            orchestration_harness() as doubles,
+            patch.object(
+                nodriver_worker.shutil, "which", autospec=True, return_value=None
+            ),
+            self.assertRaises(RuntimeError) as raised,
         ):
-            with self.assertRaisesRegex(RuntimeError, "Failed to connect to browser after 2 attempt"):
-                await _fetch_html(
-                    "https://example.com",
-                    referer=None,
-                    user_agent="ua",
-                    wait_seconds=0.0,
-                    browser_executable_path=None,
-                )
+            await fetch_html(browser_executable_path=None)
 
-        self.assertEqual(fake_launch.call_count, 2)
-        self.assertEqual(fake_terminate.call_count, 2)
-        self.assertEqual(fake_start.call_count, 0)
+        message = str(raised.exception)
+        self.assertIn("KINDLY_BROWSER_EXECUTABLE_PATH", message)
+        self.assertIn("Install Chromium", message)
+        self.assertEqual(
+            doubles.launch.call_count,
+            0,
+            "no process may be launched when no executable was found",
+        )
 
     def test_worker_stdout_write_uses_utf8_bytes(self) -> None:
         """
@@ -196,6 +550,44 @@ class TestNodriverWorkerSandbox(unittest.IsolatedAsyncioTestCase):
         payload = "Hello — 世界".encode("utf-8", errors="strict")
         nodriver_worker._safe_write_bytes(stream, payload)
         self.assertIn(b"Hello", stream.buffer.getvalue())
+
+
+class TestProcessDoubleShape(unittest.TestCase):
+    """Pin the measured autospec gap that decides how a process is doubled."""
+
+    def test_autospec_of_a_process_omits_its_streams(self) -> None:
+        """Record that an autospec process has no stream attributes
+
+        :func:`unittest.mock.create_autospec` copies a class's *methods* and its
+        class-level descriptors, not the instance attributes ``__init__``
+        assigns. On :class:`asyncio.subprocess.Process` that means ``stdout``,
+        ``stderr``, ``stdin`` and ``pid`` are absent while ``returncode``, being
+        a property on the class, survives.
+
+        The design cites this when it says a process double must be pinned by a
+        Protocol rather than by autospec, and a later step builds a typed fake
+        on the same fact. Until now it was prose. A ``mock`` release that started
+        declaring those attributes would make the reasoning obsolete silently;
+        this notices.
+        """
+        double = create_autospec(asyncio.subprocess.Process, instance=True)
+
+        for absent in ("stdout", "stderr", "stdin", "pid"):
+            self.assertFalse(
+                hasattr(double, absent),
+                f"create_autospec(Process) now supplies {absent!r}; the reason "
+                "this project doubles a process with a Protocol instead has "
+                "changed and the design should be revisited.",
+            )
+        self.assertTrue(
+            hasattr(double, "returncode"),
+            "create_autospec(Process) no longer supplies 'returncode', which "
+            "is a class-level property and was the one attribute it did carry.",
+        )
+
+    def test_the_process_stub_satisfies_the_protocol(self) -> None:
+        """Keep the stub in step with the surface the worker's collaborators read"""
+        self.assertIsInstance(StubChromiumProcess(pid=1), ChromiumProcess)
 
 
 if __name__ == "__main__":

--- a/tests/test_nodriver_worker_sandbox.py
+++ b/tests/test_nodriver_worker_sandbox.py
@@ -18,6 +18,14 @@ arguments disabled eight tests at once without one of them objecting. An
 autospec double raises :class:`TypeError` on a wrong-arity call, so the next
 signature change fails loudly here.
 
+**One double is weaker than the rest, and it is worth knowing which.**
+:func:`nodriver.start` ends in ``**kwargs``, so its autospec accepts any keyword
+at all -- measured. It catches surplus *positional* arguments and nothing else.
+A nodriver release that renamed ``browser_executable_path`` would slip past this
+module and fail only against a real browser. The three internal collaborators
+(`_launch_chromium`, `_wait_for_devtools_ready`, `_terminate_process`) have no
+``**kwargs`` and are fully checked.
+
 **The real `nodriver` package is used, with only `nodriver.start` patched.** The
 previous version installed a stand-in module built with
 ``type("X", (), {"start": ...})``. That could never have worked even with the
@@ -40,8 +48,8 @@ import os
 import tempfile
 import unittest
 from collections.abc import Iterator
-from typing import Any, Protocol, runtime_checkable
-from unittest.mock import create_autospec, patch
+from typing import Any
+from unittest.mock import MagicMock, create_autospec, patch
 
 import nodriver
 
@@ -70,37 +78,39 @@ READ_ENVIRONMENT_VARIABLES = (
 
 #: A browser path the tests hand to `_fetch_html` directly, so the executable
 #: resolver short-circuits on its first branch and no `PATH` probe happens.
+#: Deliberately not under ``/snap/``: `_is_snap_browser` keys on that prefix and
+#: a snap browser multiplies the retry backoff by three, which would make the
+#: timing of these tests depend on where the developer's Chromium came from.
 BROWSER_PATH = "/usr/bin/chromium-for-tests"
 
-
-@runtime_checkable
-class ChromiumProcess(Protocol):
-    """The surface a launched Chromium process must present to the worker.
-
-    `_terminate_process` reads ``pid`` and ``returncode``, and
-    `_wait_for_devtools_ready` reads ``returncode`` to notice a browser that
-    died before its endpoint came up. Both are doubled in this module, so
-    nothing here exercises those reads -- the Protocol exists to keep the stub
-    honest anyway, because a double that has silently lost an attribute its real
-    collaborators need is a double that will keep passing after the code stops
-    working.
-
-    It is a Protocol rather than an autospec of
-    :class:`asyncio.subprocess.Process` for a measured reason, pinned by
-    :meth:`TestProcessDoubleShape.test_autospec_of_a_process_omits_its_streams`.
-    """
-
-    pid: int
-    returncode: int | None
+#: A ceiling on any single `_fetch_html` call. The cases take about 0.1 s; this
+#: exists so a regression that fails to terminate the retry loop fails the test
+#: instead of hanging the suite.
+PER_TEST_TIMEOUT_SECONDS = 10.0
 
 
 class StubChromiumProcess:
-    """A launched-Chromium stand-in that satisfies :class:`ChromiumProcess`.
+    """A launched-Chromium stand-in, carrying only what its readers read.
+
+    `_terminate_process` reads ``pid`` and ``returncode``;
+    `_wait_for_devtools_ready` reads ``returncode`` to notice a browser that
+    died before its endpoint came up. `_fetch_html` itself reads neither -- it
+    holds the object and hands it to those two, both of which are doubled here
+    -- so this stub exists to be *identifiable*, not to be exercised. Distinct
+    pids are what let an assertion say which attempt's process was terminated
+    rather than only how many terminations happened.
+
+    It is a hand-written stub rather than
+    ``create_autospec(asyncio.subprocess.Process)`` because that autospec
+    supplies no ``pid`` at all: autospec copies a class's methods and
+    class-level descriptors, not the attributes ``__init__`` assigns. The
+    canonical typed definition of this shape belongs in production, and a later
+    step in this epic puts it there; declaring a second one here would be the
+    drift that step exists to prevent, so this stays a local stub with a
+    comment rather than a competing contract.
 
     Args:
-        pid: The process id to report. Distinct per attempt in the retry cases,
-            so an assertion can tell *which* attempt's process was terminated
-            rather than only how many terminations happened.
+        pid: The process id to report.
     """
 
     def __init__(self, pid: int) -> None:
@@ -112,54 +122,31 @@ class StubChromiumProcess:
         return f"<StubChromiumProcess pid={self.pid}>"
 
 
-class StubPage:
-    """A browser tab that returns fixed content.
+def make_browser_double(
+    html: str = "<html><body>ok</body></html>",
+) -> tuple[Any, Any]:
+    """Build a connected-browser double and the tab it hands out.
+
+    Autospecced from the real :class:`nodriver.Browser` and
+    :class:`nodriver.Tab` rather than hand-written, for the same reason as
+    everything else here: a hand-written stand-in accepts any call, which is the
+    defect this module was rewritten to remove. It also gets a detail right that
+    a hand-written one had wrong -- ``Browser.stop`` is **synchronous** while
+    ``Tab.get_content`` and ``Tab.close`` are coroutines (measured). `_cleanup`
+    tolerates both by checking :func:`asyncio.iscoroutine` on the result, so a
+    double with the wrong one would pass while misrepresenting the real object.
 
     Args:
-        html: The document `get_content` returns.
+        html: The document the tab returns from ``get_content``.
+
+    Returns:
+        The browser double and the tab double it returns from ``get``.
     """
-
-    def __init__(self, html: str) -> None:
-        self.html = html
-        self.closed = False
-
-    def get_content(self) -> str:
-        """Return the page's HTML, the way nodriver's synchronous accessor does."""
-        return self.html
-
-    async def close(self) -> None:
-        """Record that the worker closed this tab."""
-        self.closed = True
-
-
-class StubBrowser:
-    """A connected browser that hands out one :class:`StubPage`.
-
-    Args:
-        html: The document every tab returns.
-    """
-
-    def __init__(self, html: str = "<html><body>ok</body></html>") -> None:
-        self.html = html
-        self.pages: list[StubPage] = []
-        self.stopped = False
-
-    async def get(self, _url: str) -> StubPage:
-        """Open a tab and return it.
-
-        Args:
-            _url: Ignored; navigation targets are not this module's subject.
-
-        Returns:
-            A new stub tab.
-        """
-        page = StubPage(self.html)
-        self.pages.append(page)
-        return page
-
-    async def stop(self) -> None:
-        """Record that the worker stopped the browser."""
-        self.stopped = True
+    page = create_autospec(nodriver.Tab, instance=True)
+    page.get_content.return_value = html
+    browser = create_autospec(nodriver.Browser, instance=True)
+    browser.get.return_value = page
+    return browser, page
 
 
 class Doubles:
@@ -176,6 +163,9 @@ class Doubles:
         temporary_directory: Wraps the real :class:`tempfile.TemporaryDirectory`
             so its keyword arguments can be inspected without losing the real
             create-and-remove behaviour.
+        which: Stands in for :func:`shutil.which`, pinned to find nothing.
+        recorder: A parent mock the four doubles are attached to, so their calls
+            land in one ordered list.
         processes: Every process the launch double handed out, in order.
     """
 
@@ -186,7 +176,22 @@ class Doubles:
         self.pick_port: Any = None
         self.start: Any = None
         self.temporary_directory: Any = None
+        self.which: Any = None
+        self.recorder: Any = MagicMock()
         self.processes: list[StubChromiumProcess] = []
+
+    def call_sequence(self) -> list[str]:
+        """Return the doubled calls in the order they actually happened.
+
+        Per-double call *counts* cannot distinguish "each failed attempt was
+        terminated before the next began" from "every process was terminated in
+        one batch at the end" -- both give the same two numbers. Attaching the
+        doubles to a shared parent records one interleaved sequence, which can.
+
+        Returns:
+            One name per call, in order, from :attr:`recorder`.
+        """
+        return [call[0] for call in self.recorder.mock_calls]
 
     def terminated_processes(self) -> list[Any]:
         """Return the process object of each `_terminate_process` call, in order.
@@ -227,6 +232,13 @@ def orchestration_harness(
     fixed 100 ms `_cleanup` waits for Chromium to flush profile writes, which is
     behaviour under test rather than a wait for a condition.
 
+    :func:`shutil.which` is pinned to "nothing installed" even though four of
+    the five cases hand `_fetch_html` an explicit executable and never reach the
+    probe. The design states the rule and the reason: a case that leaves the
+    real lookup in place is a case whose result depends on whether the developer
+    has Chromium installed, and it would start depending on it the day the
+    resolver consults ``PATH`` first.
+
     Args:
         environment: Variables to set for the duration, on top of a cleared
             slate. Anything in :data:`READ_ENVIRONMENT_VARIABLES` and not named
@@ -266,6 +278,9 @@ def orchestration_harness(
                 autospec=True,
                 side_effect=real_temporary_directory,
             ) as temporary_directory,
+            patch.object(
+                nodriver_worker.shutil, "which", autospec=True, return_value=None
+            ) as which,
         ):
             launch.side_effect = _new_process
             pick_port.return_value = 9222
@@ -275,6 +290,14 @@ def orchestration_harness(
             doubles.pick_port = pick_port
             doubles.start = start
             doubles.temporary_directory = temporary_directory
+            doubles.which = which
+            # Attaching to a shared parent is what makes the *order* of these
+            # calls observable; it leaves each double's own arity checking
+            # intact (measured).
+            doubles.recorder.attach_mock(launch, "launch")
+            doubles.recorder.attach_mock(wait_ready, "wait_ready")
+            doubles.recorder.attach_mock(start, "connect")
+            doubles.recorder.attach_mock(terminate, "terminate")
             yield doubles
     finally:
         for name, value in saved.items():
@@ -292,11 +315,29 @@ async def fetch_html(**overrides: Any) -> str:
     type checker on its own call to the function under test would be
     self-defeating.
 
+    Every call is bounded by :func:`asyncio.wait_for`. The design requires each
+    test at this layer to carry a timeout shorter than the job's, and the
+    function under test is a retry loop with sleeps in it: without a bound, a
+    regression that stops terminating the loop hangs the suite instead of
+    failing it. Ten seconds is far above the ~0.1 s these cases take and far
+    below any plausible job timeout.
+
+    The other anti-flake requirements at this layer do not bind here, because
+    nothing real is started: there is no endpoint to hand-shake with, no port to
+    allocate, no child whose pid must be reaped, and no child output to capture
+    on failure. Those apply to the lifecycle tests that use a real fixture
+    child.
+
     Args:
         **overrides: Replacements for the defaults below.
 
     Returns:
         The HTML `_fetch_html` produced.
+
+    Raises:
+        TimeoutError: If the call does not finish within the bound, which means
+            the orchestration failed to terminate rather than failed an
+            assertion.
     """
     kwargs: dict[str, Any] = {
         "referer": None,
@@ -311,17 +352,20 @@ async def fetch_html(**overrides: Any) -> str:
     }
     kwargs.update(overrides)
     url = kwargs.pop("url", "https://example.com")
-    return await nodriver_worker._fetch_html(
-        url,
-        referer=kwargs["referer"],
-        user_agent=kwargs["user_agent"],
-        wait_seconds=kwargs["wait_seconds"],
-        browser_executable_path=kwargs["browser_executable_path"],
-        reuse_browser=kwargs["reuse_browser"],
-        remote_host=kwargs["remote_host"],
-        remote_port=kwargs["remote_port"],
-        user_data_dir=kwargs["user_data_dir"],
-        overall_timeout_seconds=kwargs["overall_timeout_seconds"],
+    return await asyncio.wait_for(
+        nodriver_worker._fetch_html(
+            url,
+            referer=kwargs["referer"],
+            user_agent=kwargs["user_agent"],
+            wait_seconds=kwargs["wait_seconds"],
+            browser_executable_path=kwargs["browser_executable_path"],
+            reuse_browser=kwargs["reuse_browser"],
+            remote_host=kwargs["remote_host"],
+            remote_port=kwargs["remote_port"],
+            user_data_dir=kwargs["user_data_dir"],
+            overall_timeout_seconds=kwargs["overall_timeout_seconds"],
+        ),
+        timeout=PER_TEST_TIMEOUT_SECONDS,
     )
 
 
@@ -379,8 +423,9 @@ class TestNodriverWorkerSandbox(unittest.IsolatedAsyncioTestCase):
         afterwards. The real :class:`tempfile.TemporaryDirectory` runs -- a mock
         in its place would leave the second half asserting against itself.
         """
+        browser, _page = make_browser_double()
         with orchestration_harness() as doubles:
-            doubles.start.return_value = StubBrowser()
+            doubles.start.return_value = browser
 
             html = await fetch_html()
 
@@ -421,7 +466,7 @@ class TestNodriverWorkerSandbox(unittest.IsolatedAsyncioTestCase):
         attempt makes "stopped retrying" a distinct, observable fact from "ran
         out of attempts": without the break a third browser is launched.
         """
-        browser = StubBrowser()
+        browser, page = make_browser_double()
         with orchestration_harness(
             environment={"KINDLY_NODRIVER_RETRY_ATTEMPTS": "3"}
         ) as doubles:
@@ -445,7 +490,19 @@ class TestNodriverWorkerSandbox(unittest.IsolatedAsyncioTestCase):
         # Comparing the objects rather than counting them is what distinguishes
         # "each attempt was cleaned up" from "one was cleaned up twice".
         self.assertEqual(doubles.terminated_processes(), doubles.processes)
-        self.assertTrue(browser.stopped, "the browser was left running")
+        # `Browser.stop` is synchronous on the real class, so this is a plain
+        # call assertion rather than an await assertion. `_cleanup` branches on
+        # `asyncio.iscoroutine` and tolerates either, which is exactly why the
+        # double has to be shaped like the real object rather than by hand.
+        browser.stop.assert_called_once_with()
+        page.close.assert_awaited_once_with()
+        # The failed attempt is cleaned up *before* the retry, not batched with
+        # the rest at the end. Counts cannot tell those apart; order can.
+        self.assertEqual(
+            doubles.call_sequence(),
+            ["launch", "wait_ready", "connect", "terminate",
+             "launch", "wait_ready", "connect", "terminate"],
+        )
 
     async def test_retries_and_terminates_on_devtools_timeout(self) -> None:
         """Terminate every attempt whose DevTools endpoint never came up
@@ -474,6 +531,13 @@ class TestNodriverWorkerSandbox(unittest.IsolatedAsyncioTestCase):
             "never became ready",
         )
         self.assertEqual(doubles.terminated_processes(), doubles.processes)
+        # Each attempt is terminated before the next is launched. An
+        # implementation that reaped everything at the end would satisfy the
+        # call counts above and still strand a browser between attempts.
+        self.assertEqual(
+            doubles.call_sequence(),
+            ["launch", "wait_ready", "terminate", "launch", "wait_ready", "terminate"],
+        )
 
     async def test_does_not_retry_a_non_retryable_error(self) -> None:
         """Surface an unrecognised startup failure at once instead of retrying it
@@ -494,8 +558,13 @@ class TestNodriverWorkerSandbox(unittest.IsolatedAsyncioTestCase):
             with self.assertRaises(RuntimeError) as raised:
                 await fetch_html()
 
-        self.assertEqual(doubles.start.call_count, 1)
+        # This count is the load-bearing assertion. Deleting the retryable
+        # check makes the loop try three times and still re-raise the *same*
+        # exception object -- the attempts-exhausted rewrite fires only on a
+        # message match, which a non-retryable error by construction fails --
+        # so only the attempt count distinguishes the two behaviours.
         self.assertEqual(doubles.launch.call_count, 1)
+        self.assertEqual(doubles.start.call_count, 1)
         self.assertEqual(doubles.terminated_processes(), doubles.processes)
         # The original diagnosis must reach the caller. Asserting the
         # attempts-exhausted wording is *absent* is the half that discriminates:
@@ -512,14 +581,14 @@ class TestNodriverWorkerSandbox(unittest.IsolatedAsyncioTestCase):
         -- that it returns ``None`` -- is asserted at component level; the
         translation into advice happens here and is asserted here.
         """
-        with (
-            orchestration_harness() as doubles,
-            patch.object(
-                nodriver_worker.shutil, "which", autospec=True, return_value=None
-            ),
-            self.assertRaises(RuntimeError) as raised,
-        ):
-            await fetch_html(browser_executable_path=None)
+        with orchestration_harness() as doubles:
+            # The harness pins `shutil.which` to find nothing for every case.
+            # This is the case that depends on it, so it states the dependency
+            # rather than inheriting a default silently.
+            self.assertIsNone(doubles.which("chromium"))
+
+            with self.assertRaises(RuntimeError) as raised:
+                await fetch_html(browser_executable_path=None)
 
         message = str(raised.exception)
         self.assertIn("KINDLY_BROWSER_EXECUTABLE_PATH", message)
@@ -550,44 +619,6 @@ class TestNodriverWorkerSandbox(unittest.IsolatedAsyncioTestCase):
         payload = "Hello — 世界".encode("utf-8", errors="strict")
         nodriver_worker._safe_write_bytes(stream, payload)
         self.assertIn(b"Hello", stream.buffer.getvalue())
-
-
-class TestProcessDoubleShape(unittest.TestCase):
-    """Pin the measured autospec gap that decides how a process is doubled."""
-
-    def test_autospec_of_a_process_omits_its_streams(self) -> None:
-        """Record that an autospec process has no stream attributes
-
-        :func:`unittest.mock.create_autospec` copies a class's *methods* and its
-        class-level descriptors, not the instance attributes ``__init__``
-        assigns. On :class:`asyncio.subprocess.Process` that means ``stdout``,
-        ``stderr``, ``stdin`` and ``pid`` are absent while ``returncode``, being
-        a property on the class, survives.
-
-        The design cites this when it says a process double must be pinned by a
-        Protocol rather than by autospec, and a later step builds a typed fake
-        on the same fact. Until now it was prose. A ``mock`` release that started
-        declaring those attributes would make the reasoning obsolete silently;
-        this notices.
-        """
-        double = create_autospec(asyncio.subprocess.Process, instance=True)
-
-        for absent in ("stdout", "stderr", "stdin", "pid"):
-            self.assertFalse(
-                hasattr(double, absent),
-                f"create_autospec(Process) now supplies {absent!r}; the reason "
-                "this project doubles a process with a Protocol instead has "
-                "changed and the design should be revisited.",
-            )
-        self.assertTrue(
-            hasattr(double, "returncode"),
-            "create_autospec(Process) no longer supplies 'returncode', which "
-            "is a class-level property and was the one attribute it did carry.",
-        )
-
-    def test_the_process_stub_satisfies_the_protocol(self) -> None:
-        """Keep the stub in step with the surface the worker's collaborators read"""
-        self.assertIsInstance(StubChromiumProcess(pid=1), ChromiumProcess)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Context for the Product Owner

To read a JavaScript-heavy page, the server starts a headless Chromium in a
child process. Bringing one up is a sequence with several ways to go wrong: pick
a port, launch the browser, wait for it to answer, connect to it, retry if it
doesn't, kill any attempt that failed, delete the temporary profile. If the
retry or the kill misbehaves, browser processes accumulate on the machine and
are never cleaned up.

Three tests were supposed to guard that sequence. They had been failing since
the launch routine changed shape, and — as with the previous change in this
epic — repairing the obvious error would not have made them trustworthy. Four
further defects were hiding behind it, each measured rather than suspected.

They now pass, and they are hard to fool: an independently drawn set of 21
sabotages of the startup sequence is caught by 21 of them.

Suite: **7 failing → 4 failing**, 408 passing → 414.

---

## What this implements

Plan step **E1-3**, "Keep retry/cleanup orchestration at `_fetch_html`". These
claims stay at this layer permanently — `_fetch_html` is the child process's own
function and owns startup, retry and cleanup, and no resolver test can assert
that a process was terminated.

Three tests repaired in place, three added.

### The four defects behind the signature error

| Defect | Why repairing the signature alone would not have been enough |
|---|---|
| **Every double accepted any call.** Each collaborator was patched with a bare `AsyncMock`. | This is the original sin of the whole epic — it is exactly why five new required arguments disabled eight tests without one objecting. Every double is now `autospec`'d from the real callable. Demonstrated: adding a required argument to `_launch_chromium`, `_wait_for_devtools_ready`, `_terminate_process` or `_pick_free_port` now **fails** the tests. |
| **The fake `nodriver` module could never have worked.** | The tests installed `type("X", (), {"start": ...})` into `sys.modules`, but `_fetch_html` runs `cdp = uc.cdp` immediately after importing, before any branch. `nodriver` is an unconditional dependency, so the real module is used with only `start` patched — which is also what makes autospec of the connect call possible. |
| **A naive repair would have shelled out, invisibly.** | With `KINDLY_USER_AGENT` unset, `_resolve_user_agent` reaches `_detect_chrome_version`, which runs `<browser> --version`. Measured with a counting spy: **zero** real launches with the pin, **four** tests launching without it. A spy that *raises* sees nothing — `_detect_chrome_version` swallows it in `except Exception: pass`. |
| **The environment steered them.** | Fourteen variables now cleared per case, plus `shutil.which`, `os.geteuid` and the module's diagnostics global — none of the last three being environment variables. The module passes under a hostile environment and fails once the sweep is removed. |

### Two claims the step requires that no test made at all

- **A non-retryable error is not retried.** Nothing exercised the false branch of
  `_is_retryable_browser_connect_error`, so deleting the question turned every
  failure — a corrupt profile, a missing shared library — into three slow
  attempts and a message blaming the connection.
- **A missing browser executable surfaces actionable guidance.** This is the
  only useful message anyone gets when no browser is installed. It was the half
  of a test the previous step deleted that belonged to `_fetch_html` rather than
  to the resolver, and the plan was amended then to assign it here.

### A third, added during review

- **The retry backoff grows and scales for snap.** Every other case drives the
  base to zero, which makes `base * 2**attempt * multiplier` zero however it is
  written — so gutting the expression survived them all, while the harness
  docstring claimed the seam "exercises the real backoff arithmetic". One case
  now sets a real base and reads the durations back.

---

## The ledger drained under its strongest category

Running the guard **before** removing the ids reports all three under:

```
In the ledger, ran, and passed (a repair; delete the id):
  …::test_retries_and_terminates_on_devtools_timeout
  …::test_retries_on_failed_to_connect_to_browser
  …::test_uses_ignore_cleanup_errors_for_profile_dir
```

and raises no complaint of the other three kinds. That is the ledger's own rule
— *an id may leave only by passing* — met natively, because rewriting a test in
place keeps its node id. No relocation exception, no mapping table, nothing
taken on trust.

**This corrects a prediction the previous step recorded.** It warned that E1-3
and E1-4 would hit its relocation loophole. They do not, and the ledger now
explains why and re-aims the machine-readable-table recommendation at **E1-5**
by name — the one remaining step whose test name (`..._defaults_on_windows`)
cannot survive being made OS-neutral, so its id really will leave by deletion.

---

## A production defect found, reported, not fixed

`_is_snap_browser("/snap/bin/chromium")` returns **False** on Ubuntu. That path
is a symlink to `/usr/bin/snap`, and the function calls `os.path.realpath`
first — so the snap backoff multiplier does not apply to the single most common
way of having a snap-packaged Chromium. Measured on Ubuntu 24.04.

Fixing it is a production change with its own risk and is not this step's. The
backoff test therefore uses a fabricated `/snap/` path with no symlink to
follow. Worth noting that the *previous* version of this file used the real
`/snap/bin/chromium` believing it exercised the snap branch — it was asserting
the non-snap branch throughout.

---

## On the mutation evidence, honestly

The first battery here was 14 mutations, 14 caught. That claim was weaker than
it sounded: those mutations were written by the same author as the tests, from
the same mental model, so they agreed with them. An **independently drawn**
battery found **ten survivors**, the important one being `uc.start(port=port+1)`
— connecting on a different port than Chromium was launched on, which is
precisely the fault this retry loop exists to handle, green against every test.

Nothing asserted that the port and executable travelled intact between the four
collaborators, nor that a port is picked *per attempt* rather than once (reusing
one sends a retry at the port the previous, still-dying browser holds). Six
assertions close it.

The battery is now 21 and catches all 21 — stated as *coverage of what was
targeted*, not as absence of survivors.

<details><summary>21 mutations, 21 caught — full output</summary>

```
CAUGHT    R3: ignore_cleanup_errors dropped
            <- test_uses_ignore_cleanup_errors_for_profile_dir
CAUGHT    R3: profile prefix changed
            <- test_uses_ignore_cleanup_errors_for_profile_dir
CAUGHT    R1/R2: failed attempt is not terminated
            <- test_retries_and_terminates_on_devtools_timeout, test_retries_on_failed_to_connect_to_browser
CAUGHT    R1/R2: only one attempt is ever made
            <- test_backoff_grows_with_each_attempt_and_scales_for_snap, test_retries_and_terminates_on_devtools_timeout, test_retries_on_failed_to_connect_to_browser
CAUGHT    R4: the retryable check is dropped from the re-raise
            <- test_does_not_retry_a_non_retryable_error
CAUGHT    R5: the missing-browser raise is removed
            <- test_missing_browser_executable_names_the_override_variable
CAUGHT    R5: the override variable is dropped from the message
            <- test_missing_browser_executable_names_the_override_variable
CAUGHT    R1: the loop never breaks on a successful connect
            <- test_retries_on_failed_to_connect_to_browser
CAUGHT    R1: final cleanup no longer terminates the process
            <- test_retries_on_failed_to_connect_to_browser
CAUGHT    R2: the attempts-exhausted diagnosis is dropped
            <- test_retries_and_terminates_on_devtools_timeout
CAUGHT    R1: the browser is never stopped
            <- test_retries_on_failed_to_connect_to_browser
CAUGHT    R6 autospec: _launch_chromium gains a required argument
            <- test_backoff_grows_with_each_attempt_and_scales_for_snap, test_does_not_retry_a_non_retryable_error, test_retries_and_terminates_on_devtools_timeout, test_retries_on_failed_to_connect_to_browser, test_uses_ignore_cleanup_errors_for_profile_dir
CAUGHT    R6 autospec: _terminate_process gains a required argument
            <- test_backoff_grows_with_each_attempt_and_scales_for_snap, test_does_not_retry_a_non_retryable_error, test_retries_and_terminates_on_devtools_timeout, test_retries_on_failed_to_connect_to_browser
CAUGHT    R6 autospec: _wait_for_devtools_ready gains a required argument
            <- test_backoff_grows_with_each_attempt_and_scales_for_snap, test_devtools_probe_ignores_proxy_env, test_does_not_retry_a_non_retryable_error, test_retries_and_terminates_on_devtools_timeout, test_retries_on_failed_to_connect_to_browser, test_uses_ignore_cleanup_errors_for_profile_dir
CAUGHT    W2: readiness probes a different port than was launched
            <- test_uses_ignore_cleanup_errors_for_profile_dir
CAUGHT    W2: connect targets a different port than was launched
            <- test_uses_ignore_cleanup_errors_for_profile_dir
CAUGHT    W2: a different executable is launched than was resolved
            <- test_uses_ignore_cleanup_errors_for_profile_dir
CAUGHT    W2: the port is picked once instead of per attempt
            <- test_retries_and_terminates_on_devtools_timeout
CAUGHT    W3: the backoff exponent is dropped
            <- test_backoff_grows_with_each_attempt_and_scales_for_snap
CAUGHT    W3: the snap multiplier is dropped from the backoff
            <- test_backoff_grows_with_each_attempt_and_scales_for_snap
CAUGHT    W3: the profile-flush wait is removed
            <- test_backoff_grows_with_each_attempt_and_scales_for_snap

21/21 caught; survivors: none
```

</details>

---

## A timeout that took five times its own budget to unwind

The review found the per-test bound was necessary and not sufficient. Measured:
with the retry loop mutated to spin forever, the 10 s `asyncio.wait_for` fired
and the test then took **47 s** to report — because every doubled call is
recorded, and a loop with zero backoff records millions of them. A timeout that
behaves that way is the outcome a timeout exists to prevent.

Fixed at the cause rather than the symptom: the launch double refuses an
eleventh browser and fails with a sentence naming the loop. **47 s → 1.4 s.**
The wall-clock bound drops to 5 s and now only catches a hang that makes no
progress at all. Both facts are recorded in §5.4 so the next test at this layer
does not rediscover them.

---

## One decision deliberately not made

The design routes this group to the `subsystem` job, whose registered meaning is
*"needs a real socket or child process"* — which these tests, written correctly,
do not. Unmarked they fall into `fast`, and that matters beyond routing:
`.coveragerc-gate` omits `nodriver_worker.py`, and control 1 requires every
omitted module to show non-zero coverage in the observational report, which
`fast` does not produce.

Three resolutions are named in §5.2 for **E4-1**, which has to answer this
anyway. E1-3 changed nothing: the marker list is a contract guarded against the
design document, the control that depends on the answer does not exist yet, and
widening a registered meaning on speculation is the wrong direction.

---

## Verification

| Check | Result |
|---|---|
| Full suite | 4 failed, 414 passed, 2 skipped (from 7 failed, 408 passed) |
| Failing set vs. the ledger's Linux block | identical |
| Failing-set diff vs. `main` | three removals, **zero additions** |
| This module | 8 passed, 1.2 s |
| Mutation battery | 21 targeted, 21 caught |
| Real subprocess launches (counting spy) | **0** — and 4 tests launch once the user-agent pin is removed |
| Hostile environment exported | passes; fails once the sweep is removed |
| Ledger guard, incl. live child run | 15 passed |
| Review system's own suite | 482 passed |
| `scripts/check_plan_dag.py` | exit 0 |
| `ruff check` on the changed file | clean |

Reviewed by `system-design-reviewer` and `code-reviewer`; both initially
requested changes and every finding is implemented or recorded in the design
with its owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
