### PR TITLE
Annotate the worker-process seam with the WorkerProcess Protocol (plan step E2-4)

### DIFF
--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -850,10 +850,28 @@ conversion bug.
    Only `returncode` actually forces the property choice; the other three
    attribute members are spelled the same way for consistency.
 
-   **`pid` is declared `int`, not `int | None`, while production still guards it**
-   (`if proc.returncode is None and proc.pid is not None`). Harmless today, since
-   `warn_unreachable` is off — but E2-4 annotates that call site, so it decides
-   there: either the guard is dead and goes, or the Protocol member widens.
+   **`pid` is declared `int`, not `int | None`. E2-4 took the first of the two
+   options and deleted the guard**, which used to read `if proc.returncode is
+   None and proc.pid is not None`. Measured twice: typeshed declares
+   `Process.pid: int`, and CPython assigns `self.pid = transport.get_pid()` once
+   in `__init__` and never clears it — a probe printed the same integer before
+   and after `wait()`. With the parameter now typed `WorkerProcess`, the conjunct
+   is dead for every implementer by declaration, not only for the real process.
+
+   Widening the Protocol was the alternative and was rejected: it preserves the
+   text at the cost of making every consumer handle a state that does not exist,
+   and of forcing `str(proc.pid)` to defend against `None`.
+
+   **The guard is pinned positively, not by a grep for the removed conjunct.**
+   That branch runs only on Windows, so nothing in the suite executes it and mypy
+   says nothing about a removed conjunct — which leaves three mutants a grep
+   cannot distinguish: deleting the whole `if` (taskkill fires unconditionally),
+   inverting it to `is not None` (taskkill fires *only* at processes that have
+   already exited, never at the hung one it exists to reap), and dropping the
+   wrong conjunct. The second is worse than the one a grep was written to catch.
+   `test_terminate_process_tree_guards_only_on_the_return_code` names the
+   operator and both operands; all three mutants were run against it and all
+   three fail.
 
    **Three mechanisms are needed, because none of them is sufficient alone.**
    Measured behaviour of `isinstance` against a Protocol:
@@ -948,11 +966,38 @@ conversion bug.
       against the caller's working directory, not the config file's) and every
       harness case asserts no import diagnostic was reported.
 
-      **What E2-1 does not close.** Nothing here connects the Protocol to
-      production's *actual* consumption. An introspection test sees only the
-      Protocol, so padding it with a member nothing reads fails — but production
-      growing an eighth member does not. That direction closes only when E2-4
-      annotates the runner. Recorded rather than implied.
+      **What E2-1 did not close, and E2-4 did.** Nothing in E2-1 connected the
+      Protocol to production's *actual* consumption. An introspection test sees
+      only the Protocol, so padding it with a member nothing reads fails — but
+      production growing an eighth member did not. E2-4 annotated the process
+      `_run_worker_command` spawns, which closes that direction, and proves it
+      with three mutations of a throwaway copy of `src/`: production reading an
+      undeclared member (`attr-defined`), the Protocol losing one the seam reads
+      (`attr-defined`), and the Protocol gaining one no real `Process` has
+      (`assignment`, plus `arg-type` where `_run_pipe_probe` hands its concrete
+      process to `_terminate_process_tree`). Measured before the annotation: all
+      three reported nothing.
+
+      **The copy needs a configuration derived from the committed one, and the
+      reason is measured.** `_run_mypy` pins the child's cwd to the repository
+      root and `mypy_path` is `$MYPY_CONFIG_FILE_DIR/src` — the *repository's* —
+      so naming a copied file on the command line loads only that one file from
+      the copy: with the copy's `types.py` mutated, mypy reported `Success` and
+      `-v` showed it parsing the repository's `types.py`. Anchoring `mypy_path`
+      at the copy fixes it and is sufficient on its own; an absolute import
+      resolves to the copy too, so production's relative import of the Protocol
+      is a second line of defence, not the mechanism. The config is *derived*
+      from `[tool.mypy]` at run time rather than hand-written, because a
+      hand-written one is a second unchecked declaration of the settings — the
+      failure this whole section names. The copy's build excludes
+      `tests/doubles` deliberately: with the double in it the third mutation
+      also breaks `FakeWorkerProcess`'s own `_contract` assignment, which E2-1
+      already checks, and the case could no longer tell its claim from that one.
+
+      The two checks are opposite and neither is redundant. `CONSUMED_SURFACE`
+      fails when the *Protocol* gains a member nothing consumes, which no amount
+      of type-checking production would notice; the annotation fails when
+      *production* drifts, which no introspection test can see.
    3. An explicit **runtime contract test** asserting each attribute exists, each
       method is callable, and each async method returns a coroutine — because
       `runtime_checkable` verifies presence only, not types or arity.
@@ -1342,8 +1387,31 @@ while its configuration-reading cases still pass — so it is recorded here rath
 than left to each job's author. E4-1, E4-3 and E4-5 each define one of the three
 affected jobs.
 
+**`types` must run `mypy` twice, with separate cache directories.** E2-4 fixed a
+pre-existing `attr-defined` on `subprocess.STARTUPINFO` by narrowing
+`_subprocess_launch_options` on `sys.platform` — the only platform check mypy
+understands. The cost, measured: **mypy does not type-check code it considers
+unreachable**, so on a Linux runner a deliberate error inside that Windows-only
+branch is *not* reported, and under `--platform win32` it is. One native
+invocation therefore leaves the branch unchecked on every runner this project
+has. The job runs the committed target natively **and** under `--platform
+win32`; a harness case
+(`test_mypy_accepts_the_committed_target_for_windows`) already does both, so the
+job inherits a proven invocation rather than a new one.
+
+Two consequences to carry, both measured. `--platform` swaps typeshed for the
+*whole* target, not only the module that motivated it, so this is a standing
+constraint on every module later added to `files` and a way for the job to go red
+over code unrelated to the change under review. And `--platform` is
+cache-affecting: sharing one cache between the two invocations makes **every**
+run cold in both directions, permanently, including a developer's plain `mypy`
+(`0.16s / 1.89s / 2.12s / 1.90s` alternating, against `0.17s / 0.17s` separate).
+That would silently reverse the reasoning recorded against `incremental` in
+`pyproject.toml`, so the second invocation gets its own `--cache-dir`.
+
 **`types` is deliberately narrow.** It runs `mypy` over the modules that declare or
-implement the test-double Protocols (§8A step 3), not the whole tree. Repo-wide
+implement the test-double Protocols (§8A step 3), plus the one production module
+that consumes them, not the whole tree. Repo-wide
 type checking on ~6,849 largely unannotated lines is its own project with its own
 justification; this job exists for one purpose — catching the signature drift that
 `runtime_checkable` cannot see — and is scoped to earn its place immediately.
@@ -1735,6 +1803,24 @@ a reader who takes "omitted" to mean "untestable" would draw the wrong
 conclusion about these five. They are testable, and E5-6 owns testing one of
 them — an L1 test on an omitted module, which is already this suite's practice
 (E5-3 targets `chromium_pool.py`, E5-4 `nodriver_worker.py`; both are omitted).
+
+**Widening a parameter to a Protocol does not open a hermetic seam, and E2-4
+did exactly that.** `_emit_worker_heartbeat` and `_terminate_process_tree` now
+take `WorkerProcess` rather than the concrete `asyncio.subprocess.Process`. The
+question was whether that contradicts this classification, since a Protocol
+exists to be satisfied by doubles. It does not: the classification is about a
+*spawn-injection parameter*, which would let a test replace the child and make
+the unhermetic claims hermetic; an annotation is erased at run time, a fake could
+always have been passed positionally, and nothing about the process boundary
+moved. `worker_runner.py` stays in `omit`.
+
+The rule that follows, so the next step does not have to re-derive it:
+**structural and contract claims about those two helpers may use a double;
+behavioural claims about process termination stay `subsystem`.** The module is
+outside the gate, so a hermetic test here earns no coverage while blurring the
+classification. E2-4 declined the hermetic behavioural test its own widening made
+possible for the first time — patching `os.name`, handing in a double, asserting
+the `taskkill` calls — and substituted a structural AST guard on the same branch.
 
 The alternative was combining every lane into the diff gate, and it does not
 survive contact with the arithmetic. A required threshold gate must take
@@ -2216,12 +2302,15 @@ and §10.4 control 1's "every omitted module has non-zero coverage in the
 observational report" rests on them; E7-2 should say whether it absorbs them or
 leaves them, so the claim does not end up with two owners.
 
-**A second consequence: `FakeWorkerProcess` now has no production consumer.**
-Nothing hands it to production between E2-3 and E2-4, so the agreement between
-the double's shape and what production reads is held only by the hand-written
-`CONSUMED_SURFACE` literal in `tests/test_worker_process_protocol.py`. E2-4's
-annotation is what restores a checked link, which is a reason to take E2-4
-promptly rather than a reason to have sequenced it differently.
+**A second consequence, now closed: `FakeWorkerProcess` had no production
+consumer.** Between E2-3 and E2-4 nothing handed it to production, so the
+agreement between the double's shape and what production reads was held only by
+the hand-written `CONSUMED_SURFACE` literal in
+`tests/test_worker_process_protocol.py`. E2-4's annotation restored a checked
+link, which was a reason to take it promptly rather than a reason to have
+sequenced it differently. The literal stays: it is the opposite direction, and
+fails when the *Protocol* gains a member nothing consumes — which type-checking
+production cannot see.
 
 **The from-import ban stands, on a narrower reason than it used to have.** The
 patch resolves through the shared `asyncio` module object, so a

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -933,23 +933,38 @@ duplicating tests or touching the same files.
   and are listed in the reviewer's guard registry, so "retire the node ids"
   applied to the file rather than to the four cases would take the boundary with
   them.
-  **`_terminate_process_tree` does not kill a tree on POSIX. Confirmed
+  **`_terminate_process_tree` does not kill a tree on EITHER platform. Confirmed
   defect — this step's "killed parent leaves no orphan" bullet already owns it,
-  and should be written knowing it starts red.** The non-Windows branch is
-  `proc.kill()` + `await proc.wait()`, and `Process.kill()` signals the direct
-  child only. The Windows branch walks the tree explicitly with
-  `taskkill /T /F /PID`, so the two platforms do different things under one
-  name. Measured on Linux against a child that had spawned a grandchild:
+  and should be written knowing it starts red on both.** The non-Windows branch
+  is `proc.kill()` + `await proc.wait()`, and `Process.kill()` signals the direct
+  child only. Measured on Linux against a child that had spawned a grandchild:
 
   ```
   before: child alive=True   grandchild alive=True
   after : child alive=False  grandchild alive=True  PPid: 1  -> ORPHANED
   ```
 
-  In production the grandchild is Chromium, and a SIGKILLed worker runs no
-  cleanup of its own — so a timed-out worker leaves a browser behind on Linux
-  and does not on Windows. Raised by the automatic reviewer on E2-3, which moved
-  the function verbatim and did not change it. Fixing it is a behaviour change to
+  **The Windows half of this entry was wrong until E2-4's code review, and the
+  correction widens this step's scope.** It said the Windows branch walks the
+  tree, because it *contains* `taskkill /T /F /PID`. It does not reach it in the
+  ordinary case. The branch calls `proc.terminate()` first, waits 1.5 s, and only
+  runs `taskkill` `if proc.returncode is None`. On Windows CPython implements
+  `terminate()` as `_winapi.TerminateProcess` — and defines `kill = terminate` —
+  which is immediate, unconditional, and kills the **named process only**;
+  Windows has no primitive for killing a tree. So the child is dead well inside
+  1.5 s, the guard is false, and the tree-walking fallback never runs.
+
+  In production that descendant is Chromium, and a killed worker runs no cleanup
+  of its own — so a timed-out worker leaves a browser and its profile directory
+  behind on **both** platforms. Raised on POSIX by the automatic reviewer on
+  E2-3, which moved the function verbatim and did not change it; corrected for
+  Windows by the code review of E2-4, which had to describe the function
+  accurately to document it. **Consequence for this step: the fix needs two
+  mechanisms, not one.** A process group plus `os.killpg` covers POSIX; Windows
+  needs a Win32 job object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`, or the
+  `taskkill /T` call promoted ahead of `terminate()` rather than left as its
+  fallback. A verify clause that checks orphans on Linux alone will pass while
+  half the defect stands. Fixing it is a behaviour change to
   process termination and belongs with the lifecycle battery that can prove it,
   not with an extraction. Candidates worth measuring: a process group
   (`start_new_session=True` at spawn, then `os.killpg`), or walking children

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -551,13 +551,46 @@ it carries no X-number.
   have been reviewed as an extraction. That leaves the module short of the
   project's "every class, method and function" rule with no step owning the gap.
   This one is annotating those same signatures and is the cheapest place to
-  close it. Two further things bite when
-  `worker_runner.py` joins §10.3's `types` target: `universal_html.py:185`
-  already fails that check today with `Module has no attribute "STARTUPINFO"`
-  (mypy narrows on `sys.platform`, not on the `os.name` guard the code uses), and
-  an untyped third-party import must be silenced at the import site rather than
-  by loosening the harness's import assertion. E2-4 also decides `pid`: the
-  Protocol declares `int` while production still guards `proc.pid is not None`. *Verify:* mypy checks the production signature against the
+  close it.
+
+  **Landed.** The three findings resolved as follows.
+
+  The `STARTUPINFO` defect was real and reproduced at `worker_runner.py:96` (the
+  extraction moved it from `universal_html.py:185`). Fixed at the guard with
+  `sys.platform`, in its own commit ahead of the annotation so the pre-existing
+  red could not read as "the annotation broke the types job". **The cost is that
+  mypy does not type-check code it considers unreachable**, so that branch is now
+  unread on a native run — closed here by a second invocation under `--platform
+  win32`, which E4-5 inherits along with the separate `--cache-dir` it needs.
+  `_terminate_process_tree` deliberately **keeps** `os.name`: measured, an error
+  injected into its Windows branch is reported natively under `os.name` and not
+  under `sys.platform`, so converting it "for consistency" would delete that
+  coverage. Both spellings are pinned, and the procedure is in the module
+  docstring.
+
+  `pid`: the guard is dead and went. Typeshed declares `Process.pid: int` and
+  CPython assigns it once in `__init__` from `transport.get_pid()`, never
+  clearing it — a probe printed the same integer before and after `wait()`. The
+  Protocol keeps `int`. **Pinned positively, not by a grep for the removed
+  conjunct**: that branch is Windows-only, so nothing in the suite executes it
+  and mypy says nothing about a removed conjunct, which leaves three
+  indistinguishable mutants — deleting the whole `if`, inverting it to `is not
+  None` (which disables the tree-kill entirely, and is worse than the mutant a
+  grep was written to catch), and dropping the wrong conjunct. All three were run
+  against the case and all three fail.
+
+  The untyped-third-party clause turned out **not to apply**, measured:
+  `worker_runner.py` imports only stdlib and `..utils.diagnostics`, itself
+  stdlib-only, and the enlarged target reports no import diagnostic.
+
+  Three mutations of a throwaway copy of `src/` prove the annotation is
+  load-bearing; before it, all three reported nothing. The copy's mypy config is
+  **derived from `[tool.mypy]` at run time**, because a hand-written one is a
+  second unchecked declaration of the settings — and because, measured, reusing
+  the committed config loads only the file named on the command line from the
+  copy, leaving both Protocol mutations invisible.
+
+  *Verify:* mypy checks the production signature against the
   Protocol; changing the Protocol without the function fails.
 
 ---
@@ -672,8 +705,22 @@ typo'd selector fails the job.
   `_run_worker_command`, which did not exist until E2-3 and is not annotated
   until E2-4. Created earlier, its target list would omit the one signature it
   exists to check, and the non-vacuity rule below would then prevent adding a
-  target that did not yet exist. *Verify:* the negative-fixture directory is excluded; **`types` is in
+  target that did not yet exist.
+  **E2-4 landed and this job inherits two things from it.** First, it must
+  invoke `mypy` **twice** — natively and under `--platform win32`, each with its
+  own `--cache-dir`. E2-4 narrowed `_subprocess_launch_options` on `sys.platform`
+  to fix a pre-existing `attr-defined` on `subprocess.STARTUPINFO`, and mypy does
+  not type-check code it considers unreachable, so one native invocation leaves
+  that Windows branch unchecked on every runner this project has. A separate
+  cache is not optional: `--platform` is cache-affecting, and one shared cache
+  makes every run cold in both directions, permanently, including a developer's
+  plain `mypy` (measured `0.16/1.89/2.12/1.90s` shared against `0.17/0.17s`
+  separate). Second, the win32 invocation swaps typeshed for the **whole**
+  target, so it is a standing constraint on every module later added to `files`.
+  *Verify:* the negative-fixture directory is excluded; **`types` is in
   `ci-required.needs`**; introducing an `Any` on the Protocol surface makes it red;
+  an error injected into a Windows-only branch makes it red, which the native
+  invocation alone does not;
   and mypy's output names every configured target module, so a target that no
   longer exists fails the job rather than leaving it green with nothing checked.
 - **E4-6.** The image definition — Python, Chromium, system deps, **no application
@@ -907,6 +954,19 @@ duplicating tests or touching the same files.
   not with an extraction. Candidates worth measuring: a process group
   (`start_new_session=True` at spawn, then `os.killpg`), or walking children
   before the kill.
+
+  **Whichever is taken must be guarded on `sys.platform`, not `os.name`.** E2-4
+  put `worker_runner.py` into the `types` target and added a `--platform win32`
+  invocation, and `os.killpg`, `os.getpgid` and `signal.SIGKILL` are all POSIX-only
+  in typeshed. Measured: the natural `os.name != "nt"` spelling is clean natively
+  and produces three `attr-defined` errors under the win32 run — the exact mirror
+  of the `STARTUPINFO` defect E2-4 fixed, in the same function's neighbourhood.
+  Note the asymmetry: a POSIX-only body is read by the **native** run and a
+  Windows-only body by the **win32** run, so `sys.platform` is right for both
+  and `os.name` is right only where the branch touches no platform-exclusive
+  stdlib at all. `worker_runner.py`'s module docstring states the procedure and
+  `tests/test_worker_runner.py` pins both existing spellings; changing
+  `_terminate_process_tree`'s guard means updating `PLATFORM_GUARDS` with it.
 
   **A pre-existing cost this step should decide about, measured by E2-3's review
   and owned by nobody yet.** With diagnostics enabled, every worker run is padded

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,11 @@ python_version = "3.13"
 # developer's local run cannot diverge.
 files = [
     "src/kindly_web_search_mcp_server/scrape/types.py",
+    # The seam itself. Production annotates the process it spawns with
+    # `WorkerProcess`, so this is what makes mypy compare the Protocol against
+    # what production actually reads -- the direction an introspection test
+    # cannot reach, because it sees only the Protocol.
+    "src/kindly_web_search_mcp_server/scrape/worker_runner.py",
     "tests/doubles",
 ]
 # There is no `py.typed` marker under `src/`, and the project is installed as a

--- a/src/kindly_web_search_mcp_server/scrape/types.py
+++ b/src/kindly_web_search_mcp_server/scrape/types.py
@@ -1,19 +1,21 @@
 """Type-only declarations for the worker-process seam.
 
-This module holds the structural contract between ``universal_html.py`` and the
+This module holds the structural contract between ``worker_runner.py`` and the
 child process it spawns. It declares no behaviour and imports nothing from this
 package, so importing it can never pull in the scraping stack.
 
-It lives under ``src/`` rather than under ``tests/`` for one reason: a later step
-annotates production code with :class:`WorkerProcess`, and production must never
-import from the test tree. Declaring it here also means there is exactly one
-definition of the shape, which is the drift this module exists to prevent — a
-Protocol declared in a test module would be the second.
+It lives under ``src/`` rather than under ``tests/`` for one reason:
+``worker_runner._run_worker_command`` annotates the process it spawns with
+:class:`WorkerProcess`, and production must never import from the test tree.
+Declaring it here also means there is exactly one definition of the shape, which
+is the drift this module exists to prevent — a Protocol declared in a test module
+would be the second.
 
 The name follows the convention for a type-only module. It shadows the stdlib
-``types`` only for absolute-import resolution inside this package, which this
-project uses throughout, and it is unrelated to the type-check CI job that
-shares the word.
+``types`` only within this package, and it is unrelated to the type-check CI job
+that shares the word. Its one production consumer imports it relatively
+(``from .types import WorkerProcess``), matching that module's other
+intra-package import; measured, nothing depends on which spelling is used.
 """
 
 from __future__ import annotations
@@ -24,11 +26,18 @@ from typing import Protocol, runtime_checkable
 
 @runtime_checkable
 class WorkerProcess(Protocol):
-    """The surface ``fetch_html_via_nodriver`` consumes from its child process.
+    """The surface ``worker_runner._run_worker_command`` consumes from its child.
 
-    Exactly the seven members production reads, and no more. The set is asserted
-    against a literal in :mod:`tests.test_worker_process_protocol`, so padding it
-    with a member nothing consumes fails the suite.
+    Exactly the seven members production reads, and no more. Two independent
+    checks hold that now. A literal in :mod:`tests.test_worker_process_protocol`
+    fails if this Protocol is padded with a member nothing consumes; and the
+    annotation on the spawned process fails if production reads an eighth member
+    or loses one of the seven. The second direction was open until the runner
+    was annotated, and until then the literal was the only link.
+
+    The consumer is no longer ``fetch_html_via_nodriver``: the runner extraction
+    took the spawn, the stream reads and the exit status out of it, and that
+    function now touches no process at all.
 
     ``@runtime_checkable`` is required for the *presence* half of the contract:
     without it ``isinstance`` raises ``TypeError`` rather than answering. It is
@@ -43,9 +52,10 @@ class WorkerProcess(Protocol):
     :class:`asyncio.subprocess.Process` does *not* satisfy this Protocol — mypy
     rejects it with "Protocol member WorkerProcess.returncode expected settable
     variable, got read-only attribute", because ``returncode`` is a read-only
-    property on the real type. A later step annotates production code with this
-    Protocol and passes it a real process, so the attribute spelling would have
-    made that step impossible. Do not "simplify" these back to annotations.
+    property on the real type. ``worker_runner._run_worker_command`` annotates
+    the process it spawns with this Protocol and is handed a real one, so the
+    attribute spelling would have made that annotation impossible. Do not
+    "simplify" these back to annotations.
 
     The cost, recorded so it is not mistaken for an oversight: read-only members
     are covariant, so a double declaring ``returncode: int`` — one that can never
@@ -80,6 +90,13 @@ class WorkerProcess(Protocol):
     @property
     def pid(self) -> int:
         """The child's process id.
+
+        Declared ``int`` rather than ``int | None``, and production was brought
+        into line rather than the other way round: ``_terminate_process_tree``
+        used to guard ``proc.pid is not None``, which this declaration makes
+        dead for every implementer. Measured on the real type as well —
+        ``asyncio.subprocess.Process`` assigns ``self.pid`` once in ``__init__``
+        from ``transport.get_pid()`` and never clears it.
 
         Returns:
             The operating-system process id, used to kill the process tree.

--- a/src/kindly_web_search_mcp_server/scrape/worker_runner.py
+++ b/src/kindly_web_search_mcp_server/scrape/worker_runner.py
@@ -110,7 +110,7 @@ from .types import WorkerProcess
 
 @dataclass
 class _StdoutAccumulator:
-    """Mutable state for one draining of a child's standard output.
+    """Mutable state for one draining of a child's standard output
 
     Passed to :func:`_read_stdout_stream`, which owns it for the life of a run
     and mutates it in place, so the caller can read the partial result after a
@@ -120,8 +120,8 @@ class _StdoutAccumulator:
         buffer: Raw bytes received so far, decoded only once the child exits.
         bytes_read: Total bytes seen, which is *not* ``len(buffer)`` for the
             stderr twin and is kept symmetrical here.
-        last_emit_time: Monotonic time of the last progress record, or ``0.0``
-            before the first one.
+        last_emit_time: Monotonic time of the last progress record, or of the
+            call that seeded the clock; ``0.0`` before either.
         last_emit_bytes: ``bytes_read`` at that record, used to rate-limit
             progress by volume as well as by elapsed time.
     """
@@ -134,7 +134,7 @@ class _StdoutAccumulator:
 
 @dataclass
 class _StderrAccumulator:
-    """Mutable state for one draining of a child's standard error.
+    """Mutable state for one draining of a child's standard error
 
     Standard error carries two interleaved things: ``KINDLY_DIAG`` frames the
     worker emits deliberately, and whatever else it or its browser writes. They
@@ -145,7 +145,8 @@ class _StderrAccumulator:
         buffer: Text received but not yet split into complete lines.
         tail: The most recent non-frame output, capped at the caller's limit.
         bytes_read: Total bytes seen, before decoding.
-        last_emit_time: Monotonic time of the last progress record.
+        last_emit_time: Monotonic time of the last progress record, or of the
+            call that seeded the clock.
         last_emit_bytes: ``bytes_read`` at that record.
         worker_entries: Decoded ``KINDLY_DIAG`` frames, merged into the caller's
             diagnostics once the run finishes.
@@ -304,8 +305,9 @@ def _maybe_emit_stream_progress(
         last_emit_bytes: ``bytes_read`` at the previous record.
 
     Returns:
-        The time and byte count to carry forward — unchanged when nothing was
-        emitted, so the caller can assign the pair back unconditionally.
+        The time and byte count to carry forward, which the caller assigns back
+        unconditionally. Unchanged when nothing was emitted, except on the very
+        first call, which emits nothing but seeds the clock.
     """
     if diagnostics is None:
         return last_emit_time, last_emit_bytes
@@ -635,21 +637,27 @@ async def _emit_worker_heartbeat(
 async def _terminate_process_tree(proc: WorkerProcess) -> None:
     """Kill a child that has overrun, and on Windows its descendants too
 
-    **The name overstates what happens on POSIX, and that is a known defect
-    rather than a shorthand.** The two branches do different things:
+    **The name overstates what this does on *both* platforms, and that is a
+    known defect rather than a shorthand.**
 
-    * On Windows, ``taskkill /T /F`` walks the tree, so the browser the worker
-      started dies with it.
-    * Everywhere else this sends a signal to the **direct child only**. Its
-      descendants are reparented and survive. Confirmed with a probe: after the
-      call, ``child alive=False grandchild alive=True PPid: 1``.
+    * Off Windows it signals the **direct child only**. Descendants are
+      reparented and survive — probed: after the call, ``child alive=False
+      grandchild alive=True PPid: 1``.
+    * On Windows the first thing tried is ``proc.terminate()``, which CPython
+      implements as ``TerminateProcess`` (and where ``kill`` is an *alias* for
+      ``terminate``). That is immediate, unconditional, and also kills the named
+      process only — Windows has no primitive for killing a tree.
+      ``taskkill /T /F``, which does walk the tree, is reached only if the child
+      is **still alive 1.5 s later**, and ``TerminateProcess`` makes that
+      unlikely. So in the ordinary case descendants survive here too.
 
-    In production that grandchild is Chromium, so a timed-out worker leaves a
-    browser and its profile directory behind on Linux and not on Windows. The
-    fix belongs to the worker-lifecycle step, whose verify clause already
-    requires that a killed parent leave no orphan; a process group at spawn plus
-    a group kill is the candidate. It is not fixed here because changing process
-    termination is a behaviour change, and this step annotates signatures.
+    In production that descendant is Chromium, so a timed-out worker leaves a
+    browser and its profile directory behind, on **either** platform. The fix
+    belongs to the worker-lifecycle step, whose verify clause already requires
+    that a killed parent leave no orphan; a process group at spawn plus a group
+    kill is the POSIX candidate, and a Win32 job object the Windows one. It is
+    not fixed here because changing process termination is a behaviour change,
+    and this step annotates signatures.
 
     Every failure is suppressed throughout. The process may exit between any two
     statements, and racing it is not an error worth propagating to a caller who

--- a/src/kindly_web_search_mcp_server/scrape/worker_runner.py
+++ b/src/kindly_web_search_mcp_server/scrape/worker_runner.py
@@ -58,11 +58,32 @@ from ..utils.diagnostics import (
     Diagnostics,
     truncate_text,
 )
+
+# Relative, matching this module's other intra-package import above. It is
+# NOT what lets the seam's mutation harness check a copied Protocol -- that
+# is the copy-anchored `mypy_path`; measured, an absolute import resolves to
+# the copy too.
 from .types import WorkerProcess
 
 
 @dataclass
 class _StdoutAccumulator:
+    """Mutable state for one draining of a child's standard output.
+
+    Passed to :func:`_read_stdout_stream`, which owns it for the life of a run
+    and mutates it in place, so the caller can read the partial result after a
+    timeout cancels the reader.
+
+    Attributes:
+        buffer: Raw bytes received so far, decoded only once the child exits.
+        bytes_read: Total bytes seen, which is *not* ``len(buffer)`` for the
+            stderr twin and is kept symmetrical here.
+        last_emit_time: Monotonic time of the last progress record, or ``0.0``
+            before the first one.
+        last_emit_bytes: ``bytes_read`` at that record, used to rate-limit
+            progress by volume as well as by elapsed time.
+    """
+
     buffer: bytearray = field(default_factory=bytearray)
     bytes_read: int = 0
     last_emit_time: float = 0.0
@@ -71,6 +92,25 @@ class _StdoutAccumulator:
 
 @dataclass
 class _StderrAccumulator:
+    """Mutable state for one draining of a child's standard error.
+
+    Standard error carries two interleaved things: ``KINDLY_DIAG`` frames the
+    worker emits deliberately, and whatever else it or its browser writes. They
+    are separated as lines arrive rather than afterwards, so a run that times out
+    still yields the frames received before the deadline.
+
+    Attributes:
+        buffer: Text received but not yet split into complete lines.
+        tail: The most recent non-frame output, capped at the caller's limit.
+        bytes_read: Total bytes seen, before decoding.
+        last_emit_time: Monotonic time of the last progress record.
+        last_emit_bytes: ``bytes_read`` at that record.
+        worker_entries: Decoded ``KINDLY_DIAG`` frames, merged into the caller's
+            diagnostics once the run finishes.
+        parse_errors: Up to three samples of frames that would not decode, kept
+            so a malformed worker is diagnosable without unbounded logging.
+    """
+
     buffer: str = ""
     tail: str = ""
     bytes_read: int = 0
@@ -90,6 +130,16 @@ PIPE_PROBE_SAMPLE_LIMIT = 400
 
 
 def _subprocess_launch_options() -> dict[str, Any]:
+    """Build the platform-specific keyword arguments for spawning a child
+
+    On Windows a console application spawned from a GUI-less parent flashes a
+    console window and joins the parent's process group, so a Ctrl-C intended
+    for the parent reaches the child as well. Both are suppressed here.
+
+    Returns:
+        Keyword arguments for :func:`asyncio.create_subprocess_exec`. Empty on
+        every non-Windows platform, where none of this applies.
+    """
     # `sys.platform`, not `os.name`: mypy narrows on the former only, and
     # `subprocess.STARTUPINFO` below is win32-only in typeshed.
     if sys.platform != "win32":
@@ -105,6 +155,20 @@ def _subprocess_launch_options() -> dict[str, Any]:
 
 
 def _append_tail_text(existing: str, addition: str, *, limit: int) -> str:
+    """Append to a bounded tail, discarding from the front when it overflows
+
+    Keeps the *most recent* text rather than the first, because the end of a
+    failing child's stderr is what names the failure.
+
+    Args:
+        existing: The tail so far.
+        addition: Text to append. An empty string is returned unchanged rather
+            than triggering a needless copy.
+        limit: Maximum characters to retain.
+
+    Returns:
+        The combined text, truncated from the left to ``limit`` characters.
+    """
     if not addition:
         return existing
     combined = existing + addition
@@ -116,6 +180,20 @@ def _append_tail_text(existing: str, addition: str, *, limit: int) -> str:
 def _consume_stderr_line(
     state: _StderrAccumulator, line: str, *, tail_limit: int
 ) -> None:
+    """Route one complete line of a child's stderr into ``state``
+
+    A line prefixed ``KINDLY_DIAG `` is a structured frame the worker emitted on
+    purpose; anything else is ordinary output and joins the tail. A frame that
+    will not decode, or that decodes to something other than an object, is
+    sampled rather than raised: a malformed frame must not cost the caller the
+    run, and must not let a chatty child flood memory either, so at most three
+    samples are kept.
+
+    Args:
+        state: Accumulator mutated in place.
+        line: One line, already stripped of its terminator.
+        tail_limit: Maximum characters to retain in ``state.tail``.
+    """
     if line == "":
         return
     if line.startswith("KINDLY_DIAG "):
@@ -138,6 +216,16 @@ def _consume_stderr_line(
 
 
 def _finalize_stderr_state(state: _StderrAccumulator, *, tail_limit: int) -> None:
+    """Consume a trailing partial line left after the stream closed
+
+    A child that exits without a final newline leaves its last line in the
+    buffer, where the reader's newline loop never sees it. That line is often
+    the most interesting one, so it is flushed through the same routing.
+
+    Args:
+        state: Accumulator mutated in place.
+        tail_limit: Maximum characters to retain in ``state.tail``.
+    """
     if not state.buffer:
         return
     line = state.buffer.rstrip("\r")
@@ -154,6 +242,29 @@ def _maybe_emit_stream_progress(
     last_emit_time: float,
     last_emit_bytes: int,
 ) -> tuple[float, int]:
+    """Emit a stream-progress record, but only if enough has changed
+
+    A record per read chunk would bury the diagnostics stream on a large page,
+    so one is emitted only once the interval **or** the byte threshold is
+    crossed. Either, not both: a slow trickle must still show progress, and a
+    fast flood must not wait out the clock to report it.
+
+    The clock is seeded on first use rather than at construction, so a stream
+    that stays silent for a minute before its first byte does not emit a record
+    the instant it wakes.
+
+    Args:
+        diagnostics: Sink, or ``None`` to do nothing.
+        stream: ``"stdout"`` or ``"stderr"``, recorded on the entry.
+        bytes_read: Total bytes drained from this stream so far.
+        started: Monotonic time the run began, for the elapsed figure.
+        last_emit_time: Monotonic time of the previous record.
+        last_emit_bytes: ``bytes_read`` at the previous record.
+
+    Returns:
+        The time and byte count to carry forward — unchanged when nothing was
+        emitted, so the caller can assign the pair back unconditionally.
+    """
     if diagnostics is None:
         return last_emit_time, last_emit_bytes
     now = time.monotonic()
@@ -180,6 +291,20 @@ async def _read_probe_stream(
     *,
     byte_limit: int,
 ) -> tuple[bytes, int, float | None]:
+    """Drain a probe stream to EOF, keeping only its first ``byte_limit`` bytes
+
+    Reading continues past the limit rather than stopping at it: the point is to
+    measure how much the pipe delivered and how quickly, and abandoning the read
+    early would block the child on a full pipe and confound the measurement.
+
+    Args:
+        stream: The stream, or ``None`` when the child was spawned without one.
+        byte_limit: Maximum bytes to retain for the sample.
+
+    Returns:
+        The retained sample, the total number of bytes read, and the monotonic
+        time the first byte arrived — ``None`` if nothing ever did.
+    """
     if stream is None:
         return b"", 0, None
     buffer = bytearray()
@@ -204,6 +329,25 @@ async def _run_pipe_probe(
     env: dict[str, str],
     diagnostics: Diagnostics,
 ) -> None:
+    """Measure whether pipes work on this host, before blaming a real worker
+
+    Spawns a short-lived interpreter that writes a known payload to both
+    streams, then records how much came back and how fast. When a worker hangs,
+    this distinguishes "the browser never started" from "this host's pipes do
+    not deliver", which are diagnosed in completely different places.
+
+    It reports rather than raises: a failed probe is a diagnostic finding about
+    the host, not a reason to fail the caller's fetch. Every exit path emits
+    exactly one record, and a probe that overruns has its process tree killed
+    before this returns.
+
+    Args:
+        executable: Interpreter to run. The only argv this module composes, and
+            it carries no caller data — a fixed four elements around a literal.
+        env: Environment for the probe child.
+        diagnostics: Sink for the result. Required, not optional: a probe whose
+            findings go nowhere has no reason to run.
+    """
     probe_payload = (
         "import sys; "
         f"data='x'*{PIPE_PROBE_OUTPUT_BYTES}; "
@@ -330,6 +474,19 @@ async def _read_stdout_stream(
     diagnostics: Diagnostics | None,
     started: float,
 ) -> None:
+    """Drain a child's standard output into ``state`` until it closes
+
+    Bytes are accumulated undecoded and decoded once at the end, because a
+    multi-byte character split across two reads would otherwise be corrupted at
+    the seam.
+
+    Args:
+        stream: The stream, or ``None`` when no pipe was requested.
+        state: Accumulator mutated in place, so a cancelled read still leaves
+            the caller whatever arrived.
+        diagnostics: Sink for progress records, or ``None``.
+        started: Monotonic time the run began, for elapsed figures.
+    """
     if stream is None:
         return
     while True:
@@ -356,6 +513,20 @@ async def _read_stderr_stream(
     started: float,
     tail_limit: int,
 ) -> None:
+    """Drain a child's standard error into ``state``, splitting it into lines
+
+    Unlike stdout this decodes as it goes, because the frames it carries are
+    line-oriented and must be available before the child exits. Undecodable
+    bytes are replaced rather than raised: stderr is diagnostic output, and
+    losing a run to a stray byte in it would be the wrong trade.
+
+    Args:
+        stream: The stream, or ``None`` when no pipe was requested.
+        state: Accumulator mutated in place.
+        diagnostics: Sink for progress records, or ``None``.
+        started: Monotonic time the run began, for elapsed figures.
+        tail_limit: Maximum characters to retain in ``state.tail``.
+    """
     if stream is None:
         return
     while True:
@@ -390,6 +561,20 @@ async def _emit_worker_heartbeat(
     diagnostics: Diagnostics | None,
     started: float,
 ) -> None:
+    """Emit a record every few seconds while the child is still running
+
+    Without this a slow fetch is indistinguishable from a hung one in the
+    diagnostics stream. Costs nothing when diagnostics are off, and returns
+    immediately in that case rather than sleeping in a loop nobody reads.
+
+    Args:
+        proc: The running child. Only ``returncode`` is read, and its optional
+            half is what this loop is spelled against.
+        stdout_state: Accumulator, read for its byte count.
+        stderr_state: Accumulator, read for its byte count.
+        diagnostics: Sink, or ``None`` to return at once.
+        started: Monotonic time the run began, for elapsed figures.
+    """
     if diagnostics is None:
         return
     while proc.returncode is None:
@@ -406,6 +591,31 @@ async def _emit_worker_heartbeat(
 
 
 async def _terminate_process_tree(proc: WorkerProcess) -> None:
+    """Kill a child that has overrun, and on Windows its descendants too
+
+    **The name overstates what happens on POSIX, and that is a known defect
+    rather than a shorthand.** The two branches do different things:
+
+    * On Windows, ``taskkill /T /F`` walks the tree, so the browser the worker
+      started dies with it.
+    * Everywhere else this sends a signal to the **direct child only**. Its
+      descendants are reparented and survive. Confirmed with a probe: after the
+      call, ``child alive=False grandchild alive=True PPid: 1``.
+
+    In production that grandchild is Chromium, so a timed-out worker leaves a
+    browser and its profile directory behind on Linux and not on Windows. The
+    fix belongs to the worker-lifecycle step, whose verify clause already
+    requires that a killed parent leave no orphan; a process group at spawn plus
+    a group kill is the candidate. It is not fixed here because changing process
+    termination is a behaviour change, and this step annotates signatures.
+
+    Every failure is suppressed throughout. The process may exit between any two
+    statements, and racing it is not an error worth propagating to a caller who
+    is already handling a timeout.
+
+    Args:
+        proc: The child to kill. Returns immediately if it has already exited.
+    """
     if proc.returncode is not None:
         return
 
@@ -414,7 +624,7 @@ async def _terminate_process_tree(proc: WorkerProcess) -> None:
             proc.terminate()
         with contextlib.suppress(Exception):
             await asyncio.wait_for(proc.wait(), timeout=1.5)
-        if proc.returncode is None and proc.pid is not None:
+        if proc.returncode is None:
             with contextlib.suppress(Exception):
                 killer = await asyncio.create_subprocess_exec(
                     "taskkill",

--- a/src/kindly_web_search_mcp_server/scrape/worker_runner.py
+++ b/src/kindly_web_search_mcp_server/scrape/worker_runner.py
@@ -36,9 +36,51 @@ repository — the import is still wrong, and is documented here because the
 symptom it produces (assertion failures in tests that name neither this module
 nor the import) points nowhere near its cause.
 
-The helpers below moved here verbatim from ``universal_html.py``. They are
-unchanged, deliberately: an extraction that also rewrites what it moves cannot
-be reviewed as an extraction.
+The helpers below arrived here verbatim from ``universal_html.py``, because an
+extraction that also rewrites what it moves cannot be reviewed as an extraction.
+They have since been documented and annotated — the step that annotated the
+seam took the docstrings with it, since it was editing the same signatures and
+no other step owned the gap.
+
+**The process this module spawns is typed** :class:`~kindly_web_search_mcp_server\
+.scrape.types.WorkerProcess`, **and that annotation is a check, not a label.**
+mypy compares the real :class:`asyncio.subprocess.Process` against the Protocol
+at the spawn site, and every read below against the Protocol's seven members —
+so reading an eighth fails, and so does dropping one of the seven from the
+Protocol. Before it, the only thing tying the test double's shape to what this
+module reads was a hand-written literal in the test suite.
+
+Widening :func:`_emit_worker_heartbeat` and :func:`_terminate_process_tree` to
+that Protocol is **not** the hermetic seam the paragraph above refuses. That
+refusal is about a spawn-injection parameter, which would let a test replace the
+child and contradict the classification this module's existence expresses. An
+annotation is erased at run time and always could have been handed a fake;
+nothing about the process boundary moved. The rule that follows from it:
+structural and contract claims about these two helpers may use a double,
+behavioural claims about process termination stay ``subsystem``, because this
+module is outside the coverage gate and a hermetic test here earns nothing while
+blurring the classification.
+
+**Two Windows guards, deliberately spelled differently.** The procedure, so a
+new branch does not have to re-derive it:
+
+* A branch touching stdlib that exists on **one platform only** must be
+  ``sys.platform``-guarded, on whichever side that is — mypy narrows on
+  ``sys.platform`` and never on ``os.name``, so ``os.name`` leaves the
+  platform-exclusive lookup as an ``attr-defined`` error. The run that reads
+  that branch is then the native one for a POSIX-only body, and the
+  ``--platform win32`` one for a Windows-only body; both exist.
+* Otherwise use ``os.name``, which leaves the branch checked on **both** runs.
+  Converting :func:`_terminate_process_tree` "for consistency" would make mypy
+  treat its whole ``taskkill`` path unreachable on Linux and stop checking it —
+  measured with an injected error, reported under ``os.name`` and not under
+  ``sys.platform``.
+
+``getattr``/``hasattr`` is a third spelling already used below. It is for
+optional *attributes* on a module that does exist, and it is not a substitute
+for either guard: it degrades the value to ``Any`` rather than proving anything.
+
+Both spellings are pinned by ``tests/test_worker_runner.py``.
 """
 
 from __future__ import annotations

--- a/src/kindly_web_search_mcp_server/scrape/worker_runner.py
+++ b/src/kindly_web_search_mcp_server/scrape/worker_runner.py
@@ -58,6 +58,7 @@ from ..utils.diagnostics import (
     Diagnostics,
     truncate_text,
 )
+from .types import WorkerProcess
 
 
 @dataclass
@@ -382,7 +383,7 @@ async def _read_stderr_stream(
 
 
 async def _emit_worker_heartbeat(
-    proc: asyncio.subprocess.Process,
+    proc: WorkerProcess,
     stdout_state: _StdoutAccumulator,
     stderr_state: _StderrAccumulator,
     *,
@@ -404,7 +405,7 @@ async def _emit_worker_heartbeat(
         await asyncio.sleep(STREAM_HEARTBEAT_INTERVAL_SECONDS)
 
 
-async def _terminate_process_tree(proc: asyncio.subprocess.Process) -> None:
+async def _terminate_process_tree(proc: WorkerProcess) -> None:
     if proc.returncode is not None:
         return
 
@@ -492,7 +493,7 @@ async def _run_worker_command(
             if the streams were never opened.
     """
     started = time.monotonic()
-    proc = await asyncio.create_subprocess_exec(
+    proc: WorkerProcess = await asyncio.create_subprocess_exec(
         *command,
         stdin=asyncio.subprocess.DEVNULL,
         stdout=asyncio.subprocess.PIPE,

--- a/src/kindly_web_search_mcp_server/scrape/worker_runner.py
+++ b/src/kindly_web_search_mcp_server/scrape/worker_runner.py
@@ -48,6 +48,7 @@ import contextlib
 import json
 import os
 import subprocess
+import sys
 import time
 from dataclasses import dataclass, field
 from typing import Any
@@ -88,7 +89,9 @@ PIPE_PROBE_SAMPLE_LIMIT = 400
 
 
 def _subprocess_launch_options() -> dict[str, Any]:
-    if os.name != "nt":
+    # `sys.platform`, not `os.name`: mypy narrows on the former only, and
+    # `subprocess.STARTUPINFO` below is win32-only in typeshed.
+    if sys.platform != "win32":
         return {}
     creationflags = 0
     creationflags |= getattr(subprocess, "CREATE_NO_WINDOW", 0)

--- a/tests/test_worker_process_protocol.py
+++ b/tests/test_worker_process_protocol.py
@@ -32,6 +32,7 @@ import ast
 import asyncio
 import os
 import re
+import shutil
 import subprocess
 import sys
 import tomllib
@@ -440,6 +441,74 @@ def test_no_source_module_imports_from_tests() -> None:
     )
 
 
+RUNNER_PATH = (
+    REPO_ROOT / "src" / "kindly_web_search_mcp_server" / "scrape" / "worker_runner.py"
+)
+
+
+def test_production_annotates_the_spawned_process_with_the_protocol() -> None:
+    """Prove production names the Protocol on the value it spawns.
+
+    The static cases below spawn a child mypy and are ``subsystem``-marked, so a
+    lane running only the fast set would notice nothing if the annotation were
+    deleted. This is the hermetic half, and it costs one AST parse.
+
+    It asserts the *annotation*, not the import. An ``if TYPE_CHECKING:`` import
+    with no use satisfies "the module imports WorkerProcess", and so does an
+    import beside a signature somebody forgot to annotate; neither makes mypy
+    compare the Protocol with what production reads.
+    """
+    source = RUNNER_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(RUNNER_PATH))
+
+    runner = next(
+        (
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.AsyncFunctionDef)
+            and node.name == "_run_worker_command"
+        ),
+        None,
+    )
+    assert runner is not None, "_run_worker_command has moved or been renamed."
+
+    annotated = [
+        node
+        for node in ast.walk(runner)
+        if isinstance(node, ast.AnnAssign)
+        and isinstance(node.target, ast.Name)
+        and node.target.id == "proc"
+        and isinstance(node.annotation, ast.Name)
+        and node.annotation.id == "WorkerProcess"
+    ]
+    assert annotated, (
+        "The process _run_worker_command spawns is not annotated "
+        "`WorkerProcess`. Without that annotation mypy checks production's "
+        "reads against the concrete asyncio type, the Protocol constrains "
+        "nothing, and the only thing tying the double's shape to what "
+        "production consumes is the CONSUMED_SURFACE literal above -- which is "
+        "a literal, not a check."
+    )
+
+    # A relative import, deliberately: the mutation cases below type-check a
+    # COPY of the tree, and an absolute import would resolve back to the
+    # repository's own Protocol, leaving both `types.py` mutations invisible.
+    relative = any(
+        isinstance(node, ast.ImportFrom)
+        and node.level == 1
+        and node.module == "types"
+        and any(alias.name == "WorkerProcess" for alias in node.names)
+        for node in ast.walk(tree)
+    )
+    assert relative, (
+        "worker_runner.py does not import WorkerProcess relatively "
+        "(`from .types import WorkerProcess`). An absolute import resolves "
+        "against mypy's search path, so a mutated copy of the Protocol would be "
+        "silently ignored and test_mypy_rejects_each_seam_mutation would go "
+        "green on the repository's own unmutated types.py."
+    )
+
+
 # --------------------------------------------------------------------------
 # The mypy configuration
 # --------------------------------------------------------------------------
@@ -502,6 +571,23 @@ def test_mypy_configuration_excludes_every_negative_fixture() -> None:
         f"{unexcluded} are not excluded from the mypy target. A file that must "
         "fail type-checking cannot sit in the path the job checks, or the job "
         "is red forever."
+    )
+
+
+def test_mypy_target_includes_the_worker_runner() -> None:
+    """Keep the annotated seam inside the checked target.
+
+    The annotation is only worth its diff while mypy reads it. Dropping the
+    module from ``files`` would leave every static case below checking a file
+    that no longer contains the seam, and each of them would go green.
+    """
+    files = _mypy_configuration()["files"]
+    expected = "src/kindly_web_search_mcp_server/scrape/worker_runner.py"
+
+    assert expected in files, (
+        f"{expected!r} is not in [tool.mypy] files, which is now {files}. "
+        "Outside the target, production can read a member the Protocol never "
+        "declares and nothing reports it."
     )
 
 
@@ -817,3 +903,194 @@ def test_the_any_fixture_is_clean_without_its_inline_directive(tmp_path: Path) -
         "so that directive is not what rejects it and the harness case proves "
         f"nothing about the setting.\n{result.stdout}"
     )
+
+
+# --------------------------------------------------------------------------
+# The seam itself: production's consumption checked against the Protocol
+#
+# This is the direction the Protocol harness above cannot reach. An
+# introspection test sees only the Protocol, so padding it with a member nothing
+# reads fails -- but production growing an eighth member, or dropping one of the
+# seven, does not. The annotation on the spawned process is what closes that,
+# and the mutations below are what prove it closed.
+# --------------------------------------------------------------------------
+
+# Each mutation is one exact substring swap applied to a throwaway copy of
+# `src/`. The (old, new) pair doubles as its own applied-check: a swap matching
+# nothing leaves the source identical, and the case says so rather than blaming
+# the seam for a clean run.
+SEAM_MUTATIONS: Final = {
+    "production_reads_a_member_the_protocol_never_declares": (
+        "worker_runner.py",
+        "    stdout_state: _StdoutAccumulator | None = None",
+        "    _undeclared = proc.stdin\n"
+        "    stdout_state: _StdoutAccumulator | None = None",
+        "attr-defined",
+    ),
+    "the_protocol_drops_a_member_production_reads": (
+        "types.py",
+        "    def stdout(self) -> asyncio.StreamReader | None:",
+        "    def stdout_renamed(self) -> asyncio.StreamReader | None:",
+        "attr-defined",
+    ),
+    "the_protocol_grows_a_member_a_real_process_lacks": (
+        "types.py",
+        "    @property\n    def stdout(self)",
+        "    @property\n"
+        "    def absent_from_a_real_process(self) -> int:\n"
+        '        """Declared by nobody, so a real process cannot satisfy it."""\n'
+        "        ...\n"
+        "\n"
+        "    @property\n"
+        "    def stdout(self)",
+        "assignment",
+    ),
+}
+
+
+def _run_mypy_on_copy(destination: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Type-check a copied ``worker_runner.py`` against the copy's own Protocol.
+
+    The committed configuration cannot be reused, and this is measured rather
+    than assumed. ``_run_mypy`` pins the child's ``cwd`` to the repository root
+    and ``pyproject.toml`` sets ``mypy_path = "$MYPY_CONFIG_FILE_DIR/src"`` --
+    the *repository's* ``src``. Under that configuration only the file named on
+    the command line comes from the copy: with the copy's ``types.py`` mutated,
+    mypy reported ``Success`` and ``-v`` showed it parsing the repository's
+    ``types.py``. So the copy gets its own config with an absolute ``mypy_path``,
+    and production imports the Protocol relatively, which cannot resolve outside
+    its own package.
+
+    The build deliberately contains this module and its followed imports only,
+    not ``tests/doubles``. With the double in it, the third mutation also breaks
+    ``FakeWorkerProcess``'s own ``_contract`` assignment -- machinery the earlier
+    step already ships -- and the case could no longer tell its claim from that
+    one. Measured: 5 errors across 2 files with the double in, 3 in 1 file
+    without it.
+
+    Args:
+        destination: Directory holding the copied tree.
+        *args: Extra flags appended to the invocation.
+
+    Returns:
+        The completed child mypy run.
+    """
+    config = destination / "mypy.ini"
+    config.write_text(
+        "[mypy]\n"
+        "python_version = 3.13\n"
+        f"mypy_path = {destination / 'src'}\n",
+        encoding="utf-8",
+    )
+    target = (
+        destination
+        / "src"
+        / "kindly_web_search_mcp_server"
+        / "scrape"
+        / "worker_runner.py"
+    )
+    return _run_mypy(
+        "--config-file",
+        str(config),
+        # A cache shared with the repository's runs would answer from the
+        # unmutated tree.
+        "--cache-dir",
+        str(destination / "cache"),
+        *args,
+        str(target),
+    )
+
+
+def _copy_source_tree(destination: Path) -> Path:
+    """Copy ``src/`` so a mutation never touches the repository.
+
+    Args:
+        destination: An empty directory, normally pytest's ``tmp_path``.
+
+    Returns:
+        The copied ``src`` root.
+    """
+    copied = destination / "src"
+    shutil.copytree(REPO_ROOT / "src", copied)
+    return copied
+
+
+@pytest.mark.subsystem
+def test_the_copied_tree_type_checks_cleanly(tmp_path: Path) -> None:
+    """Control for the mutation cases: prove an unmutated copy is clean.
+
+    Its job is narrower than it looks. It is *not* what proves the copy is on
+    mypy's path -- the two ``types.py`` mutations are, since they report nothing
+    at all if mypy read the repository's Protocol instead. What this excludes is
+    the other direction: a copy broken for some unrelated reason, under which
+    every mutation case would "detect" an error that was there all along.
+
+    Args:
+        tmp_path: Destination for the copied tree.
+    """
+    _copy_source_tree(tmp_path)
+
+    result = _run_mypy_on_copy(tmp_path)
+
+    _assert_resolved(result)
+    assert result.returncode == 0, (
+        "An unmutated copy of src/ does not type-check, so the mutation cases "
+        "below cannot attribute their errors to the mutation rather than to the "
+        f"copy.\n{result.stdout}"
+    )
+
+
+@pytest.mark.subsystem
+@pytest.mark.parametrize(("label", "mutation"), sorted(SEAM_MUTATIONS.items()))
+def test_mypy_rejects_each_seam_mutation(
+    label: str, mutation: tuple[str, str, str, str], tmp_path: Path
+) -> None:
+    """Prove the annotation makes production's consumption a checked claim.
+
+    Three drifts, one per direction the seam can fail in: production reading a
+    member the Protocol never declared, the Protocol losing a member production
+    reads, and the Protocol growing one a real ``asyncio.subprocess.Process``
+    cannot supply.
+
+    The error *code* is asserted, never the exit status: mypy exits non-zero for
+    a syntax error, an unresolved import or a crash just as readily. Membership,
+    never "the first" or "the only" error -- the third mutation also reports
+    ``arg-type`` at the two ``_run_pipe_probe`` call sites, which is correct
+    output and not a defect. And the reported path must fall inside the copy: a
+    diagnostic against the repository would mean the mutation was never read.
+
+    Args:
+        label: The drift being simulated.
+        mutation: File name, the exact text replaced, its replacement, and the
+            diagnostic that drift must provoke.
+        tmp_path: Destination for the copied tree.
+    """
+    filename, old, new, expected_code = mutation
+    copied = _copy_source_tree(tmp_path)
+    target = copied / "kindly_web_search_mcp_server" / "scrape" / filename
+    source = target.read_text(encoding="utf-8")
+    mutated = source.replace(old, new, 1)
+
+    # A swap matching nothing leaves a clean tree, and a case asserting an error
+    # would then fail with a message blaming the seam for a stale anchor.
+    assert mutated != source, (
+        f"The text this mutation replaces has moved in {filename}: {old!r}. The "
+        "case cannot simulate the drift it names until the anchor is updated."
+    )
+    target.write_text(mutated, encoding="utf-8")
+
+    result = _run_mypy_on_copy(tmp_path)
+
+    _assert_resolved(result)
+    reported = set(ERROR_CODE_PATTERN.findall(result.stdout))
+    assert expected_code in reported, (
+        f"Mutation {label!r} was not rejected with [{expected_code}]; mypy "
+        f"reported {sorted(reported) or 'nothing'}. With the seam annotated "
+        "this drift must fail the type check -- if it does not, production and "
+        f"the Protocol can diverge with the suite green.\n{result.stdout}"
+    )
+    assert str(tmp_path) in result.stdout, (
+        "mypy reported no diagnostic inside the copied tree, so it checked the "
+        f"repository's own sources and the mutation was never read.\n{result.stdout}"
+    )
+

--- a/tests/test_worker_process_protocol.py
+++ b/tests/test_worker_process_protocol.py
@@ -56,10 +56,16 @@ from tests.doubles.worker_process import FakeWorkerProcess, primed_reader
 # cosmetic. That function no longer touches a process at all -- the runner
 # extraction took the spawn, the stream reads and the exit status with it -- so
 # the four loader tests that used to hand `FakeWorkerProcess` to production now
-# double the runner instead. Until the runner's parameter is annotated with
-# `WorkerProcess`, this literal is the *only* thing tying the double's shape to
-# what production reads: nothing else fails if they diverge. That annotation is
-# the very next step in the plan, and this comment is why it should not wait.
+# double the runner instead.
+#
+# This literal is no longer the ONLY thing tying the double's shape to what
+# production reads. It was, between the extraction and the annotation, and
+# nothing failed if the two diverged. `_run_worker_command` now annotates the
+# process it spawns with the Protocol, so the seam cases at the bottom of this
+# module catch a divergence that this literal cannot see: production growing an
+# eighth read. The two check opposite directions and neither is redundant --
+# this one fails when the PROTOCOL gains a member nothing consumes, which no
+# amount of type-checking production would notice.
 CONSUMED_SURFACE: Final = frozenset(
     {"stdout", "stderr", "pid", "returncode", "wait", "kill", "terminate"}
 )

--- a/tests/test_worker_process_protocol.py
+++ b/tests/test_worker_process_protocol.py
@@ -1022,10 +1022,11 @@ SEAM_MUTATIONS: Final = {
 }
 
 
-def _as_ini_value(value: Any) -> str:
+def _as_ini_value(key: str, value: Any) -> str:
     """Render a value read from ``pyproject.toml`` as mypy expects it in an INI.
 
     Args:
+        key: The option's name, which decides how a list is joined.
         value: A scalar or list taken from the committed ``[tool.mypy]`` table.
 
     Returns:
@@ -1034,7 +1035,12 @@ def _as_ini_value(value: Any) -> str:
     if isinstance(value, bool):
         return "True" if value else "False"
     if isinstance(value, list):
-        return ", ".join(str(item) for item in value)
+        # `exclude` is a single regular expression in INI form -- the array is a
+        # TOML affordance. Comma-joining two entries would produce a valid
+        # regex meaning something else, accepted in silence. Every other
+        # list-valued mypy option really is comma-separated.
+        separator = "|" if key == "exclude" else ", "
+        return separator.join(str(item) for item in value)
     return str(value)
 
 
@@ -1075,7 +1081,7 @@ def _copy_configuration(destination: Path) -> Path:
     for key, value in sorted(committed.items()):
         if key in {"files", "mypy_path", "overrides"}:
             continue
-        lines.append(f"{key} = {_as_ini_value(value)}")
+        lines.append(f"{key} = {_as_ini_value(key, value)}")
     lines.append(f"mypy_path = {destination / 'src'}")
     lines.append(f"files = {target}")
 
@@ -1088,7 +1094,9 @@ def _copy_configuration(destination: Path) -> Path:
                 continue
             lines.append("")
             lines.append(f"[mypy-{module}]")
-            lines.extend(f"{k} = {_as_ini_value(v)}" for k, v in sorted(settings.items()))
+            lines.extend(
+                f"{k} = {_as_ini_value(k, v)}" for k, v in sorted(settings.items())
+            )
 
     config = destination / "mypy.ini"
     config.write_text("\n".join(lines) + "\n", encoding="utf-8")
@@ -1173,7 +1181,22 @@ def test_the_copied_tree_type_checks_cleanly(tmp_path: Path) -> None:
     assert "unused section" not in result.stdout, (
         "The configuration derived from the committed [tool.mypy] carries a "
         "per-module section that binds to nothing in the copy's build, so its "
-        f"settings are inert here and this run is not the committed one.\n{result.stdout}"
+        "settings are inert here and this run is not the committed one.\n"
+        f"{result.stdout}"
+    )
+    # Measured: mypy reports an unrecognised option name, or a value it cannot
+    # parse, as `<config>: [mypy]: ...` and still EXITS 0. So neither the exit
+    # status above nor the unused-section guard -- which itself depends on
+    # `warn_unused_configs` having been carried across correctly -- can see a
+    # setting this derivation renders wrongly.
+    #
+    # Measured a second time, because the obvious spelling of this assertion is
+    # itself a guard that can never fire: those diagnostics go to STDERR, while
+    # every other assertion in this module reads stdout.
+    assert ": [mypy]" not in result.stderr, (
+        "The derived configuration produced a config diagnostic, so a key from "
+        "the committed [tool.mypy] did not survive `_as_ini_value` and the copy "
+        f"is not running the committed settings.\n{result.stderr}"
     )
 
 

--- a/tests/test_worker_process_protocol.py
+++ b/tests/test_worker_process_protocol.py
@@ -36,6 +36,7 @@ import shutil
 import subprocess
 import sys
 import tomllib
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Final
 
@@ -490,24 +491,6 @@ def test_production_annotates_the_spawned_process_with_the_protocol() -> None:
         "a literal, not a check."
     )
 
-    # A relative import, deliberately: the mutation cases below type-check a
-    # COPY of the tree, and an absolute import would resolve back to the
-    # repository's own Protocol, leaving both `types.py` mutations invisible.
-    relative = any(
-        isinstance(node, ast.ImportFrom)
-        and node.level == 1
-        and node.module == "types"
-        and any(alias.name == "WorkerProcess" for alias in node.names)
-        for node in ast.walk(tree)
-    )
-    assert relative, (
-        "worker_runner.py does not import WorkerProcess relatively "
-        "(`from .types import WorkerProcess`). An absolute import resolves "
-        "against mypy's search path, so a mutated copy of the Protocol would be "
-        "silently ignored and test_mypy_rejects_each_seam_mutation would go "
-        "green on the repository's own unmutated types.py."
-    )
-
 
 # --------------------------------------------------------------------------
 # The mypy configuration
@@ -727,6 +710,42 @@ def test_mypy_accepts_the_typed_double_surface() -> None:
 
 
 @pytest.mark.subsystem
+def test_mypy_accepts_the_committed_target_for_windows(tmp_path: Path) -> None:
+    """Type-check the Windows-only branches a native run declares unreachable.
+
+    This is the cost of narrowing ``_subprocess_launch_options`` on
+    ``sys.platform`` rather than silencing the ``STARTUPINFO`` lookup, and it is
+    paid here rather than left for the type-check job to discover. Measured:
+    mypy does not check code it considers unreachable, so on a Linux runner a
+    deliberate ``str``-into-``int`` error inside that function's Windows branch
+    is not reported, and under ``--platform win32`` it is. Without this case
+    that branch is unchecked on every runner this project currently has.
+
+    Note what it does *not* cover: ``_terminate_process_tree``'s Windows branch
+    guards on ``os.name``, which mypy cannot narrow, so the native run reads it
+    and this run adds nothing there. That asymmetry is deliberate and is pinned
+    by ``test_each_platform_guard_uses_the_spelling_its_checking_needs``.
+
+    Args:
+        tmp_path: Home for this run's cache. ``--platform`` is cache-affecting,
+            so sharing ``.mypy_cache`` with the native runs makes every run cold
+            in both directions -- permanently, including a developer's plain
+            ``mypy``. Measured: 0.16s / 1.89s / 2.12s / 1.90s alternating on a
+            shared cache, against 0.17s / 0.17s on separate ones. That would
+            silently reverse the reasoning recorded against ``incremental`` in
+            ``pyproject.toml``. A ``tmp_path`` leaves nothing untracked behind.
+    """
+    result = _run_mypy("--platform", "win32", "--cache-dir", str(tmp_path / "cache"))
+
+    _assert_resolved(result)
+    assert result.returncode == 0, (
+        "mypy rejected the committed target under --platform win32. The Windows "
+        "branch of _subprocess_launch_options is unreachable on a native run, "
+        f"so this is the only case that reads it.\n{result.stdout}"
+    )
+
+
+@pytest.mark.subsystem
 def test_ordinary_target_reports_no_unused_configuration_sections() -> None:
     """Prove every per-module section actually binds to a file mypy processes.
 
@@ -915,73 +934,129 @@ def test_the_any_fixture_is_clean_without_its_inline_directive(tmp_path: Path) -
 # and the mutations below are what prove it closed.
 # --------------------------------------------------------------------------
 
-# Each mutation is one exact substring swap applied to a throwaway copy of
-# `src/`. The (old, new) pair doubles as its own applied-check: a swap matching
-# nothing leaves the source identical, and the case says so rather than blaming
-# the seam for a clean run.
-SEAM_MUTATIONS: Final = {
-    "production_reads_a_member_the_protocol_never_declares": (
-        "worker_runner.py",
-        "    stdout_state: _StdoutAccumulator | None = None",
-        "    _undeclared = proc.stdin\n"
-        "    stdout_state: _StdoutAccumulator | None = None",
-        "attr-defined",
-    ),
-    "the_protocol_drops_a_member_production_reads": (
-        "types.py",
-        "    def stdout(self) -> asyncio.StreamReader | None:",
-        "    def stdout_renamed(self) -> asyncio.StreamReader | None:",
-        "attr-defined",
-    ),
-    "the_protocol_grows_a_member_a_real_process_lacks": (
-        "types.py",
-        "    @property\n    def stdout(self)",
+
+def _read_a_member_the_protocol_never_declares(source: str) -> str:
+    """Make the seam read ``proc.stdin``, which the Protocol does not declare.
+
+    Args:
+        source: ``worker_runner.py``'s text.
+
+    Returns:
+        The mutated text.
+    """
+    anchor = "    stdout_state: _StdoutAccumulator | None = None"
+    return source.replace(anchor, f"    _undeclared = proc.stdin\n{anchor}", 1)
+
+
+def _drop_a_member_the_seam_reads(source: str) -> str:
+    """Delete ``stdout`` from the Protocol outright.
+
+    A deletion, not a rename. Renaming does two things at once -- the Protocol
+    loses a member the seam reads *and* gains one no real process has -- which is
+    the next mutation's drift, with its diagnostics. Measured: the rename
+    reports four errors and is indistinguishable from that case; the deletion
+    reports one.
+
+    Sliced between two signature anchors rather than swapped as one literal, so
+    the case is not coupled to the member's docstring prose.
+
+    Args:
+        source: ``types.py``'s text.
+
+    Returns:
+        The mutated text.
+    """
+    start = source.index("    @property\n    def stdout(self)")
+    end = source.index("    @property\n    def stderr(self)")
+    return source[:start] + source[end:]
+
+
+def _add_a_member_no_real_process_has(source: str) -> str:
+    """Grow the Protocol by a member ``asyncio.subprocess.Process`` cannot supply.
+
+    Args:
+        source: ``types.py``'s text.
+
+    Returns:
+        The mutated text.
+    """
+    anchor = "    @property\n    def stdout(self)"
+    addition = (
         "    @property\n"
         "    def absent_from_a_real_process(self) -> int:\n"
         '        """Declared by nobody, so a real process cannot satisfy it."""\n'
         "        ...\n"
         "\n"
-        "    @property\n"
-        "    def stdout(self)",
-        "assignment",
+    )
+    return source.replace(anchor, addition + anchor, 1)
+
+
+# Each entry: the file it edits, how it edits it, and the EXACT set of error
+# codes it must provoke. Exact rather than membership, because the sets are what
+# prove the three mutations do different work: the first two report one code
+# from one site, the third also reports `arg-type` where `_run_pipe_probe` hands
+# its concrete process to `_terminate_process_tree`. A mutation quietly
+# collapsing onto another's diagnostics is the failure this pins.
+SEAM_MUTATIONS: Final = {
+    "production_reads_a_member_the_protocol_never_declares": (
+        "worker_runner.py",
+        _read_a_member_the_protocol_never_declares,
+        frozenset({"attr-defined"}),
+    ),
+    "the_protocol_drops_a_member_production_reads": (
+        "types.py",
+        _drop_a_member_the_seam_reads,
+        frozenset({"attr-defined"}),
+    ),
+    "the_protocol_grows_a_member_a_real_process_lacks": (
+        "types.py",
+        _add_a_member_no_real_process_has,
+        frozenset({"arg-type", "assignment"}),
     ),
 }
 
 
-def _run_mypy_on_copy(destination: Path, *args: str) -> subprocess.CompletedProcess[str]:
-    """Type-check a copied ``worker_runner.py`` against the copy's own Protocol.
+def _as_ini_value(value: Any) -> str:
+    """Render a value read from ``pyproject.toml`` as mypy expects it in an INI.
 
-    The committed configuration cannot be reused, and this is measured rather
-    than assumed. ``_run_mypy`` pins the child's ``cwd`` to the repository root
-    and ``pyproject.toml`` sets ``mypy_path = "$MYPY_CONFIG_FILE_DIR/src"`` --
-    the *repository's* ``src``. Under that configuration only the file named on
-    the command line comes from the copy: with the copy's ``types.py`` mutated,
-    mypy reported ``Success`` and ``-v`` showed it parsing the repository's
-    ``types.py``. So the copy gets its own config with an absolute ``mypy_path``,
-    and production imports the Protocol relatively, which cannot resolve outside
-    its own package.
+    Args:
+        value: A scalar or list taken from the committed ``[tool.mypy]`` table.
 
-    The build deliberately contains this module and its followed imports only,
-    not ``tests/doubles``. With the double in it, the third mutation also breaks
-    ``FakeWorkerProcess``'s own ``_contract`` assignment -- machinery the earlier
-    step already ships -- and the case could no longer tell its claim from that
-    one. Measured: 5 errors across 2 files with the double in, 3 in 1 file
-    without it.
+    Returns:
+        The INI spelling.
+    """
+    if isinstance(value, bool):
+        return "True" if value else "False"
+    if isinstance(value, list):
+        return ", ".join(str(item) for item in value)
+    return str(value)
+
+
+def _copy_configuration(destination: Path) -> Path:
+    """Derive the copy's mypy configuration from the committed one.
+
+    Written rather than hand-authored on purpose. A hand-authored config is a
+    second, unchecked declaration of the type-check settings: the committed
+    table could later gain a setting that changes what the seam check means --
+    ``strict``, or extending ``disallow_any_expr`` to this module -- and these
+    cases would go on exercising a configuration nobody ships, staying green.
+    That is the failure this module opens by naming: a literal is not a check.
+
+    Everything is carried over except ``files`` and ``mypy_path``, which must
+    point at the copy, and the per-module overrides for modules outside the
+    copy's build. ``tests/doubles`` is deliberately not in that build: with the
+    double present the third mutation also breaks ``FakeWorkerProcess``'s own
+    ``_contract`` assignment -- a check the Protocol harness already ships --
+    and the case could no longer tell its own claim from that one. Measured: 5
+    errors across 2 files with it, 3 in 1 file without.
 
     Args:
         destination: Directory holding the copied tree.
-        *args: Extra flags appended to the invocation.
 
     Returns:
-        The completed child mypy run.
+        The written config file's path.
     """
-    config = destination / "mypy.ini"
-    config.write_text(
-        "[mypy]\n"
-        "python_version = 3.13\n"
-        f"mypy_path = {destination / 'src'}\n",
-        encoding="utf-8",
-    )
+    committed = _mypy_configuration()
     target = (
         destination
         / "src"
@@ -989,16 +1064,29 @@ def _run_mypy_on_copy(destination: Path, *args: str) -> subprocess.CompletedProc
         / "scrape"
         / "worker_runner.py"
     )
-    return _run_mypy(
-        "--config-file",
-        str(config),
-        # A cache shared with the repository's runs would answer from the
-        # unmutated tree.
-        "--cache-dir",
-        str(destination / "cache"),
-        *args,
-        str(target),
-    )
+
+    lines = ["[mypy]"]
+    for key, value in sorted(committed.items()):
+        if key in {"files", "mypy_path", "overrides"}:
+            continue
+        lines.append(f"{key} = {_as_ini_value(value)}")
+    lines.append(f"mypy_path = {destination / 'src'}")
+    lines.append(f"files = {target}")
+
+    for override in committed.get("overrides", []):
+        settings = {k: v for k, v in override.items() if k != "module"}
+        for module in override["module"]:
+            # An override for a module outside this build would match nothing,
+            # and `warn_unused_configs` -- carried over above -- would report it.
+            if not module.startswith("kindly_web_search_mcp_server."):
+                continue
+            lines.append("")
+            lines.append(f"[mypy-{module}]")
+            lines.extend(f"{k} = {_as_ini_value(v)}" for k, v in sorted(settings.items()))
+
+    config = destination / "mypy.ini"
+    config.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return config
 
 
 def _copy_source_tree(destination: Path) -> Path:
@@ -1015,15 +1103,53 @@ def _copy_source_tree(destination: Path) -> Path:
     return copied
 
 
+def _run_mypy_on_copy(destination: Path) -> subprocess.CompletedProcess[str]:
+    """Type-check the copied runner against the copy's own Protocol.
+
+    The committed configuration cannot simply be reused, and that is measured
+    rather than assumed. ``_run_mypy`` pins the child's ``cwd`` to the
+    repository root and the committed ``mypy_path`` is
+    ``$MYPY_CONFIG_FILE_DIR/src`` -- the *repository's*. Under it, only the file
+    named on the command line comes from the copy: with the copy's ``types.py``
+    mutated, mypy reported ``Success`` and ``-v`` showed it parsing the
+    repository's ``types.py``. Anchoring ``mypy_path`` at the copy is what fixes
+    that, and it is sufficient on its own -- measured, an absolute import
+    resolves to the copy too, so production's relative import of the Protocol is
+    a second line of defence and not the mechanism.
+
+    Args:
+        destination: Directory holding the copied tree.
+
+    Returns:
+        The completed child mypy run.
+    """
+    return _run_mypy(
+        "--config-file",
+        str(_copy_configuration(destination)),
+        # A cache shared with the repository's own runs would answer from the
+        # unmutated tree.
+        "--cache-dir",
+        str(destination / "cache"),
+    )
+
+
 @pytest.mark.subsystem
 def test_the_copied_tree_type_checks_cleanly(tmp_path: Path) -> None:
     """Control for the mutation cases: prove an unmutated copy is clean.
 
-    Its job is narrower than it looks. It is *not* what proves the copy is on
+    Its job is narrower than it looks. It is not what proves the copy is on
     mypy's path -- the two ``types.py`` mutations are, since they report nothing
-    at all if mypy read the repository's Protocol instead. What this excludes is
-    the other direction: a copy broken for some unrelated reason, under which
-    every mutation case would "detect" an error that was there all along.
+    at all if mypy reads the repository's Protocol instead, and the remaining
+    mutation asserts the reported path itself. What this excludes is the other
+    direction: a copy broken for some unrelated reason, under which every
+    mutation case would "detect" an error that was there all along.
+
+    Each case builds its own copy, so this control speaks for the machinery, not
+    for one shared tree that later cases inherit.
+
+    The unused-section assertion is what proves the *derived* configuration
+    actually binds: the copied override is keyed on a module that must be in the
+    build, and mypy reports the section as unused if it is not.
 
     Args:
         tmp_path: Destination for the copied tree.
@@ -1038,12 +1164,19 @@ def test_the_copied_tree_type_checks_cleanly(tmp_path: Path) -> None:
         "below cannot attribute their errors to the mutation rather than to the "
         f"copy.\n{result.stdout}"
     )
+    assert "unused section" not in result.stdout, (
+        "The configuration derived from the committed [tool.mypy] carries a "
+        "per-module section that binds to nothing in the copy's build, so its "
+        f"settings are inert here and this run is not the committed one.\n{result.stdout}"
+    )
 
 
 @pytest.mark.subsystem
 @pytest.mark.parametrize(("label", "mutation"), sorted(SEAM_MUTATIONS.items()))
 def test_mypy_rejects_each_seam_mutation(
-    label: str, mutation: tuple[str, str, str, str], tmp_path: Path
+    label: str,
+    mutation: tuple[str, Callable[[str], str], frozenset[str]],
+    tmp_path: Path,
 ) -> None:
     """Prove the annotation makes production's consumption a checked claim.
 
@@ -1052,30 +1185,28 @@ def test_mypy_rejects_each_seam_mutation(
     reads, and the Protocol growing one a real ``asyncio.subprocess.Process``
     cannot supply.
 
-    The error *code* is asserted, never the exit status: mypy exits non-zero for
-    a syntax error, an unresolved import or a crash just as readily. Membership,
-    never "the first" or "the only" error -- the third mutation also reports
-    ``arg-type`` at the two ``_run_pipe_probe`` call sites, which is correct
-    output and not a defect. And the reported path must fall inside the copy: a
-    diagnostic against the repository would mean the mutation was never read.
+    Error *codes* are asserted, never the exit status: mypy exits non-zero for a
+    syntax error, an unresolved import or a crash just as readily. And the
+    reported path must fall inside the copy -- a diagnostic against the
+    repository would mean the mutation was never read.
 
     Args:
         label: The drift being simulated.
-        mutation: File name, the exact text replaced, its replacement, and the
-            diagnostic that drift must provoke.
+        mutation: File to edit, the edit, and the exact codes it must provoke.
         tmp_path: Destination for the copied tree.
     """
-    filename, old, new, expected_code = mutation
+    filename, mutate, expected_codes = mutation
     copied = _copy_source_tree(tmp_path)
     target = copied / "kindly_web_search_mcp_server" / "scrape" / filename
     source = target.read_text(encoding="utf-8")
-    mutated = source.replace(old, new, 1)
+    mutated = mutate(source)
 
-    # A swap matching nothing leaves a clean tree, and a case asserting an error
-    # would then fail with a message blaming the seam for a stale anchor.
+    # A mutation that matched nothing leaves a clean tree, and a case asserting
+    # an error would then fail with a message blaming the seam for a stale
+    # anchor.
     assert mutated != source, (
-        f"The text this mutation replaces has moved in {filename}: {old!r}. The "
-        "case cannot simulate the drift it names until the anchor is updated."
+        f"Mutation {label!r} changed nothing in {filename}, so its anchor has "
+        "moved. The case cannot simulate the drift it names until that is fixed."
     )
     target.write_text(mutated, encoding="utf-8")
 
@@ -1083,14 +1214,15 @@ def test_mypy_rejects_each_seam_mutation(
 
     _assert_resolved(result)
     reported = set(ERROR_CODE_PATTERN.findall(result.stdout))
-    assert expected_code in reported, (
-        f"Mutation {label!r} was not rejected with [{expected_code}]; mypy "
-        f"reported {sorted(reported) or 'nothing'}. With the seam annotated "
-        "this drift must fail the type check -- if it does not, production and "
-        f"the Protocol can diverge with the suite green.\n{result.stdout}"
+    assert reported == set(expected_codes), (
+        f"Mutation {label!r} was expected to report exactly "
+        f"{sorted(expected_codes)}; mypy reported {sorted(reported) or 'nothing'}. "
+        "With the seam annotated this drift must fail the type check -- if it "
+        "reports nothing, production and the Protocol can diverge with the "
+        "suite green; if it reports a different set, this mutation has "
+        f"collapsed onto another's drift.\n{result.stdout}"
     )
     assert str(tmp_path) in result.stdout, (
         "mypy reported no diagnostic inside the copied tree, so it checked the "
         f"repository's own sources and the mutation was never read.\n{result.stdout}"
     )
-

--- a/tests/test_worker_runner.py
+++ b/tests/test_worker_runner.py
@@ -388,3 +388,76 @@ async def test_runner_diagnostics_keep_their_order() -> None:
         "worker.timeout_budget_parent",
         "worker.stdout",
     ], stages
+
+
+# --------------------------------------------------------------------------
+# Platform guards, and why the two are spelled differently
+# --------------------------------------------------------------------------
+
+# The rule, so a future reader can apply it without re-measuring:
+#
+#   Use `sys.platform` where the branch touches stdlib that exists only on that
+#   platform AND a second mypy run under `--platform win32` covers it.
+#   Use `os.name` where you want the branch checked on EVERY run.
+#
+# mypy narrows on `sys.platform` and never on `os.name`, and it does not
+# type-check code it considers unreachable. So the spelling decides which runs
+# read the branch at all, and the two functions below want different answers.
+PLATFORM_GUARDS = {
+    # Touches `subprocess.STARTUPINFO`, which typeshed declares win32-only. Under
+    # `os.name` this produced `Module has no attribute "STARTUPINFO"` the moment
+    # the module joined the type-check target.
+    "_subprocess_launch_options": ("sys.platform", "os.name"),
+    # Touches no platform-exclusive stdlib, so it costs nothing to keep readable
+    # on every run — and converting it would make mypy treat the whole `taskkill`
+    # path unreachable on Linux and stop checking it there.
+    "_terminate_process_tree": ("os.name", "sys.platform"),
+}
+
+
+@pytest.mark.parametrize(("function_name", "guards"), sorted(PLATFORM_GUARDS.items()))
+def test_each_platform_guard_uses_the_spelling_its_checking_needs(
+    function_name: str, guards: tuple[str, str]
+) -> None:
+    """Pin both halves of the two-spelling rule, so a tidy-up cannot erase coverage
+
+    The asymmetry reads as an oversight and is not. Asserting only the
+    `sys.platform` half would leave a "make it consistent" edit free to convert
+    the other function and silently stop Linux from checking its Windows branch;
+    asserting only the `os.name` half would let the `STARTUPINFO` defect return.
+    Both directions are pinned because each fails a different way.
+
+    Args:
+        function_name: The guarded function in `worker_runner.py`.
+        guards: The spelling it must use, and the one it must not.
+    """
+    required, forbidden = guards
+    source = Path(worker_runner.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=worker_runner.__file__)
+    function = next(
+        (
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == function_name
+        ),
+        None,
+    )
+    assert function is not None, f"{function_name} has moved or been renamed."
+
+    # Attribute accesses, not a text search: the comment that explains why the
+    # rejected spelling was rejected has to be free to name it.
+    accessed = {
+        f"{node.value.id}.{node.attr}"
+        for node in ast.walk(function)
+        if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name)
+    }
+
+    assert required in accessed, (
+        f"{function_name} no longer reads `{required}`. See PLATFORM_GUARDS "
+        "above for which runs each spelling leaves the branch checked by."
+    )
+    assert forbidden not in accessed, (
+        f"{function_name} reads `{forbidden}`, which is the wrong spelling for "
+        "it. See PLATFORM_GUARDS above."
+    )

--- a/tests/test_worker_runner.py
+++ b/tests/test_worker_runner.py
@@ -240,6 +240,28 @@ def test_worker_runner_does_not_from_import_the_spawn_primitive() -> None:
     )
 
 
+# Everything the extraction moved out of `universal_html.py`. A list, not a spot
+# check: the move is only worth its diff if the whole block travelled. Shared by
+# the two cases below so the set has one definition -- a second enumeration is
+# the drift this list exists to prevent.
+PROCESS_MANAGEMENT_SURFACE = (
+    "_run_worker_command",
+    "_run_pipe_probe",
+    "_read_probe_stream",
+    "_read_stdout_stream",
+    "_read_stderr_stream",
+    "_consume_stderr_line",
+    "_finalize_stderr_state",
+    "_append_tail_text",
+    "_maybe_emit_stream_progress",
+    "_emit_worker_heartbeat",
+    "_terminate_process_tree",
+    "_subprocess_launch_options",
+    "_StdoutAccumulator",
+    "_StderrAccumulator",
+)
+
+
 def test_worker_runner_owns_the_process_management_surface() -> None:
     """Name what moved, so a partial move back is a failure rather than a drift
 
@@ -248,29 +270,14 @@ def test_worker_runner_owns_the_process_management_surface() -> None:
     unhermetic code back inside the gated module without any single assertion
     above noticing.
     """
-    expected = (
-        "_run_worker_command",
-        "_run_pipe_probe",
-        "_read_probe_stream",
-        "_read_stdout_stream",
-        "_read_stderr_stream",
-        "_consume_stderr_line",
-        "_finalize_stderr_state",
-        "_append_tail_text",
-        "_maybe_emit_stream_progress",
-        "_emit_worker_heartbeat",
-        "_terminate_process_tree",
-        "_subprocess_launch_options",
-        "_StdoutAccumulator",
-        "_StderrAccumulator",
-    )
-
-    missing = [name for name in expected if not hasattr(worker_runner, name)]
+    missing = [
+        name for name in PROCESS_MANAGEMENT_SURFACE if not hasattr(worker_runner, name)
+    ]
     assert not missing, f"worker_runner.py is missing {missing}"
 
     strays = [
         name
-        for name in expected
+        for name in PROCESS_MANAGEMENT_SURFACE
         if getattr(getattr(universal_html, name, None), "__module__", None)
         == universal_html.__name__
     ]
@@ -461,3 +468,142 @@ def test_each_platform_guard_uses_the_spelling_its_checking_needs(
         f"{function_name} reads `{forbidden}`, which is the wrong spelling for "
         "it. See PLATFORM_GUARDS above."
     )
+
+
+def _windows_branch_of(function_name: str) -> ast.If:
+    """Locate the ``os.name == "nt"`` branch inside a function in the runner.
+
+    Args:
+        function_name: The function to search.
+
+    Returns:
+        The ``if`` node guarding that function's Windows-only body.
+    """
+    source = Path(worker_runner.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=worker_runner.__file__)
+    function = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == function_name
+    )
+    return next(
+        node
+        for node in ast.walk(function)
+        if isinstance(node, ast.If)
+        and isinstance(node.test, ast.Compare)
+        and isinstance(node.test.left, ast.Attribute)
+        and node.test.left.attr == "name"
+        and isinstance(node.test.left.value, ast.Name)
+        and node.test.left.value.id == "os"
+    )
+
+
+def test_terminate_process_tree_guards_only_on_the_return_code() -> None:
+    """Pin the tree-kill guard to exactly `proc.returncode is None`
+
+    The guard used to read `proc.returncode is None and proc.pid is not None`.
+    The second conjunct was dead — `WorkerProcess.pid` is declared `int`, and
+    measured on CPython, `asyncio.subprocess.Process` assigns `self.pid =
+    transport.get_pid()` once in `__init__` and never clears it: a probe printed
+    the same integer before and after `wait()`.
+
+    Asserting its *absence* would have been the weak test. This branch runs only
+    on Windows, so nothing in this suite executes it, and mypy says nothing about
+    a removed conjunct — which leaves three mutants a grep cannot tell apart:
+
+    * deleting the whole `if` — `taskkill` then fires unconditionally;
+    * inverting it to `is not None` — `taskkill` fires only at processes that
+      have already exited, and never at the hung one it exists to reap;
+    * dropping the wrong conjunct, leaving `proc.pid is not None`.
+
+    So the test is positive and names the operator and both operands. All three
+    mutants fail it.
+    """
+    branch = _windows_branch_of("_terminate_process_tree")
+
+    guards = [
+        node
+        for node in ast.walk(branch)
+        if isinstance(node, ast.If)
+        and any(
+            isinstance(inner, ast.Attribute)
+            and inner.attr == "returncode"
+            and isinstance(inner.value, ast.Name)
+            and inner.value.id == "proc"
+            for inner in ast.walk(node.test)
+        )
+    ]
+    assert len(guards) == 1, (
+        f"Expected exactly one guard on `proc.returncode` inside "
+        f"_terminate_process_tree's Windows branch, found {len(guards)}. The "
+        "branch's other conditions test `killer`, not `proc`."
+    )
+
+    test = guards[0].test
+    assert isinstance(test, ast.Compare), (
+        "The tree-kill guard is no longer a single comparison. A `BoolOp` here "
+        "means a conjunct came back -- the `proc.pid is not None` half was "
+        "removed because WorkerProcess.pid is declared `int` and can never be "
+        "None."
+    )
+    assert len(test.ops) == 1 and isinstance(test.ops[0], ast.Is), (
+        "The tree-kill guard no longer tests `is None`. Inverted to `is not "
+        "None` it fires taskkill only at processes that have already exited, "
+        "which disables the tree-kill entirely and passes every other check in "
+        "this suite."
+    )
+    assert (
+        isinstance(test.left, ast.Attribute)
+        and test.left.attr == "returncode"
+        and isinstance(test.left.value, ast.Name)
+        and test.left.value.id == "proc"
+    ), "The tree-kill guard no longer tests `proc.returncode` on the left."
+    assert len(test.comparators) == 1 and isinstance(
+        test.comparators[0], ast.Constant
+    ), "The tree-kill guard no longer compares against a constant."
+    assert test.comparators[0].value is None, (
+        "The tree-kill guard no longer compares `proc.returncode` against None."
+    )
+
+
+def test_every_moved_symbol_is_documented() -> None:
+    """Hold the module to the project's every-symbol docstring rule
+
+    Thirteen of these fourteen arrived undocumented. They moved verbatim out of
+    `universal_html.py`, where they had none either, because an extraction that
+    also rewrites what it moves cannot be reviewed as an extraction — so the gap
+    was carried, deliberately, into the step that annotates the same signatures.
+
+    Scoped to the moved surface rather than to `src/`: the rest of the tree has
+    the same gap, closing it is no current step's business, and a repo-wide guard
+    would be red on arrival and get muted.
+
+    Read off `ast`, not `__doc__`. Two of these are dataclasses, and
+    `@dataclass` synthesises a `__doc__` from the field list when none is
+    written, so an attribute check reports both as documented when neither is.
+    """
+    source = Path(worker_runner.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=worker_runner.__file__)
+    defined = {
+        node.name: node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+    }
+
+    missing = [name for name in PROCESS_MANAGEMENT_SURFACE if name not in defined]
+    assert not missing, (
+        f"{missing} are named in PROCESS_MANAGEMENT_SURFACE but not defined at "
+        "module scope in worker_runner.py."
+    )
+
+    undocumented = [
+        name
+        for name in PROCESS_MANAGEMENT_SURFACE
+        if not (ast.get_docstring(defined[name]) or "").strip()
+    ]
+    assert not undocumented, (
+        f"These symbols in worker_runner.py carry no docstring: {undocumented}. "
+        "The project's rule is every class, method and function."
+    )
+    assert ast.get_docstring(tree), "worker_runner.py has lost its module docstring."

--- a/tests/test_worker_runner.py
+++ b/tests/test_worker_runner.py
@@ -482,21 +482,35 @@ def _windows_branch_of(function_name: str) -> ast.If:
     source = Path(worker_runner.__file__).read_text(encoding="utf-8")
     tree = ast.parse(source, filename=worker_runner.__file__)
     function = next(
-        node
-        for node in ast.walk(tree)
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-        and node.name == function_name
+        (
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == function_name
+        ),
+        None,
     )
-    return next(
-        node
-        for node in ast.walk(function)
-        if isinstance(node, ast.If)
-        and isinstance(node.test, ast.Compare)
-        and isinstance(node.test.left, ast.Attribute)
-        and node.test.left.attr == "name"
-        and isinstance(node.test.left.value, ast.Name)
-        and node.test.left.value.id == "os"
+    assert function is not None, f"{function_name} has moved or been renamed."
+
+    branch = next(
+        (
+            node
+            for node in ast.walk(function)
+            if isinstance(node, ast.If)
+            and isinstance(node.test, ast.Compare)
+            and isinstance(node.test.left, ast.Attribute)
+            and node.test.left.attr == "name"
+            and isinstance(node.test.left.value, ast.Name)
+            and node.test.left.value.id == "os"
+        ),
+        None,
     )
+    assert branch is not None, (
+        f"{function_name} has no `os.name` branch. Converting it to "
+        "`sys.platform` would make mypy treat the whole branch unreachable on "
+        "Linux and stop checking it -- see PLATFORM_GUARDS."
+    )
+    return branch
 
 
 def test_terminate_process_tree_guards_only_on_the_return_code() -> None:
@@ -607,3 +621,13 @@ def test_every_moved_symbol_is_documented() -> None:
         "The project's rule is every class, method and function."
     )
     assert ast.get_docstring(tree), "worker_runner.py has lost its module docstring."
+
+    # Both this case and the ownership case above iterate the tuple, so without
+    # this a fifteenth module-level symbol -- undocumented -- is invisible to
+    # both, and the rule silently stops reaching the module it is scoped to.
+    extra = sorted(set(defined) - set(PROCESS_MANAGEMENT_SURFACE))
+    assert not extra, (
+        f"worker_runner.py defines {extra} outside PROCESS_MANAGEMENT_SURFACE, "
+        "so neither the ownership case nor the docstring rule reaches them. Add "
+        "them to the tuple."
+    )


### PR DESCRIPTION
## Context for the Product Owner

When this server fetches a web page, it drives a headless Chromium in a **separate child process** and reads the result back over pipes. Parent and child have to agree on exactly what the parent may read.

That agreement has broken before, in production: the parent started reading the child's output *stream* while its test stand-in still offered an older method, and page fetching failed with a **completely green test suite**. A written contract — `WorkerProcess` — was created to stop that recurring.

**The contract existed but was attached to nothing.** `grep -rn "WorkerProcess" src/` returned its own declaration and nothing else. It was a specification no code had signed. This PR signs it, so the type checker now refuses three things that previously passed silently:

- the parent reads something the contract doesn't cover;
- the contract loses something the parent depends on;
- the contract drifts to something a real process cannot provide.

All three were **verified silent before this change** — the three mutation tests were run against the unannotated code and every one reported nothing.

No user-visible behaviour changes. The only functional edit is deleting a safety check that could never fire.

---

## Two defects found along the way

**1. A dead check hiding a much worse one.** The Windows kill path guarded `proc.pid is not None`, which is never false. Deleting it is trivial; *proving* it was deleted correctly is not. The obvious test — grep for the removed text — is also satisfied by a change that **inverts** the guard, which would fire the Windows process-killer only at processes that have *already exited*. Nothing in the suite would catch that: the branch never runs on Linux, and the type checker says nothing about a removed condition. The test now names the operator and both operands; all three bad variants were run against it and all three fail.

**2. A two-platform bug recorded as one-platform.** Requirement R9 asked that `_terminate_process_tree`'s docstring say what it *does*, not what its name implies. Writing that sentence honestly exposed the following, confirmed against CPython's source:

```python
def terminate(self):                       # Windows
    _winapi.TerminateProcess(self._handle, 1)
kill = terminate
```

The Windows branch calls `terminate()` first, waits 1.5 s, and reaches its tree-walking `taskkill /T /F` **only if the child is still alive**. `TerminateProcess` is immediate, unconditional, and kills the named process only — so the fallback essentially never runs, and **Chromium is orphaned on Windows too**, not just on Linux as three documents and a project memory had recorded.

Not fixed here — changing process termination is a behaviour change, and this PR annotates signatures. The step that owns the orphan fix has been **rescoped**: its entry now says the fix needs two mechanisms and that *a verify clause checking orphans on Linux alone passes while half the defect stands.*

---

## What changed

| Commit | |
|---|---|
| `65fb3f1` | Fix a pre-existing type error on `subprocess.STARTUPINFO`; pin **both** Windows guard spellings |
| `5e87826` | The annotation, plus three mutation tests proving it load-bearing |
| `ee48085` | Design-review answers: the tree-kill guard, a derived config, a true-deletion mutation |
| `636b51c` | Correct every sentence this work falsified; hand two constraints to later steps |
| `ef225c6` | Code-review answers, including the Windows orphan correction |

**Eleven new tests** (485 → 496). Also: thirteen previously undocumented symbols in `worker_runner.py` now carry docstrings — they were deliberately left undocumented by the extraction that moved them, with no step owning the gap, and this PR edits the same signatures.

### A deliberate asymmetry, so it is not "tidied up"

`_subprocess_launch_options` guards on `sys.platform`; `_terminate_process_tree` keeps `os.name`. That looks like an oversight and is not. mypy narrows only on `sys.platform`, and **does not type-check code it considers unreachable**. Measured, with an error injected into `_terminate_process_tree`'s Windows branch:

| guard | native run | `--platform win32` |
|---|---|---|
| `os.name` | **reported** | reported |
| `sys.platform` | not reported | reported |

Converting the second function for consistency would silently stop Linux checking the whole `taskkill` path. Both spellings are pinned by a test, and the rule is written into the module docstring as a procedure.

### Inherited by later steps, recorded in their plan entries

- The type-check job must run mypy **twice** — natively and `--platform win32` — each with its own `--cache-dir`. (Sharing one makes every run cold in both directions, *permanently*, including a developer's plain `mypy`: measured 0.16/1.89/2.12/1.90 s shared against 0.17/0.17 s separate.)
- The orphan fix's planned `os.killpg` must use `sys.platform`: under `os.name` it is clean natively and produces three `attr-defined` errors under the win32 run — the exact mirror of the defect fixed here.

## Verification

| Gate | Result |
|---|---|
| `pytest` | `496 passed, 2 skipped, 16 subtests` |
| `mypy` | `Success: no issues found in 4 source files` |
| `mypy --platform win32` | `Success: no issues found in 4 source files` |
| `ruff check` (changed files) | 4 findings, all pre-existing, count unchanged |
| `check_plan_dag.py` | `OK: 78 steps, acyclic` |
| review-system tests | `OK` |

Every new test was watched failing for the right reason before its production change, and each was then falsified against a deliberate mutation.

Two rounds of `system-design-reviewer` and one of `code-reviewer`, all findings applied. One correction worth flagging: the code reviewer's suggested guard against a mis-derived config was itself unfalsifiable — mypy writes config diagnostics to **stderr**, while every other assertion in that module reads stdout. Caught by falsifying it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
