### PR TITLE
Schedule the provider parsing and error paths nobody owned (plan step E5-8)

### DIFF
--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -160,6 +160,47 @@ for another.
 
 ### 3.1 Targets
 
+**Search-provider response parsing and error paths.** `search_serper`,
+`search_serpbase`, `search_tavily`, `search_searxng`, `search_sofya`,
+`search_youcom` — the six coroutines `PROVIDERS` dispatches to. Driven with
+`httpx.MockTransport`, so this is L1 and belongs in the `fast` job.
+
+**Coverage today runs inversely to selection priority**, which is the reason this
+is called out rather than left to the risk matrix. Counted 2026-09-03:
+
+| Provider | Selection order | Unit tests | HTTP error statuses covered |
+|---|---|---|---|
+| Serper | **1st — the default** | **1** (happy-path parse) | none |
+| SerpBase | 2nd | **0 — no test module exists** | none |
+| Tavily | 3rd | **1** (happy-path parse) | none |
+| SearXNG | 4th | 9 | 403, 429, invalid JSON |
+| Sofya | 5th | 11 | none — shape and empty only |
+| You.com | 6th | 15 | none — shape, empty, missing key |
+
+So the first provider a deployment actually selects is the least tested, and
+`search_serpbase` — which parses a whole provider's responses — is executed by no
+test in the tree. **No provider has a `401` case**, which is the failure an
+operator meets first: a key that is wrong, expired, or revoked. None has a
+timeout case.
+
+The instrument is settled and cheap — `MockTransport` is already how
+`test_searxng_unit.py` works — so what is missing is the work, not a decision
+about how to do it. Each provider needs its documented success shape, the
+malformed-item and empty-result paths it already claims to handle, and the five
+transport-level failures: `401`, `429`, a non-JSON body, a JSON body of the wrong
+shape, and a timeout.
+
+**One production defect is in scope here rather than filed separately**, because
+it is the thing that makes these errors hard to act on:
+`search_searxng` catches every per-instance exception in its multi-URL loop and
+re-raises `SearxngError(f"All configured SearXNG instances failed. Last error:
+{last_error}")` **without `from`**, so the branch's own message survives only as
+a substring of an aggregate and the exception chain is discarded entirely. The
+403 branch exists to tell an operator "enable the JSON format"; today that
+sentence reaches them flattened into a string with no traceback behind it. Fix
+the chaining as part of pinning the behaviour, so the assertion is written
+against an error worth raising.
+
 **Launch-argument and sandbox decisions.** `_build_chromium_launch_args`,
 `_resolve_sandbox_enabled`, `_resolve_browser_executable_path`,
 `_resolve_start_retry_attempts`, `_resolve_snap_backoff_multiplier`,
@@ -1498,8 +1539,8 @@ The **Today** column describes *test coverage*, not implementation status.
 | Subsystem / behaviour | Today | Target layer | CI job | Owner |
 |---|---|---|---|---|
 | Provider routing, strict order, no fallback | covered | L1 | `fast` | |
-| Serper / SerpBase / Tavily / SearXNG / Sofya parsing | partial | L1 | `fast` | |
-| Provider errors: 401, 429, malformed JSON, timeout, empty | gap | L1 (`httpx.MockTransport`) | `fast` | |
+| Serper / SerpBase / Tavily / SearXNG / Sofya parsing | partial — §3.1 counts it per provider; E5-8 owns it | L1 | `fast` | |
+| Provider errors: 401, 429, malformed JSON, timeout, empty | gap — E5-8 owns it | L1 (`httpx.MockTransport`) | `fast` | |
 | Provider registry ⇄ docs | covered | L2 | `fast` | |
 | StackExchange / GitHub issues / GitHub discussions / Wikipedia | partial — parsing covered, failure paths thin | L1 + L2 | `fast` | |
 | arXiv + PDF extraction | partial | L1 | `fast` | |

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -118,7 +118,7 @@ action).
 
 ## 2. Sequencing for parallelism
 
-<!-- totals: steps=78 authorable=50 pr_authorable=46 -->
+<!-- totals: steps=79 authorable=51 pr_authorable=47 -->
 
 Only **E0-1 and E0-2** are serial — a dependency declaration and a pytest config
 block, both S. Everything else fans out. The validator computes what is
@@ -808,6 +808,7 @@ typo'd selector fails the job.
 | **E5-5** | Markdown transforms against the corpus | PR | impl E3-3 | M |
 | **E5-6** | Text accumulators and encoding-cookie helpers | PR | impl E0-2 | S |
 | **E5-7** | Redaction helper units — existing behaviour only | PR | impl E0-2 | M |
+| **E5-8** | Search-provider parsing and error paths | PR | impl E0-2 | L |
 
 E5-3 and E5-4 own **disjoint** function sets, so they can run in parallel without
 duplicating tests or touching the same files.
@@ -906,6 +907,25 @@ duplicating tests or touching the same files.
   merges green; every emit-boundary assertion belongs to E9-1.
   *Verify:* properties fail if a masking rule is removed; no test added here fails
   on the current tree.
+
+- **E5-8.** The six coroutines `PROVIDERS` dispatches to, driven with
+  `httpx.MockTransport`. **Closes the two risk-matrix rows no step owned** —
+  provider parsing (`partial`) and provider errors (`gap`) — which is why it
+  exists as its own step rather than as scope on a migration or canary step.
+  §3.1 carries the count that motivates it: coverage runs *inversely* to
+  selection priority. Serper, the default provider, has one happy-path test;
+  `search_serpbase` has **no test module at all**; no provider has a `401` case.
+  E8-4's Serper canary does not substitute — it is nightly, needs a real
+  credential, and cannot drive a failure deterministically.
+  *Verify:* for each of the six, the documented success shape, the malformed-item
+  and empty-result paths, and `401`, `429`, a non-JSON body, a wrong-shaped JSON
+  body and a timeout; each case fails if its branch is removed. Also fixes
+  `search_searxng`'s aggregate re-raise to chain with `from`, so the per-instance
+  error is assertable as more than a substring — the one production change in
+  this step, and the reason the error assertions are worth writing.
+  **Deliberately not split per provider**: the six modules are independent, so
+  one engineer can land them in any order, and splitting would multiply the
+  shared `MockTransport` helper across six PRs.
 
 ---
 
@@ -1318,7 +1338,7 @@ under `tests/`; this unblocks E6-4.
 
 | ID | Step | Type | Blocked by | Size |
 |---|---|---|---|---|
-| **E13-1** | Suite complete | milestone | merge E10-10, merge E10-7, merge E10-11, merge E13-2, merge E12-1, complete E11-5, merge E6-1, merge E6-3, merge E6-4, merge E4-13, merge E7-1, merge E8-2, merge E8-3, merge E2-4, merge E5-5, merge E5-6, merge E9-1, merge E9-5, merge E9-6, merge E9-7 | S |
+| **E13-1** | Suite complete | milestone | merge E10-10, merge E10-7, merge E10-11, merge E13-2, merge E12-1, complete E11-5, merge E6-1, merge E6-3, merge E6-4, merge E4-13, merge E7-1, merge E8-2, merge E8-3, merge E2-4, merge E5-5, merge E5-6, merge E5-8, merge E9-1, merge E9-5, merge E9-6, merge E9-7 | S |
 | **E13-2** | Record the risk-matrix owners in `TEST_SUITE.md` | PR | complete X-6 | S |
 
 No diff. Exists because "every row is done" is otherwise something nobody checks:


### PR DESCRIPTION
## Context for the Product Owner

This is a **planning change only** — no test code and no product code moves, in this PR or as a result of merging it. It schedules work that the design document already said was missing but that nothing was assigned to do.

Our server searches the web through six providers, tried in priority order. If the first one is configured, it handles the query. I went looking at how well each is tested and found the coverage runs **backwards**: the provider a default install actually uses is the least tested, and one provider's response handling is tested by nothing at all.

| Provider | Order tried | Tests today | HTTP error cases |
|---|---|---|---|
| **Serper** | **1st — the default** | **1** (happy path only) | none |
| **SerpBase** | 2nd | **0 — no test file exists** | none |
| **Tavily** | 3rd | **1** (happy path only) | none |
| SearXNG | 4th | 9 | 403, 429, bad JSON |
| Sofya | 5th | 11 | none |
| You.com | 6th | 15 | none |

Counted 2026-09-03.

**No provider has a test for a rejected API key.** That is the failure an operator hits first — a key that is wrong, expired, or revoked — and nothing pins what the server does when it happens. There are also no timeout tests anywhere.

Why this matters commercially: these are the paths a paying user meets on a bad day. A silent parsing regression in SerpBase ships undetected; an expired Serper key produces whatever it produces, untested. The work is cheap — it needs no browser, no network and no infrastructure, and the technique is already in use elsewhere in the suite — so this is a gap of scheduling, not of difficulty.

---

## What changed

- `TEST_SUITE.md` §3.1 gains a **Search-provider response parsing and error paths** target, carrying the count above and the reasoning.
- The implementation plan gains **E5-8**, sized `L`, blocked only by `impl E0-2` (Done), so it is immediately authorable.
- The two risk-matrix rows that carried `partial` and `gap` with a blank owner now name E5-8.
- `E13-1`'s dependency list gains it — the DAG checker caught its absence, which is the check doing its job.
- Totals comment: `steps=78 → 79`, `authorable=50 → 51`, `pr_authorable=46 → 47`.

`git diff --stat` is two `.system_design/` files. Nothing else.

## Why it is its own step

`grep` for a plan step naming any provider coroutine returns nothing. E5-1/E5-2 are the five **URL** parsers; E5-3/E5-4 are config resolvers; E11-1 is an async migration of the files that already exist; E8-4 is a **nightly** Serper canary that needs a real credential and cannot drive a failure deterministically. None of them closes these rows.

Deliberately **one** step rather than six: the six modules are independent, so one engineer can land them in any order, and splitting would copy the shared `MockTransport` helper into six PRs.

## One production defect is scheduled in E5-8, not fixed here

To leave no room to skim past it: **this PR changes no production code.** Until E5-8 is authored, an operator still meets the flattened error below.

`search_searxng` catches every per-instance exception in its multi-URL loop and re-raises `SearxngError("All configured SearXNG instances failed. Last error: …")` **without `from`** (`search/searxng.py:178`) — the chain is discarded. So the 403 branch, which exists to tell an operator "enable the JSON format on your instance", reaches them flattened into a substring with no traceback behind it.

It is folded into the scope of E5-8 rather than filed as a separate step because it is what makes the error assertions worth writing: you cannot pin a useful error that production has already flattened. The fix lands with that step. This was found while writing the SearXNG fixture in #69 and is recorded there too.

## Checks

`scripts/check_plan_dag.py` — `OK: 79 steps, 5 external prerequisites, acyclic`. `tests/test_plan_dag.py` 33 passed. Review system's own 482 tests OK. Full suite **526 passed, 2 skipped, 16 subtests** — unchanged, as expected for a documentation-only diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)