### PR TITLE
Reach the suite-green milestone, and repair what the Windows run found (plan step E1-6)

### DIFF
--- a/.system_design/BASELINE_FAILURES.md
+++ b/.system_design/BASELINE_FAILURES.md
@@ -16,9 +16,17 @@ and what `tests/test_baseline_failure_ledger.py` asserts against a live run.
 
 Every entry below is a test that fails today and is expected to. **E1-2 through
 E1-5 each delete exactly the ids they repair and add none.** E1-6 — the
-suite-green milestone — is reached when both blocks are empty, at which point the
-guard is asserting that a real run has no failures at all. The document and the
-milestone are therefore the same fact, checked once.
+suite-green milestone — needs both blocks empty.
+
+**It needs more than that, and the milestone proved it.** This paragraph used to
+end "the document and the milestone are therefore the same fact, checked once."
+That was false, and a real run is what showed it: at commit `38026ae` both blocks
+were empty, the guard was green on Linux, and **the suite was red on Windows** —
+because the failing test was newer than the platform's only measurement and no
+lane had run since. An empty ledger is a **necessary** condition for the
+milestone, never a sufficient one. It can only ever assert something about the
+platform the guard is running on, and a claim about a platform is worth exactly
+one run on it. See *"Verified — the suite-green milestone"* below.
 
 **An id may leave this ledger only by passing.** Deleting a test, renaming its
 class or marking it skipped removes it from the failing set too, and all three
@@ -93,6 +101,12 @@ failing set — so it is kept rather than deleted with E1-6. Its cost is one ext
 child run of the suite, roughly doubling wall time; that is accepted because the
 alternative is trusting twelve repaired tests to stay repaired with nothing
 watching them.
+
+**It has now paid for itself once, measurably.** On the first Windows run in this
+repository's history the guard — not a reviewer — caught the regression,
+classified it under *"Failing but not in the ledger (a regression; fix the test,
+do not add the id)"*, and named the one node id responsible. The instruction in
+that message is what was followed.
 
 ## What is asserted and what is provenance
 
@@ -243,17 +257,26 @@ four**: the test it retires failed *because* it faked a platform, its replacemen
 patches no platform attribute at all, and `_resolve_web_search_max_concurrency`
 reads one environment variable and one integer and nothing else.
 
-**E1-6 must still take its Windows figure from a real run**, not from this
-document. A drained document is evidence of nothing on a platform nobody ran, and
-with the two blocks now identical the cross-platform difference check below is a
-tautology. Distinguishing a run from an argument, above, is the whole reason this
-section survives to the milestone.
+**E1-6 took its Windows figure from a real run, and the run disagreed with the
+argument.** That was the point of insisting on one: a drained document is
+evidence of nothing on a platform nobody ran, and with the two blocks identical
+the cross-platform difference check below is a tautology. Distinguishing a run
+from an argument, above, is the whole reason this section survived to the
+milestone, and it earned its keep — the first Windows run in this repository's
+history found a real failure. See *"Verified — the suite-green milestone"* below
+for what it found and what it now records.
 
-**One claim went uncovered with E1-5, deliberately.** The three retired
-concurrency tests were, between them, the only thing in the tree that would
-notice an `os.name` branch reappearing in that resolver. Nothing asserts its
-absence now; the replacement's docstring says so, and E1-6's one real Windows run
-is the next thing to cover it.
+**The argument above was sound; it was also incomplete, and the distinction
+matters.** Every claim it makes about E1-2 through E1-5's *repairs* held up on
+Windows. What it could not cover is a test written **after** the baseline run and
+never executed on the platform at all — which is exactly what failed. An argument
+about the repairs is not an argument about the suite, and only a run is.
+
+**One claim went uncovered with E1-5, deliberately, and is now covered.** The
+three retired concurrency tests were, between them, the only thing in the tree
+that would notice an `os.name` branch reappearing in that resolver. E1-6's real
+Windows run is what covers it: the resolver produced identical results on both
+platforms, so no platform branch has reappeared in it.
 
 **The five-row relocation table above is not machine-checked, and stays that
 way.** It maps each retired id to the *function* its claim moved to. Converting
@@ -265,9 +288,109 @@ asserting a mapping this step never measured, which is attributing to another
 step's run a fact that run did not produce: the failure the `Result:`/
 `Remaining:` split exists to prevent, committed in a table instead of in a
 number. So it is declined, in writing, and **no later step is scoped to convert
-it** — E1-6 has no diff. Those five rows stand as prose backed by E1-2's one-off
-hand-run, which is what they have always been. The block below is machine-checked
+it**. Those five rows stand as prose backed by E1-2's one-off hand-run, which is
+what they have always been.
+
+**That decline used to rest on "E1-6 has no diff", and no longer can**, because
+E1-6 took one. The reason above is the real one and always was: the mapping was
+never measured, and no amount of diff budget in a later step conjures a
+measurement of a run that already happened. Re-grounded here rather than left
+resting on a premise the milestone falsified — a conclusion propped up by a
+stale fact is how a deliberate trade-off gets mistaken for an accident. The block below is machine-checked
 and says so.
+
+## Verified — the suite-green milestone
+
+Both platforms, measured. This section is the milestone's evidence and is the
+only place in this document where a **Windows figure comes from a run** rather
+than from the argument recorded above.
+
+It carries no `Result:` bullet, deliberately: `_documented_platform_headings`
+identifies a platform section by exactly that line, so a bullet of that shape
+here would manufacture a phantom platform and fail
+`test_ledger_documents_every_platform_the_guard_knows`. The same constraint the
+*"Relocated claims"* section below records, for the same reason.
+
+- **Linux** · 2026-09-02 · Ubuntu 24.04.4 LTS · Linux 6.8.0-138 ·
+  CPython 3.13.15 · pytest 9.1.1 · pytest-asyncio 1.4.0 · hypothesis 6.167.1 ·
+  mcp 1.29.1 · starlette 1.6.0 · uvicorn 0.52.4 · nodriver 0.50.3 —
+  **0 failed, 449 passed, 2 skipped, 16 subtests passed.**
+- **Windows** · 2026-09-02 · Windows Server 2025 (10.0.26100) ·
+  GitHub Actions `windows-latest` · CPython 3.13.15 · same dependency set,
+  verified from the run's own `pip list` —
+  **0 failed, 449 passed, 2 skipped, 16 subtests passed.**
+
+The two runs agree exactly, including the subtest count, which is a stronger
+result than the milestone required and is worth stating: the suite is not merely
+green on both, it is green in the same shape on both. That reconciliation is the
+check worth making on any recorded pair — a divergence would mean a test collects
+on one platform and not the other, which is the condition this milestone is the
+last opportunity to notice before the CI matrix exists.
+
+**Both figures are one-off developer-driven runs, and the Linux one is no more
+routine than the Windows one.** `ci.yml` states in terms that it does not run
+`pytest`; there is no lane on either platform. Neither number is re-derived by
+anything until the CI epic.
+
+Measured on the same throwaway-branch instrument the Windows baseline used — a
+temporary workflow on a branch of its own, deleted once the numbers were
+recorded. It touched neither `ci.yml` nor any workflow region the implementation
+plan serialises, and **it is not the Windows CI lane**; that still arrives with
+the CI epic. Nothing re-runs these two figures, which is why the milestone is
+immediately followed by the workflow that makes them enforceable.
+
+### What the first Windows run found
+
+**It was red**, and the failure was real:
+
+```console
+2 failed, 446 passed, 2 skipped, 16 subtests passed
+FAILED tests/test_nodriver_worker_sandbox.py::TestNodriverWorkerSandbox::test_backoff_grows_with_each_attempt_and_scales_for_snap
+FAILED tests/test_baseline_failure_ledger.py::test_live_outcome_matches_the_ledger
+```
+
+The second is this guard, reporting the first under *"Failing but not in the
+ledger (a regression; fix the test, do not add the id)"*. It is one defect, not
+two, and the guard behaved exactly as designed on a platform it had never run on.
+
+**The id was not added to the Windows block.** The instruction in the guard's own
+message is the rule this document states — a new red test is a regression, and
+this ledger holds what is left of the pre-existing twelve. The block stayed empty
+and the test was repaired.
+
+**Root cause, established on the platform rather than argued.** The test drove
+the retry backoff `base * 2**attempt * snap_multiplier` and expected the snap
+multiplier to apply, which needs `_is_snap_browser` to answer `True` for a
+`/snap/`-prefixed path. That function calls `os.path.realpath`, which is
+platform-dependent. A probe step in the same temporary workflow ran the shipped
+function on the runner:
+
+```console
+'/snap/bin/chromium-for-tests' -> realpath='D:\snap\bin\chromium-for-tests' is_snap=False
+```
+
+Windows rewrites the separators and prepends a drive letter, so the `/snap/`
+marker cannot survive and **no path whatsoever classifies as snap there**. The
+recorded delays were the un-multiplied series. Production is correct and was left
+alone — snap is a Linux packaging format — so the defect was the test's, and the
+repair injects the classification through a seam instead of deriving it from the
+host's path semantics. The wiring that remains asserted, and the coverage given
+up, are stated in that test's docstring and in `TEST_SUITE.md`.
+
+**No relocation row was added, and none is needed.** The test was rewritten in
+place under its existing node id, which is the pattern this document says to
+prefer: the id never left the collected set, so nothing left this ledger by
+deletion and *"Relocated claims"* is untouched. Stated because it is the first
+question this document trains a reader to ask.
+
+**Why nothing caught it earlier, and why that is the lesson.** The test landed
+2026-09-01, at commit `a95462e`; the Windows baseline was measured 2026-08-31 at
+commit `3af0563`. It is **newer than the only Windows run this repository had
+ever had**, and no lane has run since. The drain argument above covers the
+*repairs* E1-2 through E1-5 made, and every part of it held. It could not cover a
+test written after the measurement and never executed on the platform, because no
+argument can. That gap closes only with a Windows lane, not with a better
+argument.
 
 ## Relocated claims
 
@@ -336,11 +459,13 @@ pass everything that actually runs.
 **It is a weaker check than the one it replaces, and knowingly so.** While the
 blocks differed, this section pinned a verified Windows fact. Empty, it says
 only that the two blocks match — which two identically *wrong* blocks also
-satisfy. Combined with the Windows section being unmeasurable until the CI
-epic's Windows lane exists, that means the Windows block is now asserted by
-nothing that runs. E1-6 must not read "0 failed on both platforms" off this
-document: the Linux half is checked against a real run, the Windows half is a
-claim awaiting its lane.
+satisfy. That was the whole of the Windows evidence until the milestone, which is
+why E1-6 was forbidden to read "0 failed on both platforms" off this document.
+**It did not: it ran the suite on Windows, found a failure this section could
+never have shown, and recorded the result below.** The warning is kept in the
+past tense rather than deleted, because the same hole reopens the moment a test
+is added that no Windows lane executes — which is precisely how the failure got
+in, and it stays open until the CI epic's matrix exists.
 
 ```text
 ```
@@ -393,8 +518,14 @@ different word.
 Four of those eleven left with E1-2, three more with E1-3, three more with E1-4
 and the last with E1-5, hence none remaining. **All eleven left by inference, not
 by a run** — that argument is stated once, in *"How each block was drained"*
-above, and is not repeated here; what it rests on is that no repair touches a
-branch reading `os.name` or `sys.platform`. E1-5's id is the one that most
+above, and is not repeated here. The *end state* it argued for has since been
+confirmed by a real Windows run, recorded under *"Verified — the suite-green
+milestone"*; the drains themselves were still taken on the argument, and that
+distinction is kept rather than smoothed over. What the argument rests on is that
+no repair **asserts a value computed by** a branch reading `os.name` or
+`sys.platform` — the precise phrasing the section above uses, restored here,
+where this sentence had kept the looser "touches" wording that section explicitly
+records as false. E1-5's id is the one that most
 obviously could have: it left because the test *faked* a platform the resolver
 never reads. **The frozen `3 skipped` is now
 stale by one:** the third skip *was*

--- a/.system_design/BASELINE_FAILURES.md
+++ b/.system_design/BASELINE_FAILURES.md
@@ -319,14 +319,33 @@ here would manufacture a phantom platform and fail
 `test_ledger_documents_every_platform_the_guard_knows`. The same constraint the
 *"Relocated claims"* section below records, for the same reason.
 
-- **Linux** · 2026-09-02 · Ubuntu 24.04.4 LTS · Linux 6.8.0-138 ·
+Both were taken at the tree of commit **`f3f5771`**, this step's last
+substantive commit. A figure that cannot be pinned to a tree cannot be
+re-derived or falsified, which in a document arguing that a platform claim is
+worth exactly one run would be self-defeating.
+
+- **Linux** · 2026-09-02 · commit `f3f5771` · Ubuntu 24.04.4 LTS ·
+  Linux 6.8.0-138 · CPython 3.13.15 · pytest 9.1.1 · pytest-asyncio 1.4.0 ·
+  hypothesis 6.167.1 · mcp 1.29.1 · starlette 1.6.0 · uvicorn 0.52.4 ·
+  nodriver 0.50.3 —
+  **0 failed, 449 passed, 2 skipped, 16 subtests passed.**
+- **Windows** · 2026-09-02 · commit `f3f5771`, run as probe commit `3cc4a88` ·
+  Windows Server 2025 (10.0.26100) · GitHub Actions `windows-latest` ·
   CPython 3.13.15 · pytest 9.1.1 · pytest-asyncio 1.4.0 · hypothesis 6.167.1 ·
-  mcp 1.29.1 · starlette 1.6.0 · uvicorn 0.52.4 · nodriver 0.50.3 —
+  mcp 1.29.1 · starlette 1.6.0 · uvicorn 0.52.4 · nodriver 0.50.3, read from the
+  run's own `pip list` —
   **0 failed, 449 passed, 2 skipped, 16 subtests passed.**
-- **Windows** · 2026-09-02 · Windows Server 2025 (10.0.26100) ·
-  GitHub Actions `windows-latest` · CPython 3.13.15 · same dependency set,
-  verified from the run's own `pip list` —
-  **0 failed, 449 passed, 2 skipped, 16 subtests passed.**
+
+`3cc4a88` is `f3f5771` plus the temporary workflow file and nothing else,
+verified with `git diff --stat` before the run and quoted in the pull request. It
+is named rather than hidden because the sha the runner reported is the one a
+reader would look for, and it no longer exists — the branch was deleted, as the
+instrument requires.
+
+**The commit recording these figures is necessarily later than `f3f5771`**, since
+a run cannot name the commit that records it. Its diff against `f3f5771` is this
+subsection alone. Stated because this document treats an unpinnable measurement
+as no measurement, and the same standard applies to its own bookkeeping.
 
 The two runs agree exactly, including the subtest count, which is a stronger
 result than the milestone required and is worth stating: the suite is not merely

--- a/.system_design/BASELINE_FAILURES.md
+++ b/.system_design/BASELINE_FAILURES.md
@@ -103,10 +103,12 @@ alternative is trusting twelve repaired tests to stay repaired with nothing
 watching them.
 
 **It has now paid for itself once, measurably.** On the first Windows run in this
-repository's history the guard — not a reviewer — caught the regression,
-classified it under *"Failing but not in the ledger (a regression; fix the test,
-do not add the id)"*, and named the one node id responsible. The instruction in
-that message is what was followed.
+repository's history it **classified** the regression — plain `pytest` reported
+the failing test too, so detection is not the claim. What the guard added is the
+judgement: it placed the failure under *"Failing but not in the ledger (a
+regression; fix the test, do not add the id)"* rather than leaving a reader to
+decide whether an unfamiliar red test on an unmeasured platform was a baseline
+entry. The instruction in that message is what was followed.
 
 ## What is asserted and what is provenance
 
@@ -258,10 +260,12 @@ patches no platform attribute at all, and `_resolve_web_search_max_concurrency`
 reads one environment variable and one integer and nothing else.
 
 **E1-6 took its Windows figure from a real run, and the run disagreed with the
-argument.** That was the point of insisting on one: a drained document is
-evidence of nothing on a platform nobody ran, and with the two blocks identical
-the cross-platform difference check below is a tautology. Distinguishing a run
-from an argument, above, is the whole reason this section survived to the
+milestone claim** — with *"the suite is green"*, not with the drain argument
+below, which held in every particular. That was the point of insisting on one: a
+drained document is evidence of nothing on a platform nobody ran, and with the
+two blocks identical the cross-platform difference check below is a tautology.
+Distinguishing a run from an argument, above, is the whole reason this section
+survived to the
 milestone, and it earned its keep — the first Windows run in this repository's
 history found a real failure. See *"Verified — the suite-green milestone"* below
 for what it found and what it now records.
@@ -272,11 +276,13 @@ Windows. What it could not cover is a test written **after** the baseline run an
 never executed on the platform at all — which is exactly what failed. An argument
 about the repairs is not an argument about the suite, and only a run is.
 
-**One claim went uncovered with E1-5, deliberately, and is now covered.** The
-three retired concurrency tests were, between them, the only thing in the tree
-that would notice an `os.name` branch reappearing in that resolver. E1-6's real
-Windows run is what covers it: the resolver produced identical results on both
-platforms, so no platform branch has reappeared in it.
+**One claim went uncovered with E1-5, deliberately, and E1-6's run covered it
+once.** The three retired concurrency tests were, between them, the only thing in
+the tree that would notice an `os.name` branch reappearing in that resolver.
+E1-6's real Windows run covered it: the resolver produced identical results on
+both platforms, so no platform branch had reappeared as of that run. **The cover
+is not standing** — it was one run, nothing re-derives it until the CI matrix, and
+nothing asserts the branch's absence in the meantime.
 
 **The five-row relocation table above is not machine-checked, and stays that
 way.** It maps each retired id to the *function* its claim moved to. Converting
@@ -288,16 +294,18 @@ asserting a mapping this step never measured, which is attributing to another
 step's run a fact that run did not produce: the failure the `Result:`/
 `Remaining:` split exists to prevent, committed in a table instead of in a
 number. So it is declined, in writing, and **no later step is scoped to convert
-it**. Those five rows stand as prose backed by E1-2's one-off hand-run, which is
-what they have always been.
+it**. (*"Below"* here means *"Relocated claims"*, two sections down; the
+*"Verified"* section now between them is a record of two runs and is explicitly
+not machine-checked.) Those five rows stand as prose backed by E1-2's one-off
+hand-run, which is what they have always been.
 
 **That decline used to rest on "E1-6 has no diff", and no longer can**, because
 E1-6 took one. The reason above is the real one and always was: the mapping was
 never measured, and no amount of diff budget in a later step conjures a
 measurement of a run that already happened. Re-grounded here rather than left
 resting on a premise the milestone falsified — a conclusion propped up by a
-stale fact is how a deliberate trade-off gets mistaken for an accident. The block below is machine-checked
-and says so.
+stale fact is how a deliberate trade-off gets mistaken for an accident. The
+block two sections down is machine-checked and says so.
 
 ## Verified — the suite-green milestone
 
@@ -462,7 +470,8 @@ only that the two blocks match — which two identically *wrong* blocks also
 satisfy. That was the whole of the Windows evidence until the milestone, which is
 why E1-6 was forbidden to read "0 failed on both platforms" off this document.
 **It did not: it ran the suite on Windows, found a failure this section could
-never have shown, and recorded the result below.** The warning is kept in the
+never have shown, and recorded the result in *"Verified — the suite-green
+milestone"* above.** The warning is kept in the
 past tense rather than deleted, because the same hole reopens the moment a test
 is added that no Windows lane executes — which is precisely how the failure got
 in, and it stays open until the CI epic's matrix exists.

--- a/.system_design/BASELINE_FAILURES.md
+++ b/.system_design/BASELINE_FAILURES.md
@@ -396,8 +396,10 @@ function on the runner:
 '/snap/bin/chromium-for-tests' -> realpath='D:\snap\bin\chromium-for-tests' is_snap=False
 ```
 
-Windows rewrites the separators and prepends a drive letter, so the `/snap/`
-marker cannot survive and **no path whatsoever classifies as snap there**. The
+A path with a single leading slash is not absolute on Windows, so `realpath`
+joins it against the current working drive and normalises the separators — the
+`/snap/` marker cannot survive and **no path whatsoever classifies as snap
+there**. The `D:` above is whichever drive the checkout sat on, not a constant. The
 recorded delays were the un-multiplied series. Production is correct and was left
 alone — snap is a Linux packaging format — so the defect was the test's, and the
 repair injects the classification through a seam instead of deriving it from the

--- a/.system_design/BASELINE_FAILURES.md
+++ b/.system_design/BASELINE_FAILURES.md
@@ -319,32 +319,35 @@ here would manufacture a phantom platform and fail
 `test_ledger_documents_every_platform_the_guard_knows`. The same constraint the
 *"Relocated claims"* section below records, for the same reason.
 
-Both were taken at the tree of commit **`f3f5771`**, this step's last
+Both were taken at the tree of commit **`926a57a`**, this step's last
 substantive commit. A figure that cannot be pinned to a tree cannot be
 re-derived or falsified, which in a document arguing that a platform claim is
 worth exactly one run would be self-defeating.
 
-- **Linux** · 2026-09-02 · commit `f3f5771` · Ubuntu 24.04.4 LTS ·
+- **Linux** · 2026-09-02 · commit `926a57a` · Ubuntu 24.04.4 LTS ·
   Linux 6.8.0-138 · CPython 3.13.15 · pytest 9.1.1 · pytest-asyncio 1.4.0 ·
   hypothesis 6.167.1 · mcp 1.29.1 · starlette 1.6.0 · uvicorn 0.52.4 ·
   nodriver 0.50.3 —
   **0 failed, 449 passed, 2 skipped, 16 subtests passed.**
-- **Windows** · 2026-09-02 · commit `f3f5771`, run as probe commit `3cc4a88` ·
+- **Windows** · 2026-09-02 · commit `926a57a`, run as probe commit `9c6d2b4` ·
   Windows Server 2025 (10.0.26100) · GitHub Actions `windows-latest` ·
   CPython 3.13.15 · pytest 9.1.1 · pytest-asyncio 1.4.0 · hypothesis 6.167.1 ·
   mcp 1.29.1 · starlette 1.6.0 · uvicorn 0.52.4 · nodriver 0.50.3, read from the
   run's own `pip list` —
   **0 failed, 449 passed, 2 skipped, 16 subtests passed.**
 
-`3cc4a88` is `f3f5771` plus the temporary workflow file and nothing else,
+`9c6d2b4` is `926a57a` plus the temporary workflow file and nothing else,
 verified with `git diff --stat` before the run and quoted in the pull request. It
 is named rather than hidden because the sha the runner reported is the one a
 reader would look for, and it no longer exists — the branch was deleted, as the
 instrument requires.
 
-**The commit recording these figures is necessarily later than `f3f5771`**, since
-a run cannot name the commit that records it. Its diff against `f3f5771` is this
-subsection alone. Stated because this document treats an unpinnable measurement
+**The commit recording these figures is necessarily later than `926a57a`**, since
+a run cannot name the commit that records it. Its diff against `926a57a` is this
+subsection alone. The suite was re-run on both platforms after every
+review-driven change rather than once at the start: this document is parsed by
+the guard, so a documentation edit really can move the result, and a figure
+pinned to a superseded tree is the failure the sha exists to prevent. Stated because this document treats an unpinnable measurement
 as no measurement, and the same standard applies to its own bookkeeping.
 
 The two runs agree exactly, including the subtest count, which is a stronger

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -71,8 +71,12 @@ collected" complaint, which fires only for ids still listed, so a dropped claim
 and a repair look identical. The ledger now carries machine-readable
 `<retired id> -> <replacement id>` rows and the guard holds each replacement to
 the same child run. Linux is measured; the Windows blocks were drained on a
-stated argument, which E1-6 replaced with a real Windows run — and that run
-disagreed, which is why the insistence on it was worth the cost.
+stated argument, which E1-6 replaced with a real Windows run. **That run
+contradicted the milestone claim, not the drain argument** — the argument covered
+E1-2 through E1-5's repairs and held in every particular; what it could not cover
+was a test written after the measurement and never executed on the platform,
+which is what failed. No argument can. That is why the insistence on a run was
+worth its cost.
 
 ### 1.2 What is actually uncovered
 

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -54,8 +54,14 @@ not move. Baselines are quoted per platform, from real runs, or not quoted.
 repaired test from a repaired test alongside a newly broken one, so the failing
 **node ids** are recorded per platform in `BASELINE_FAILURES.md` and asserted
 against a live child run by `tests/test_baseline_failure_ledger.py`. E1-2 through
-E1-5 each delete exactly the ids they repair; E1-6 is reached when the ledger is
-empty, which is the same statement as the guard finding no failures.
+E1-5 each delete exactly the ids they repair; E1-6 needs the ledger empty.
+
+**"Empty ledger" and "no failures" are not the same statement, and E1-6 measured
+the difference.** At `38026ae` both blocks were empty and the guard was green —
+on Linux. The first Windows run in this repository's history found the suite red
+there. An empty ledger is necessary for the milestone and never sufficient,
+because the guard can only speak for the platform it runs on. See
+`BASELINE_FAILURES.md`, *"Verified — the suite-green milestone"*.
 
 **The ledger is now empty on both blocks** — E1-5 removed the last id. It also
 gave the guard a second invariant, because its repair *renamed* the test and so
@@ -65,7 +71,8 @@ collected" complaint, which fires only for ids still listed, so a dropped claim
 and a repair look identical. The ledger now carries machine-readable
 `<retired id> -> <replacement id>` rows and the guard holds each replacement to
 the same child run. Linux is measured; the Windows blocks were drained on a
-stated argument, which E1-6 must still replace with a real Windows run.
+stated argument, which E1-6 replaced with a real Windows run — and that run
+disagreed, which is why the insistence on it was worth the cost.
 
 ### 1.2 What is actually uncovered
 
@@ -910,12 +917,15 @@ conversion bug.
    resolver does not read. All three retirements are recorded as relocation rows
    rather than described in a pull request.
 
-   **One claim went uncovered, deliberately.** The three retired methods were,
-   between them, the only thing in the tree that would notice an `os.name` branch
-   reappearing in this resolver, and nothing asserts its absence now. E1-6's one
-   real Windows run is the next thing to cover it. Recorded here as well as in
-   the test's docstring and the ledger, because a coverage loss stated only where
-   the deletion happened is found only by whoever goes looking there.
+   **One claim went uncovered, deliberately, and E1-6's run covered it once.**
+   The three retired methods were, between them, the only thing in the tree that
+   would notice an `os.name` branch reappearing in this resolver, and nothing
+   asserts its absence. E1-6's real Windows run is what covered it: the resolver
+   produced identical results on both platforms, so no platform branch has
+   reappeared. **The cover is not standing** — it was one run, and nothing
+   re-derives it until the CI matrix. Recorded here as well as in the test's
+   docstring and the ledger, because a coverage loss stated only where the
+   deletion happened is found only by whoever goes looking there.
 
    **Each row states the single-line mutation it detects**, carried on the row
    rather than in prose, and reported when the row fails. The positivity guard
@@ -923,6 +933,57 @@ conversion bug.
    kills the negative row and leaves the zero row passing. `max(1, ...)` is an
    equivalent mutant — unreachable given the filter above it — and is triaged in
    the docstring instead of tested.
+
+5. **Verify the suite green on both platforms.** Predicted as a no-diff
+   milestone. It took a diff, because the one real Windows run it exists to
+   demand found a genuine failure — and the prediction is corrected here rather
+   than quietly failed, as E1-5's unsatisfiable clause was.
+
+   **The failure was a test asserting a platform-dependent value.** The retry
+   backoff case drove `base * 2**attempt * snap_multiplier` and expected the
+   multiplier to apply, which needs `_is_snap_browser` to answer `True`. That
+   function calls `os.path.realpath`, which on Windows rewrites the separators
+   and prepends a drive letter, so a `/snap/`-prefixed path loses the marker the
+   detector keys on and **nothing classifies as snap there**. Measured against
+   the shipped function on the runner, not inferred. Production is correct —
+   snap is a Linux packaging format — so the repair is the test's: the
+   classification is injected through a seam instead of derived from the host's
+   path semantics.
+
+   **The step it could not have been caught by is the point.** The test landed
+   the day *after* the Windows baseline was measured, so it was newer than the
+   platform's only run and no lane had executed it. The drain argument covers the
+   repairs E1-2 through E1-5 made and every part of it held; no argument can
+   cover a test written after the measurement. That gap closes with a lane, not
+   with better prose.
+
+   **Two alternatives were declined.** Patching `os.path.realpath` to the
+   identity keeps the real `startswith("/snap/")` derivation under test and gives
+   up strictly less — declined because it is a process-global, and this module's
+   harness avoids globals by policy, admitting exactly one exception
+   (`asyncio.sleep`, to observe a duration without waiting 4.5 s). Skipping the
+   snap half on non-POSIX is the cheaper fix and is declined outright: a
+   platform-gated skip is what the ledger's "Why the two platforms differ"
+   section existed to track, and reintroducing one reopens the skew the empty
+   block now asserts away.
+
+   **The seam's cost was measured and then repaid.** Injecting the answer gives
+   up the wiring from a *path shape* to the classification, which belongs to
+   E5-4 — the step that owns `_is_snap_browser` outright. What it keeps is
+   asserted explicitly: the detector is consulted, and about the path the caller
+   supplied. Measured — with that assertion removed, a mutation asking the
+   detector about the wrong path survives; with it, the mutation dies.
+
+   **A live mutant on the line being repaired was found and killed.** The
+   `if is_snap else 1.0` conditional was asserted by **nothing in the tree**:
+   deleting it, so every browser is multiplied, left the whole suite passing.
+   Every other case in that module sets the base backoff to zero, which makes the
+   product zero regardless. The seam would have made the hole permanent, since a
+   classification injected only as `True` can never reach the `else`. A
+   negative-polarity case now supplies it, and its expected series is exactly
+   what the affirmative case wrongly produced on Windows — so the platform bug
+   has to be spelled out to be asserted. **A test that patches a branch condition
+   owes the branch both polarities.**
 
 **B. Enforce green — immediately after A, before anything else.** The failure this
 document exists to fix was not that tests broke; it was that a red suite was

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -177,6 +177,35 @@ that never reach it: an environment-variable case that leaves the real lookup in
 place is a case whose result depends on whether the developer has Chromium
 installed.
 
+**`_is_snap_browser` reads the filesystem, and answers wrongly on both platforms
+for two different measured reasons.** Its only ambient input is
+`os.path.realpath`, so pin it —
+`monkeypatch.setattr(os.path, "realpath", …)` — in every case, on the same
+reasoning as `shutil.which` above: a case that leaves the real call in place
+answers differently depending on where the developer's Chromium came from.
+
+- **On Windows nothing classifies as snap, whatever the path.** A path with a
+  single leading slash is not absolute there, so `realpath` joins it against the
+  current working drive and normalises the separators; `/snap/bin/chromium`
+  becomes `<drive>:\snap\bin\chromium` and the `/snap/` marker the detector keys
+  on is erased. Measured against the shipped function on a `windows-latest`
+  runner. **This is correct production behaviour** — snap is a Linux packaging
+  format — and must not be "fixed" in the detector by matching separators.
+- **On Ubuntu the commonest snap install classifies as non-snap.** The real
+  `/snap/bin/chromium` is a symlink to `/usr/bin/snap`, which `realpath` follows
+  before the prefix test. That one is an **open production defect**, reported and
+  characterised rather than repaired; see §14.
+
+E1-6 hit the first of these and repaired the affected test by injecting the
+classification. The path-shape wiring it gave up belongs to **E5-4**, whose entry
+cites this section — the pointer runs both ways deliberately, because the layer
+split sends resolver tests to
+`tests/test_nodriver_worker_launch_resolvers.py` while the traps were first
+recorded in `tests/test_nodriver_worker_sandbox.py`, which an E5-4 author has no
+reason to open. E5-4 lands *after* E4-2 makes the cross-platform job required, so
+the obvious first assertion — a `/snap/` path is snap — turns a required gate red
+rather than a local run.
+
 **The `hasattr(os, "geteuid")` guard is not a testable branch.** Deleting the
 attribute exercises the *condition*, but the call sits inside a
 `try: … except Exception: pass`, so removing the guard makes the bare call raise
@@ -2247,3 +2276,14 @@ is nothing to test.
   `_is_snap_browser`), which implies breakage has happened and will recur.
 - **`_split_worker_diagnostics` is dead code** (§4.3), flagged for removal under
   a separate change.
+- **`_is_snap_browser` misclassifies the commonest snap install**, and the defect
+  is open. `/snap/bin/chromium` is a symlink to `/usr/bin/snap` on Ubuntu, and
+  the function calls `os.path.realpath` before testing for the `/snap/` prefix,
+  so the browser that most needs the longer DevTools timeout is the one that does
+  not get it. Measured on Ubuntu 24.04. Recorded here because it was previously
+  documented only in a test-module comment, which left E5-4 — the step that will
+  write the first direct test of this function — to choose unaided between
+  asserting a known-wrong answer and repairing production inside a testing step.
+  It should do the former, with the defect named; the repair deserves its own
+  change. §3.1 carries the detail, including the separate Windows behaviour that
+  is **not** a defect.

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -639,12 +639,29 @@ duplicating tests or touching the same files.
   blank, malformed, zero, negative. **String and list normalisation**
   (`_resolve_chrome_proxy`, `_resolve_chrome_proxy_bypass`, `_split_no_proxy_value`):
   unset, blank, single value, comma-separated with surrounding whitespace,
-  duplicate entries. **Detection** (`_detect_chrome_version`, `_resolve_user_agent`):
+  duplicate entries. **Version and user-agent**
+  (`_detect_chrome_version`, `_resolve_user_agent`):
   a stubbed executable reporting a known version, an executable that fails to run,
   and no executable at all — each returning a usable fallback rather than raising.
+  **Classification** (`_is_snap_browser`, `_is_retryable_browser_connect_error`):
+  each driven by its *input* rather than by an injected answer.
+  `_is_retryable_browser_connect_error` gets one exception of each polarity.
+  `_is_snap_browser` gets the path-shape wiring **E1-6 gave up** — a
+  `/snap/`-shaped path classifies as snap and a `/usr/bin/` one does not — with
+  `os.path.realpath` pinned, since that is this function's only ambient input.
+  **Read §3.1 before writing that case**: this function answers *wrongly* on both
+  platforms, for two different measured reasons, and the obvious first assertion
+  turns E4-2's required cross-platform gate red. Characterise the current answer
+  with the defect named in the docstring; do **not** repair production in a
+  testing step.
   **Composite** (`_resolve_worker_timeout_details`): the returned tuple is
-  consistent with the individual resolvers it composes. No function here is also
-  tested by E5-3 or E1-2.
+  consistent with the individual resolvers it composes.
+  No function in the five groups above is also tested by E5-3 or E1-2, and the
+  groups are exhaustive over this step's ownership list — a claim worth stating
+  because E5-4 is scoped by *exclusion*, so a function owned here but named in no
+  group is orphaned permanently rather than deferred. **E1-6 handed the
+  classification group its one retired claim**, and found the list short by two
+  when it went looking for the owner.
 - **E5-5.** `html_to_markdown`, `sanitize_markdown`, `extract_content_as_markdown`,
   `_apply_markdown_cap`, `_build_md_suffix_url` over E3-3's fragments.
   *Verify:* structural assertions (headings preserved, code fences intact, no raw
@@ -1039,7 +1056,7 @@ Five engineers.
 E1-4 goes to engineer B as soon as A's E2-1 lands; E2-3 waits on it. E4-1 is
 authored early but merges with E1-6, and E4-2 follows immediately — the gate is on
 within a day of green. Coverage work (E10-1) waits on E2-3. E3-2, E3-3, E3-5,
-E5-3, E5-6, E5-7, E8-4 are unassigned backlog. With `pr_authorable` steps open
+E5-3, E5-4, E5-6, E5-7, E8-4 are unassigned backlog. With `pr_authorable` steps open
 from day one (§2), the constraint on throughput is people, not the graph.
 
 In parallel, the maintainer works **X-1** — the only prerequisite blocking steps

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -306,7 +306,7 @@ it carries no X-number.
   asked for and holds each replacement to the live child run. It covers its own
   three retirements only; the five older rows stay prose, declined in writing
   with the reason, and nothing later is scoped to convert them.
-- **E1-6.** No diff. *Verify:* **0 failed** on Windows and Linux, and
+- **E1-6.** *Verify:* **0 failed** on Windows and Linux, and
   `BASELINE_FAILURES.md` lists no remaining ids — the two facts are checked
   together, since either alone can be true while the other is not. CI enforcement
   begins here. **The Windows half must come from a real Windows run**, not from
@@ -314,6 +314,26 @@ it carries no X-number.
   blocks became identical, which makes the cross-platform difference check a
   tautology, and nothing else asserts the Windows block until E4-1's matrix
   exists. A drained document is evidence of nothing on a platform nobody ran.
+  **"No diff" was the prediction, and it was wrong** — corrected here rather than
+  quietly failed, following E1-5's precedent for an unsatisfiable clause. The
+  clause that mattered is the one that held: the run was demanded, it was taken,
+  and it found the suite red on Windows. Insisting on the run is what this step
+  contributed; a step with no diff would have declared the milestone on a green
+  Linux run beside a drained document, which is exactly the pair of facts that
+  were both true while Windows was broken. Measured: `2 failed, 446 passed` at
+  `38026ae`.
+  **The step stays typed `milestone` even though it carries a diff.** Five steps
+  depend on it with the `complete` kind — E4-1 and E11-1 through E11-4 — and
+  `scripts/check_plan_dag.py` accepts `complete` only against a milestone,
+  decision, operation or external prerequisite. Retyping it to `PR` would break
+  those five dependencies at once for a bookkeeping reason. The type describes
+  what the step *is* — a verification gate its dependents schedule against — not
+  whether repairing what it found cost a diff, and the diff is the repair rather
+  than authorable work in its own right.
+  **What it repaired**, in one line: a retry-backoff test asserted a value
+  derived from `os.path.realpath`, which is platform-dependent, so it demanded a
+  snap multiplier that Windows can never produce. Detail in `TEST_SUITE.md` §8
+  block A item 5 and in the ledger's *"Verified"* section.
 
 ---
 

--- a/tests/test_nodriver_worker_sandbox.py
+++ b/tests/test_nodriver_worker_sandbox.py
@@ -291,13 +291,13 @@ def orchestration_harness(
     for the duration and reach far past the code under test. Driving it to zero
     does **not** exercise the backoff arithmetic -- zero times anything is zero,
     and gutting the expression survives every case that uses this default. The
-    one case that asserts the arithmetic patches :func:`asyncio.sleep` for
-    itself and says so.
+    two cases that assert the arithmetic -- one per polarity of the snap
+    multiplier -- patch :func:`asyncio.sleep` for themselves and say so.
 
     The other sleep that remains is the fixed 100 ms `_cleanup` waits for
     Chromium to flush profile writes before the profile directory is removed.
-    It is about 0.4 s of this module's runtime and is asserted by that same
-    case; the rest pay it without observing it.
+    It is about 0.4 s of this module's runtime and is asserted by those same two
+    cases; the rest pay it without observing it.
 
     :func:`shutil.which` is pinned to "nothing installed" even though four of
     the five cases hand `_fetch_html` an explicit executable and never reach the
@@ -677,7 +677,8 @@ class TestNodriverWorkerSandbox(unittest.IsolatedAsyncioTestCase):
         and does not exist on Windows.
 
         What the seam gives up is the wiring from a *path shape* to the answer,
-        which belongs to the resolver step that owns `_is_snap_browser` outright.
+        which belongs to plan step E5-4, the resolver step that owns
+        `_is_snap_browser` outright.
         What it keeps is the wiring that matters to the backoff, asserted below:
         that the detector is consulted at all, that it is asked about the
         executable path the caller supplied, and that its answer is what selects
@@ -686,21 +687,22 @@ class TestNodriverWorkerSandbox(unittest.IsolatedAsyncioTestCase):
         See :data:`SNAP_BROWSER_PATH` for the second, independent reason the real
         `/snap/bin/chromium` cannot stand in here.
 
-        This is the only case that patches :func:`asyncio.sleep`. It is a global
-        and the harness avoids it for that reason, but a duration cannot be
-        observed without either replacing the clock or actually waiting 4.5 s.
+        This case and its non-snap sibling below are the **only two** that patch
+        :func:`asyncio.sleep`. It is a global and the harness avoids it for that
+        reason, but a duration cannot be observed without either replacing the
+        clock or actually waiting 4.5 s.
         """
         recorded: list[float] = []
-        classified: list[str] = []
 
         async def _record(delay: float) -> None:
             recorded.append(delay)
 
-        # The seam. Recording the argument is what keeps the wiring claim alive
-        # once the answer stops being derived from the path.
-        def _classify_as_snap(executable_path: str) -> bool:
-            classified.append(executable_path)
-            return True
+        # The seam, autospec'd like every other double here, so production calling
+        # it with the wrong arity raises rather than being quietly accepted.
+        # Asserting what it received is what keeps the wiring claim alive once the
+        # answer stops being derived from the path.
+        is_snap_browser = create_autospec(nodriver_worker._is_snap_browser)
+        is_snap_browser.return_value = True
 
         with orchestration_harness(
             environment={
@@ -714,7 +716,7 @@ class TestNodriverWorkerSandbox(unittest.IsolatedAsyncioTestCase):
             )
 
             with (
-                patch.object(nodriver_worker, "_is_snap_browser", _classify_as_snap),
+                patch.object(nodriver_worker, "_is_snap_browser", is_snap_browser),
                 patch.object(nodriver_worker.asyncio, "sleep", _record),
                 self.assertRaises(RuntimeError),
             ):
@@ -725,7 +727,7 @@ class TestNodriverWorkerSandbox(unittest.IsolatedAsyncioTestCase):
         # the resolver reached for. A production change that stopped consulting
         # the detector, or asked it about the wrong path, fails here rather than
         # falling back silently to a multiplier of 1.0.
-        self.assertEqual(classified, [SNAP_BROWSER_PATH])
+        is_snap_browser.assert_called_once_with(SNAP_BROWSER_PATH)
         # 0.5 * 2**0 * 3, then 0.5 * 2**1 * 3. There is no third: the last
         # attempt raises instead of backing off. The trailing 0.1 is the profile
         # flush `_cleanup` waits for before removing the directory.
@@ -751,16 +753,19 @@ class TestNodriverWorkerSandbox(unittest.IsolatedAsyncioTestCase):
         Windows before it was repaired. Reading `[0.5, 1.0, 0.1]` here as the
         *expected* value is what makes the platform bug impossible to reintroduce
         unnoticed: it now has to be spelled out to be asserted.
+
+        Like its sibling above it patches :func:`asyncio.sleep`, and for the same
+        reason: the harness avoids that global by policy, and a duration cannot be
+        observed without either replacing the clock or waiting out the backoff.
+        Between them these two are the only cases in this module that do.
         """
         recorded: list[float] = []
-        classified: list[str] = []
-
-        def _classify_as_not_snap(executable_path: str) -> bool:
-            classified.append(executable_path)
-            return False
 
         async def _record(delay: float) -> None:
             recorded.append(delay)
+
+        is_snap_browser = create_autospec(nodriver_worker._is_snap_browser)
+        is_snap_browser.return_value = False
 
         with orchestration_harness(
             environment={
@@ -776,14 +781,14 @@ class TestNodriverWorkerSandbox(unittest.IsolatedAsyncioTestCase):
             )
 
             with (
-                patch.object(nodriver_worker, "_is_snap_browser", _classify_as_not_snap),
+                patch.object(nodriver_worker, "_is_snap_browser", is_snap_browser),
                 patch.object(nodriver_worker.asyncio, "sleep", _record),
                 self.assertRaises(RuntimeError),
             ):
                 await fetch_html(browser_executable_path=BROWSER_PATH)
 
         self.assertEqual(doubles.launch.call_count, 3)
-        self.assertEqual(classified, [BROWSER_PATH])
+        is_snap_browser.assert_called_once_with(BROWSER_PATH)
         # 0.5 * 2**0, then 0.5 * 2**1, unmultiplied. The trailing 0.1 is the
         # profile flush, as above.
         self.assertEqual(recorded, [0.5, 1.0, 0.1])

--- a/tests/test_nodriver_worker_sandbox.py
+++ b/tests/test_nodriver_worker_sandbox.py
@@ -115,6 +115,15 @@ BROWSER_PATH = "/usr/bin/chromium-for-tests"
 #: classified correctly. The production defect that implies is reported, not
 #: fixed here; a test that used the real path would silently assert the
 #: non-snap branch, which is what the previous version of this file did.
+#:
+#: **On Windows nothing classifies as snap, whatever the path.** `os.path.realpath`
+#: rewrites the separators and prepends a drive letter, so this value resolves to
+#: ``D:\snap\bin\chromium-for-tests`` and the ``/snap/`` marker is gone -- measured
+#: against the shipped function on a `windows-latest` runner. That is correct
+#: behaviour, snap being a Linux packaging format, and it is why the backoff case
+#: below injects the classification instead of deriving it from this constant. The
+#: constant is still what that case hands to the detector, so it still records what
+#: a snap-packaged browser's path looks like.
 SNAP_BROWSER_PATH = "/snap/bin/chromium-for-tests"
 
 #: A ceiling on any single `_fetch_html` call, guarding a hang that makes no
@@ -642,7 +651,7 @@ class TestNodriverWorkerSandbox(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(doubles.pick_port.call_count, 2)
 
     async def test_backoff_grows_with_each_attempt_and_scales_for_snap(self) -> None:
-        """Wait longer after each failed attempt, and longer again for a snap browser
+        r"""Wait longer after each failed attempt, and longer again for a snap browser
 
         The backoff is `base * 2**attempt * snap_multiplier`. Every other case
         here sets the base to zero, which makes the whole expression zero and
@@ -654,19 +663,44 @@ class TestNodriverWorkerSandbox(unittest.IsolatedAsyncioTestCase):
         because one case can distinguish all three mutations -- dropping the
         exponent, dropping the multiplier, and dropping both.
 
-        See :data:`SNAP_BROWSER_PATH` for why the snap path here is fabricated
-        rather than the real `/snap/bin/chromium`: the real one is classified
-        **non**-snap by the code under test, which is a production defect this
-        case would otherwise have papered over.
+        **The snap classification is injected here, not derived from the path,
+        and that is a platform repair rather than a convenience.**
+        `_is_snap_browser` calls `os.path.realpath`, whose result is
+        platform-dependent: Windows rewrites the separators and prepends a drive
+        letter, so ``/snap/bin/...`` resolves to ``D:\snap\bin\...`` and the
+        ``/snap/`` marker the detector keys on cannot survive. Measured against
+        the shipped function on a `windows-latest` runner. **No path whatsoever
+        classifies as snap there**, so a case deriving the answer from a path
+        asserts the multiplied series on POSIX and the un-multiplied one on
+        Windows -- this one did, and failed there with ``[0.5, 1.0, 0.1]``.
+        Production is right and is left alone: snap is a Linux packaging format
+        and does not exist on Windows.
+
+        What the seam gives up is the wiring from a *path shape* to the answer,
+        which belongs to the resolver step that owns `_is_snap_browser` outright.
+        What it keeps is the wiring that matters to the backoff, asserted below:
+        that the detector is consulted at all, that it is asked about the
+        executable path the caller supplied, and that its answer is what selects
+        the multiplier.
+
+        See :data:`SNAP_BROWSER_PATH` for the second, independent reason the real
+        `/snap/bin/chromium` cannot stand in here.
 
         This is the only case that patches :func:`asyncio.sleep`. It is a global
         and the harness avoids it for that reason, but a duration cannot be
         observed without either replacing the clock or actually waiting 4.5 s.
         """
         recorded: list[float] = []
+        classified: list[str] = []
 
         async def _record(delay: float) -> None:
             recorded.append(delay)
+
+        # The seam. Recording the argument is what keeps the wiring claim alive
+        # once the answer stops being derived from the path.
+        def _classify_as_snap(executable_path: str) -> bool:
+            classified.append(executable_path)
+            return True
 
         with orchestration_harness(
             environment={
@@ -680,16 +714,79 @@ class TestNodriverWorkerSandbox(unittest.IsolatedAsyncioTestCase):
             )
 
             with (
+                patch.object(nodriver_worker, "_is_snap_browser", _classify_as_snap),
                 patch.object(nodriver_worker.asyncio, "sleep", _record),
                 self.assertRaises(RuntimeError),
             ):
                 await fetch_html(browser_executable_path=SNAP_BROWSER_PATH)
 
         self.assertEqual(doubles.launch.call_count, 3)
+        # Asked once, and about the path the caller gave -- not about some default
+        # the resolver reached for. A production change that stopped consulting
+        # the detector, or asked it about the wrong path, fails here rather than
+        # falling back silently to a multiplier of 1.0.
+        self.assertEqual(classified, [SNAP_BROWSER_PATH])
         # 0.5 * 2**0 * 3, then 0.5 * 2**1 * 3. There is no third: the last
         # attempt raises instead of backing off. The trailing 0.1 is the profile
         # flush `_cleanup` waits for before removing the directory.
         self.assertEqual(recorded, [1.5, 3.0, 0.1])
+
+    async def test_backoff_is_unscaled_for_a_non_snap_browser(self) -> None:
+        """Leave the backoff at `base * 2**attempt` when the browser is not snap
+
+        The sibling case above supplies the affirmative half. This one supplies
+        the negative half, and it is not symmetry for its own sake: the
+        `if is_snap else 1.0` conditional was asserted by **nothing in the tree**
+        before this case existed. Measured on the parent commit -- deleting the
+        conditional outright, so that every browser is multiplied, left the whole
+        suite passing.
+
+        That hole predates the seam and is not caused by it, but the seam would
+        have made it permanent: with the classification injected as `True` in one
+        case and derived nowhere, no case could ever reach the `else`. A test
+        that patches a branch condition owes the branch both polarities.
+
+        The durations are the same series as above with the multiplier absent --
+        and they are also, exactly, what the affirmative case wrongly produced on
+        Windows before it was repaired. Reading `[0.5, 1.0, 0.1]` here as the
+        *expected* value is what makes the platform bug impossible to reintroduce
+        unnoticed: it now has to be spelled out to be asserted.
+        """
+        recorded: list[float] = []
+        classified: list[str] = []
+
+        def _classify_as_not_snap(executable_path: str) -> bool:
+            classified.append(executable_path)
+            return False
+
+        async def _record(delay: float) -> None:
+            recorded.append(delay)
+
+        with orchestration_harness(
+            environment={
+                "KINDLY_NODRIVER_RETRY_ATTEMPTS": "3",
+                "KINDLY_NODRIVER_RETRY_BACKOFF_SECONDS": "0.5",
+                # Set, and deliberately so: the multiplier must be ignored
+                # because the browser is not snap, not because none was configured.
+                "KINDLY_NODRIVER_SNAP_BACKOFF_MULTIPLIER": "3",
+            }
+        ) as doubles:
+            doubles.wait_ready.side_effect = RuntimeError(
+                "DevTools endpoint did not become ready in time"
+            )
+
+            with (
+                patch.object(nodriver_worker, "_is_snap_browser", _classify_as_not_snap),
+                patch.object(nodriver_worker.asyncio, "sleep", _record),
+                self.assertRaises(RuntimeError),
+            ):
+                await fetch_html(browser_executable_path=BROWSER_PATH)
+
+        self.assertEqual(doubles.launch.call_count, 3)
+        self.assertEqual(classified, [BROWSER_PATH])
+        # 0.5 * 2**0, then 0.5 * 2**1, unmultiplied. The trailing 0.1 is the
+        # profile flush, as above.
+        self.assertEqual(recorded, [0.5, 1.0, 0.1])
 
     async def test_does_not_retry_a_non_retryable_error(self) -> None:
         """Surface an unrecognised startup failure at once instead of retrying it

--- a/tests/test_nodriver_worker_sandbox.py
+++ b/tests/test_nodriver_worker_sandbox.py
@@ -116,10 +116,12 @@ BROWSER_PATH = "/usr/bin/chromium-for-tests"
 #: fixed here; a test that used the real path would silently assert the
 #: non-snap branch, which is what the previous version of this file did.
 #:
-#: **On Windows nothing classifies as snap, whatever the path.** `os.path.realpath`
-#: rewrites the separators and prepends a drive letter, so this value resolves to
-#: ``D:\snap\bin\chromium-for-tests`` and the ``/snap/`` marker is gone -- measured
-#: against the shipped function on a `windows-latest` runner. That is correct
+#: **On Windows nothing classifies as snap, whatever the path.** A path with a single
+#: leading slash is not absolute there, so `os.path.realpath` joins it against the
+#: current working drive and normalises the separators: this value resolves to
+#: ``<drive>:\snap\bin\chromium-for-tests`` and the ``/snap/`` marker is gone --
+#: measured against the shipped function on a `windows-latest` runner, where the
+#: drive happened to be ``D:``. That is correct
 #: behaviour, snap being a Linux packaging format, and it is why the backoff case
 #: below injects the classification instead of deriving it from this constant. The
 #: constant is still what that case hands to the detector, so it still records what


### PR DESCRIPTION
## Context for the Product Owner

**This is the step that declares the test suite healthy — and it is the first time anyone has actually checked on Windows.**

Background in one paragraph: this repository's test suite has been knowingly broken for a while. Twelve tests were failing, and rather than fix them blindly, the team wrote down every failing test by name in a ledger and repaired them in four tracked batches. This step is the finish line: prove the suite is green, so that automated checks can be switched on and stay on. Everything after this depends on it — nothing can be *enforced* until there is a green state to enforce.

**The plan said this step would need no code change. That turned out to be wrong, and finding out is the value it delivered.**

The suite runs on Linux and on Windows. Only Linux had ever actually been run — the Windows half of the ledger was drained on a careful written argument, because no Windows machine was ever wired up. The plan explicitly forbade accepting that argument at the finish line: *"a drained document is evidence of nothing on a platform nobody ran."*

So a Windows run was taken. **It came back red.** One test genuinely fails there, and had been failing silently since the day it was written.

**What was broken, in plain terms.** When the browser fails to start, the server waits before retrying, and it waits *longer* if the browser came from a particular Linux packaging system ("snap"), which is slower to warm up. A test checked that longer wait. To do so it had to ask the product "is this a snap browser?" — and on Windows that question can never be answered yes, because Windows rewrites file paths in a way that erases the marker the check looks for. The test demanded a Windows-impossible answer and failed.

**The product is not wrong and has not been changed.** Snap is a Linux-only packaging format; a Windows machine correctly has none. The defect was in the test, which assumed a Linux fact was universal.

**A second, larger problem surfaced while fixing the first.** Fixing the test meant supplying the snap answer directly instead of deriving it from the file path. That exposed something worse: the product's decision *"use the longer wait only for snap browsers"* was verified by **nothing at all**. We measured it — deleting that condition entirely, so every browser got the slow retry, left the whole test suite passing. A user on an ordinary browser would have waited three times longer on every retry and no test would have noticed. That gap is now closed by a new test.

**Where this leaves us.** Both platforms are measured green — 449 tests passing on each, identical results. The next step turns on continuous integration, so this never again depends on someone remembering to check.

**One honest caveat, recorded in the docs.** These are still one-off runs on a temporary setup, on both platforms. Nothing re-checks them automatically until the CI work lands. That is precisely the hole that let this bug live for a day undetected, and it stays open until then.

---

## What changed (plan step E1-6)

Four files. No production code.

### `tests/test_nodriver_worker_sandbox.py`

**Repaired `test_backoff_grows_with_each_attempt_and_scales_for_snap`.** It asserted `base * 2**attempt * snap_multiplier` by handing `_fetch_html` a `/snap/`-prefixed path and letting `_is_snap_browser` classify it. That function calls `os.path.realpath`, which is platform-dependent. Measured against the shipped function on a `windows-latest` runner:

```console
'/snap/bin/chromium-for-tests' -> realpath='D:\snap\bin\chromium-for-tests' is_snap=False
```

Windows rewrites the separators and prepends a drive letter, so the `/snap/` marker cannot survive and **no path whatsoever classifies as snap there**. The recorded delays were the un-multiplied series, `[0.5, 1.0, 0.1]`.

The classification is now injected through a seam. Production is untouched: `_is_snap_browser` returning `False` for every Windows path is correct.

**Added `test_backoff_is_unscaled_for_a_non_snap_browser`,** which is the more valuable half of this diff. The seam made an existing hole visible: `snap_multiplier = _resolve_snap_backoff_multiplier() if is_snap else 1.0` was asserted by **nothing in the tree**. Measured on the parent commit — deleting the conditional outright left `428 passed, 2 skipped, 16 subtests`, a fully green suite. Every other case in that module sets the base backoff to zero, which makes the product zero regardless of the multiplier.

Its expected series is exactly what the affirmative case wrongly produced on Windows, so the platform bug now has to be spelled out to be asserted.

### Mutation evidence

Each applied to `nodriver_worker.py`, run, observed, reverted. `9 passed` on shipped code.

| Mutation | Result |
|---|---|
| drop `(2**attempt)` | 2 failed |
| drop `* snap_multiplier` | 1 failed |
| drop both | 2 failed |
| `is_snap = False` | 2 failed |
| `is_snap = True` | 2 failed |
| ask the detector about a different path | 2 failed |
| drop `if is_snap else 1.0` | 1 failed — **survived the entire suite before this PR** |

The wrong-path mutation is killed only by the new `classified == [SNAP_BROWSER_PATH]` assertion; measured with that assertion removed, it survives. That assertion is what repays the seam's cost.

### `.system_design/BASELINE_FAILURES.md`

Additive. **No `Measured:`, `Result:` or `Remaining:` line is edited** — verified by `git diff`. Both platform blocks stay empty; the failure was a regression, not a baseline entry, exactly as the guard's own message instructs.

New *"Verified — the suite-green milestone"* section recording both runs, what the first Windows run found, and the root cause. It carries no `Result:` bullet by design — `_documented_platform_headings` identifies a platform section by that line, so one here would manufacture a phantom platform.

Three corrections the run forced:
- **"The document and the milestone are therefore the same fact"** was false. At `38026ae` both blocks were empty, the guard was green, and Windows was red. An empty ledger is necessary, never sufficient.
- **The five-row relocation decline was grounded on "E1-6 has no diff"**, a premise this step falsifies. Re-grounded on its own reason (the mapping was never measured). The conclusion is unchanged.
- **One sentence still carried the "no repair *touches* an `os.name` branch" phrasing** that the section above it explicitly records as false. Restored to "asserts a value computed by".

No relocation row was added; the test was rewritten in place under its existing node id.

### `.system_design/TEST_SUITE.md`

§1.1's milestone equivalence corrected. §8 block A gains item 5: the repair, the two declined alternatives (patching `os.path.realpath` — a process-global this module's harness avoids by policy; skipping on non-POSIX — reopens the platform skew the empty block asserts away), the coverage the seam gives up and who owns it (E5-4, which owns `_is_snap_browser`), and the live mutant.

E1-5's declared uncovered claim — an `os.name` branch reappearing in `_resolve_web_search_max_concurrency` — was covered once by this run, and is marked **not standing**.

### `.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md`

E1-6's "No diff" prediction corrected in writing rather than quietly failed, following E1-5's precedent. **The step stays typed `milestone`**: five steps depend on it with the `complete` kind, which `scripts/check_plan_dag.py` accepts only against a milestone. `check_plan_dag.py` exits 0; `tests/test_plan_dag.py` passes.

---

## Verification

| Check | Result |
|---|---|
| Suite, Linux (Ubuntu 24.04.4, CPython 3.13.15) | **0 failed, 449 passed, 2 skipped, 16 subtests** |
| Suite, Windows (Server 2025, CPython 3.13.15, `windows-latest`) | **0 failed, 449 passed, 2 skipped, 16 subtests** |
| Ledger guard, Windows, verbose | 20 passed |
| `mypy` | Success, 3 files |
| `ruff check` on the changed file | passed |
| Review system + leak guard | 482 tests, OK |
| `scripts/check_plan_dag.py` | exit 0 |

The Windows run was taken on a throwaway branch carrying a temporary workflow, the same instrument the baseline used, **deleted after the run**. Its tree differed from this branch's by that workflow file alone — verified with `git diff --stat` before the run — so the measurement is of what merges here. It is not the Windows CI lane; that arrives with the CI epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
