### PR TITLE
Classify the Ubuntu snap launcher as snap, and prove it at both call sites

### DIFF
--- a/.system_design/BASELINE_FAILURES.md
+++ b/.system_design/BASELINE_FAILURES.md
@@ -409,6 +409,15 @@ repair injects the classification through a seam instead of deriving it from the
 host's path semantics. The wiring that remains asserted, and the coverage given
 up, are stated in that test's docstring and in `TEST_SUITE.md`.
 
+The probe output above is a measurement of the function as it was shipped on
+2026-09-02 and is left exactly as recorded. The *answer* it reports is still
+production's answer — nothing classifies as snap away from POSIX — but the
+mechanism behind it is not: a later change repaired a separate Ubuntu
+misclassification by testing the `/snap/` marker on the path as given, which
+would have made this path classify as snap, so an explicit `os.name` guard now
+carries the Windows answer. `TEST_SUITE.md` §3.1 has the detail. Nothing in this
+document's figures changes.
+
 **No relocation row was added, and none is needed.** The test was rewritten in
 place under its existing node id, which is the pattern this document says to
 prefer: the id never left the collected set, so nothing left this ledger by

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -229,6 +229,20 @@ differently depending on where the developer's Chromium came from — and
 POSIX. A case that pins only the first asserts one answer on Linux and its
 opposite on Windows.
 
+**The marker is matched anywhere in the path, not as a prefix**, and that is a
+requirement rather than a spelling. snapd mounts snaps under
+`/var/lib/snapd/snap` and puts `/var/lib/snapd/snap/bin` on `PATH`; `/snap`
+exists only where an administrator creates the symlink by hand, which classic
+confinement needs and nothing else does (ArchWiki, *Snap*). So on Fedora, Arch
+and Debian the launcher is `/var/lib/snapd/snap/bin/chromium` and the marker sits
+mid-path. The shipped function spelled this `resolved.startswith("/snap/") or
+"/snap/" in resolved` — a redundant prefix test beside the substring test that
+subsumed it — so "tidy that back to the prefix" is the refactor the next reader
+reaches for, and it would deny the allowance to every snap browser off Ubuntu.
+Two of §3.1's cases carry a mid-path marker for exactly this reason, one on the
+given path and one on the resolved one; without them that mutation survives the
+whole suite. Measured.
+
 The guard is spelled `os.name != "posix"` and not `sys.platform` or a Linux test,
 on two separate grounds. POSIX rather than Linux: macOS has no snap either, but a
 `/snap/` path there classified as snap before the guard existed and
@@ -2209,9 +2223,11 @@ job's own pinned run of the L1/L2 selection; nothing is combined across jobs. Bu
 that single run is reported twice, and the difference is load-bearing.
 
 `source_pkgs` makes the report **whole-package by definition** — that is the point
-of control 1, and it is also a trap. A module the hermetic lane cannot execute,
-such as `chromium_pool.py`, appears with every statement at zero hits. It is not
-absent; it is present and uncovered. So a scope claim cannot be made by wishing:
+of control 1, and it is also a trap. A module the hermetic lane cannot execute
+appears with every statement at zero hits. It is not absent; it is present and
+uncovered. `chromium_pool.py` was the example here and is now only a partial one
+— its slot startup gained a hermetic case with the snap-detection fix, so the
+lane executes the module, though almost all of it stays at zero. So a scope claim cannot be made by wishing:
 without filtering, `diff-cover` sees those zero-hit statements and counts changed
 ones as uncovered, and adding L3-only statements grows the ratchet's denominator
 while the numerator stands still. Ordinary worker or pool development would fail

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -218,34 +218,49 @@ that never reach it: an environment-variable case that leaves the real lookup in
 place is a case whose result depends on whether the developer has Chromium
 installed.
 
-**`_is_snap_browser` reads the filesystem, and answers wrongly on both platforms
-for two different measured reasons.** Its only ambient input is
-`os.path.realpath`, so pin it —
-`monkeypatch.setattr(os.path, "realpath", …)` — in every case, on the same
-reasoning as `shutil.which` above: a case that leaves the real call in place
-answers differently depending on where the developer's Chromium came from.
+**`_is_snap_browser` has two ambient inputs, and both are pinned in every case
+that derives a classification.** They are `os.path.realpath` —
+`monkeypatch.setattr(os.path, "realpath", …)`, on the same reasoning as
+`shutil.which` above, because a case that leaves the real call in place answers
+differently depending on where the developer's Chromium came from — and
+`os.name`, because the function refuses to classify anything as snap away from
+POSIX. A case that pins only the first asserts one answer on Linux and its
+opposite on Windows.
 
-- **On Windows nothing classifies as snap, whatever the path.** A path with a
-  single leading slash is not absolute there, so `realpath` joins it against the
-  current working drive and normalises the separators; `/snap/bin/chromium`
-  becomes `<drive>:\snap\bin\chromium` and the `/snap/` marker the detector keys
-  on is erased. Measured against the shipped function on a `windows-latest`
-  runner. **This is correct production behaviour** — snap is a Linux packaging
-  format — and must not be "fixed" in the detector by matching separators.
-- **On Ubuntu the commonest snap install classifies as non-snap.** The real
-  `/snap/bin/chromium` is a symlink to `/usr/bin/snap`, which `realpath` follows
-  before the prefix test. That one is an **open production defect**, reported and
-  characterised rather than repaired; see §14.
+The function used to answer *wrongly* on both platforms, for two different
+measured reasons. One was a defect and is fixed; the other was correct and now
+rests on an explicit guard instead of an accident.
+
+- **Nothing classifies as snap away from POSIX, whatever the path.** This is
+  correct production behaviour — snap is a Linux packaging format — and it used
+  to fall out of `realpath`: a path with a single leading slash is not absolute
+  on Windows, so it was joined against the current working drive and its
+  separators normalised, turning `/snap/bin/chromium` into
+  `<drive>:\snap\bin\chromium` and erasing the `/snap/` marker. Measured against
+  the then-shipped function on a `windows-latest` runner. Testing the path **as
+  given** removed that accident, so an `os.name` guard carries the answer now.
+  The instruction that stands is unchanged in substance: do not "fix" this by
+  matching separators.
+- **On Ubuntu the commonest snap install classified as non-snap.** The real
+  `/snap/bin/chromium` is a symlink to `/usr/bin/snap`, which `realpath` followed
+  before the prefix test, so the browser that most needs the longer DevTools
+  budget was the only one that never got it. That was an open production defect,
+  carried across four steps as a characterised known-wrong answer; it is now
+  **fixed** — the marker is tested on the path as given, then on the resolved
+  path. Resolving still earns its place: a browser reached by an ordinary path
+  can be a snap package underneath, and only the resolved form says so.
 
 E1-6 hit the first of these and repaired the affected test by injecting the
-classification. The path-shape wiring it gave up belongs to **E5-4**, whose entry
-cites this section — the pointer runs both ways deliberately, because the layer
-split sends resolver tests to
+classification. The path-shape wiring it gave up has since been restored at both
+call sites by the fix above, which pins `os.name` and `os.path.realpath` rather
+than injecting an answer, and the component-level cases for `_is_snap_browser`
+landed with it in `tests/test_nodriver_worker_launch_resolvers.py`. **E5-4 no
+longer owns that function**; its classification group keeps
+`_is_retryable_browser_connect_error` alone. The pointer between this section and
+E5-4's entry is kept anyway, because the layer split sends resolver tests to
 `tests/test_nodriver_worker_launch_resolvers.py` while the traps were first
 recorded in `tests/test_nodriver_worker_sandbox.py`, which an E5-4 author has no
-reason to open. E5-4 lands *after* E4-2 makes the cross-platform job required, so
-the obvious first assertion — a `/snap/` path is snap — turns a required gate red
-rather than a local run.
+reason to open.
 
 **The `hasattr(os, "geteuid")` guard is not a testable branch.** Deleting the
 attribute exercises the *condition*, but the call sits inside a
@@ -1472,11 +1487,20 @@ conversion bug.
    block now asserts away.
 
    **The seam's cost was measured and then repaid.** Injecting the answer gives
-   up the wiring from a *path shape* to the classification, which belongs to
-   E5-4 — the step that owns `_is_snap_browser` outright. What it keeps is
+   up the wiring from a *path shape* to the classification. What it keeps is
    asserted explicitly: the detector is consulted, and about the path the caller
    supplied. Measured — with that assertion removed, a mutation asking the
    detector about the wrong path survives; with it, the mutation dies.
+
+   **Superseded in part.** The reasoning above is left as it was recorded, and
+   the two seam cases still stand — but the wiring it gave up has since been
+   restored. The Ubuntu misclassification named in §14 was repaired in a change
+   of its own, and `_is_snap_browser` now reads `os.name` as well as
+   `os.path.realpath`. Pinning **both** is what a case needs to derive a
+   classification from a path and still assert one constant on every platform;
+   pinning only `realpath`, as was possible when this was written, is not enough
+   and is the reason the seam looked unavoidable. Each call site gained a case
+   per polarity on that basis. See §3.1.
 
    **A live mutant on the line being repaired was found and killed.** The
    `if is_snap else 1.0` conditional was asserted by **nothing in the tree**:
@@ -2879,14 +2903,14 @@ is nothing to test.
   `_is_snap_browser`), which implies breakage has happened and will recur.
 - **`_split_worker_diagnostics` is dead code** (§4.3), flagged for removal under
   a separate change.
-- **`_is_snap_browser` misclassifies the commonest snap install**, and the defect
-  is open. `/snap/bin/chromium` is a symlink to `/usr/bin/snap` on Ubuntu, and
-  the function calls `os.path.realpath` before testing for the `/snap/` prefix,
-  so the browser that most needs the longer DevTools timeout is the one that does
-  not get it. Measured on Ubuntu 24.04. Recorded here because it was previously
-  documented only in a test-module comment, which left E5-4 — the step that will
-  write the first direct test of this function — to choose unaided between
-  asserting a known-wrong answer and repairing production inside a testing step.
-  It should do the former, with the defect named; the repair deserves its own
-  change. §3.1 carries the detail, including the separate Windows behaviour that
-  is **not** a defect.
+- **`_is_snap_browser` misclassified the commonest snap install. CLOSED** — the
+  repair landed as a change of its own, which is what this entry said it
+  deserved. `/snap/bin/chromium` is a symlink to `/usr/bin/snap` on Ubuntu and
+  the function resolved the path before testing it for the `/snap/` marker, so
+  the browser that most needs the longer DevTools timeout was the one that never
+  got it. Measured on Ubuntu 24.04, and re-measured against the repaired function
+  on the same host. The marker is now tested on the path as given before the
+  resolved one, behind an `os.name` guard that keeps the (correct) Windows answer
+  from depending on an accident of `realpath`. Both call sites — `_fetch_html`
+  and the pooled slot — have a case per polarity deriving the classification from
+  a path. §3.1 carries the detail.

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -91,6 +91,8 @@ specific:
   `_emit_worker_heartbeat`, `_terminate_process_tree`. The 3 stale loader tests
   target this.
 - **All of `scrape/chromium_pool.py`** (372 lines) — no test file references it.
+  *(Since narrowed: `tests/test_chromium_pool_slot_start.py` covers
+  `ChromiumSlot._start`'s snap DevTools budget. The rest of the module stands.)*
 
 Working and not to be disturbed: 15 of 18 tests in
 `test_universal_html_loader.py` cover the Markdown-suffix probe path end to end,
@@ -227,6 +229,16 @@ differently depending on where the developer's Chromium came from — and
 POSIX. A case that pins only the first asserts one answer on Linux and its
 opposite on Windows.
 
+The guard is spelled `os.name != "posix"` and not `sys.platform` or a Linux test,
+on two separate grounds. POSIX rather than Linux: macOS has no snap either, but a
+`/snap/` path there classified as snap before the guard existed and
+misclassifying one costs only a longer timeout — narrowing it would be a
+behaviour change made for tidiness. `os.name` rather than `sys.platform`: the
+convention this repository already records is that only a body touching
+platform-exclusive stdlib needs the `sys.platform` spelling, because mypy narrows
+on it and then declines to check the branch it calls unreachable; this body is
+ordinary and both runs should read it.
+
 The function used to answer *wrongly* on both platforms, for two different
 measured reasons. One was a defect and is fixed; the other was correct and now
 rests on an explicit guard instead of an accident.
@@ -249,6 +261,18 @@ rests on an explicit guard instead of an accident.
   **fixed** — the marker is tested on the path as given, then on the resolved
   path. Resolving still earns its place: a browser reached by an ordinary path
   can be a snap package underneath, and only the resolved form says so.
+
+**The executable path is never `realpath`-resolved before launch, and must not
+be.** `_resolve_browser_executable_path` returns the path as configured or as
+found on `PATH`; only `_is_snap_browser` resolves, and only to answer a question.
+That distinction is load-bearing: `/usr/bin/snap` dispatches on the *name the
+binary was invoked as*, and every `/snap/bin/<app>` is a symlink to it — so
+launching the resolved path starts the snap CLI and prints its help, not
+Chromium. Confirmed on snapd's own forum
+(`forum.snapcraft.io/t/symlinks-and-snap-bin-structure/16532`), where a
+maintainer states the dispatch rule outright. Stated here because the variable
+the launcher reads is called `resolved_browser_executable_path` and this section
+now puts `os.path.realpath` in the reader's mind two hundred lines above it.
 
 E1-6 hit the first of these and repaired the affected test by injecting the
 classification. The path-shape wiring it gave up has since been restored at both
@@ -2063,10 +2087,14 @@ would actually have caught this project's worst gap, and the first draft of this
 section did not have it.
 
 By default coverage.py reports only files it *observed being executed*. A module
-no test ever imports is absent from the report entirely — so
-`scrape/chromium_pool.py`, 372 lines with no test file, would contribute nothing
-and drag nothing down. It would be invisible rather than visibly at zero. Setting
-`source_pkgs` is what makes coverage.py report never-executed files.
+a given run never imports is absent from the report entirely — so
+`scrape/chromium_pool.py`, 372 lines, would contribute nothing and drag nothing
+down under any run that does not reach it. It would be invisible rather than
+visibly at zero. Setting `source_pkgs` is what makes coverage.py report
+never-executed files. (That module is no longer wholly untested — the snap
+DevTools budget of `ChromiumSlot._start` is covered — but the guard's control
+uses a standalone probe script that imports one unrelated module, so the
+observable is unaffected.)
 
 Three configuration files, because the jobs genuinely need different behaviour and
 an earlier draft described settings that were not in the file it displayed:

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -1105,7 +1105,10 @@ duplicating tests or touching the same files.
   than opening a second module over the same coroutine, and note what it
   deliberately leaves — its own docstring lists port selection, profile
   directories, the slot health probe and the pool's queueing, every one of which
-  is this step's.
+  is this step's. **Its two existing cases are unmarked and must stay so**: they
+  are hermetic and belong in the fast lane. Every claim this step adds there
+  needs its own `chromium` or `subsystem` marker, or a step written against a
+  locally installed Chromium quietly acquires cases that run everywhere.
 
 ---
 

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -1097,7 +1097,15 @@ duplicating tests or touching the same files.
   the range is ignored; **a slot released twice is not queued twice** — `release`
   rejects or de-duplicates a slot already in the queue, falsified by releasing one
   slot twice and observing two concurrent acquires hand back the same object.
-  Closes the repo's largest untested module.
+  Closes the repo's largest **still** untested module — one call site left it
+  ahead of this step. `tests/test_chromium_pool_slot_start.py` covers
+  `ChromiumSlot._start`'s snap DevTools budget, both polarities, hermetically:
+  it landed with the snap-detection fix because that fix owed both of the
+  detector's call sites a case. **It belongs to this step now.** Extend it rather
+  than opening a second module over the same coroutine, and note what it
+  deliberately leaves — its own docstring lists port selection, profile
+  directories, the slot health probe and the pool's queueing, every one of which
+  is this step's.
 
 ---
 

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -855,11 +855,15 @@ duplicating tests or touching the same files.
   `_resolve_devtools_ready_timeout_seconds`, `_resolve_worker_timeout_seconds`,
   `_resolve_worker_timeout_details`, `_resolve_snap_backoff_multiplier`,
   `_resolve_chrome_proxy`, `_resolve_chrome_proxy_bypass`, `_split_no_proxy_value`,
-  plus `_is_snap_browser` and `_is_retryable_browser_connect_error`. Those last
-  two were named as component-level targets in §3.1 but claimed by no step —
-  found while implementing E1-2, which declined them rather than absorb work no
-  one had scoped. Nothing checks §3.1's target list against step ownership, so
-  the gap would not have surfaced twice.
+  plus `_is_retryable_browser_connect_error`. That one, and `_is_snap_browser`
+  alongside it, were named as component-level targets in §3.1 but claimed by no
+  step — found while implementing E1-2, which declined them rather than absorb
+  work no one had scoped. Nothing checks §3.1's target list against step
+  ownership, so the gap would not have surfaced twice. **`_is_snap_browser` has
+  since left this step**: the production defect §14 recorded against it was
+  repaired in a change of its own, and that change carried the component cases
+  with it into `tests/test_nodriver_worker_launch_resolvers.py`. Nothing is
+  orphaned by the hand-back — it left with its tests, not without them.
   *Verify:* grouped by behaviour. **Numeric env parsing**
   (`_resolve_retry_backoff_seconds`, `_resolve_devtools_ready_timeout_seconds`,
   `_resolve_worker_timeout_seconds`, `_resolve_snap_backoff_multiplier`): unset,
@@ -870,17 +874,14 @@ duplicating tests or touching the same files.
   (`_detect_chrome_version`, `_resolve_user_agent`):
   a stubbed executable reporting a known version, an executable that fails to run,
   and no executable at all — each returning a usable fallback rather than raising.
-  **Classification** (`_is_snap_browser`, `_is_retryable_browser_connect_error`):
-  each driven by its *input* rather than by an injected answer.
-  `_is_retryable_browser_connect_error` gets one exception of each polarity.
-  `_is_snap_browser` gets the path-shape wiring **E1-6 gave up** — a
-  `/snap/`-shaped path classifies as snap and a `/usr/bin/` one does not — with
-  `os.path.realpath` pinned, since that is this function's only ambient input.
-  **Read §3.1 before writing that case**: this function answers *wrongly* on both
-  platforms, for two different measured reasons, and the obvious first assertion
-  turns E4-2's required cross-platform gate red. Characterise the current answer
-  with the defect named in the docstring; do **not** repair production in a
-  testing step.
+  **Classification** (`_is_retryable_browser_connect_error`): driven by its
+  *input* rather than by an injected answer, with one exception of each polarity.
+  `_is_snap_browser` **is no longer this step's** — the path-shape wiring E1-6
+  gave up was restored by the change that repaired the function, which asserts
+  the corrected answer at component level and at both call sites. Two
+  consequences for whoever writes this step: do not add a second set of cases for
+  it, and do not read §3.1's older instruction to characterise a known-wrong
+  answer as still standing — §3.1 is updated.
   **Composite** (`_resolve_worker_timeout_details`): the returned tuple is
   consistent with the individual resolvers it composes.
   No function in the five groups above is also tested by E5-3 or E1-2, and the
@@ -888,7 +889,8 @@ duplicating tests or touching the same files.
   because E5-4 is scoped by *exclusion*, so a function owned here but named in no
   group is orphaned permanently rather than deferred. **E1-6 handed the
   classification group its one retired claim**, and found the list short by two
-  when it went looking for the owner.
+  when it went looking for the owner; the snap-detection fix has since taken one
+  of those two back, tests included.
 - **E5-5.** `html_to_markdown`, `sanitize_markdown`, `extract_content_as_markdown`,
   `_apply_markdown_cap`, `_build_md_suffix_url` over E3-3's fragments.
   *Verify:* structural assertions (headings preserved, code fences intact, no raw

--- a/src/kindly_web_search_mcp_server/scrape/nodriver_worker.py
+++ b/src/kindly_web_search_mcp_server/scrape/nodriver_worker.py
@@ -368,6 +368,11 @@ def _is_snap_browser(executable_path: str) -> bool:
     # Snap is a Linux packaging format. On Windows a single leading slash is not
     # absolute, so the marker below would match a path that no snap runtime
     # could ever have produced; refuse the whole question there instead.
+    # POSIX rather than Linux deliberately: macOS has no snap either, but it
+    # answered the marker before this guard existed and a misclassification there
+    # only lengthens a timeout, so narrowing it would be a behaviour change made
+    # for tidiness. `os.name`, not `sys.platform`, because the body is ordinary
+    # stdlib and both mypy runs should read it.
     if os.name != "posix":
         return False
     # The marker is tested on the path AS GIVEN first, and that ordering is the

--- a/src/kindly_web_search_mcp_server/scrape/nodriver_worker.py
+++ b/src/kindly_web_search_mcp_server/scrape/nodriver_worker.py
@@ -356,7 +356,11 @@ def _is_snap_browser(executable_path: str) -> bool:
 
     A snap-packaged Chromium is markedly slower to open its DevTools endpoint
     than a distribution-packaged one, so the caller multiplies both the
-    DevTools-ready timeout and the retry backoff for one.
+    DevTools-ready timeout and the retry backoff for one. The marker ``/snap/``
+    is matched anywhere in the path, on the path as supplied and then on its
+    resolved form; the reasoning for the ordering, for the POSIX guard, and for
+    matching a substring rather than a prefix is recorded in
+    ``.system_design/TEST_SUITE.md`` §3.1.
 
     Args:
         executable_path: The browser executable path, as the caller supplied it
@@ -365,25 +369,13 @@ def _is_snap_browser(executable_path: str) -> bool:
     Returns:
         ``True`` when the path identifies a snap-packaged browser.
     """
-    # Snap is a Linux packaging format. On Windows a single leading slash is not
-    # absolute, so the marker below would match a path that no snap runtime
-    # could ever have produced; refuse the whole question there instead.
-    # POSIX rather than Linux deliberately: macOS has no snap either, but it
-    # answered the marker before this guard existed and a misclassification there
-    # only lengthens a timeout, so narrowing it would be a behaviour change made
-    # for tidiness. `os.name`, not `sys.platform`, because the body is ordinary
-    # stdlib and both mypy runs should read it.
+    # No snap runtime exists off POSIX, so no path there may classify as one.
     if os.name != "posix":
         return False
-    # The marker is tested on the path AS GIVEN first, and that ordering is the
-    # point: `/snap/bin/chromium` -- the only way Ubuntu has shipped Chromium
-    # since 19.10 -- is a symlink to `/usr/bin/snap`, so resolving first replaces
-    # the evidence with a target that carries no marker at all.
+    # Before resolving, because the launcher symlink is what destroys the marker.
     if "/snap/" in executable_path:
         return True
-    # Resolving still earns its place: a browser reached by an ordinary path can
-    # be a snap package underneath, and only the resolved form says so. A path
-    # that will not resolve is reported non-snap rather than aborting a launch.
+    # After, because an ordinary path can be a snap package underneath.
     try:
         resolved = os.path.realpath(executable_path)
     except Exception:

--- a/src/kindly_web_search_mcp_server/scrape/nodriver_worker.py
+++ b/src/kindly_web_search_mcp_server/scrape/nodriver_worker.py
@@ -352,11 +352,38 @@ def _is_retryable_browser_connect_error(exc: BaseException) -> bool:
 
 
 def _is_snap_browser(executable_path: str) -> bool:
+    """Report whether a browser executable is snap-packaged.
+
+    A snap-packaged Chromium is markedly slower to open its DevTools endpoint
+    than a distribution-packaged one, so the caller multiplies both the
+    DevTools-ready timeout and the retry backoff for one.
+
+    Args:
+        executable_path: The browser executable path, as the caller supplied it
+            or as the executable resolver produced it.
+
+    Returns:
+        ``True`` when the path identifies a snap-packaged browser.
+    """
+    # Snap is a Linux packaging format. On Windows a single leading slash is not
+    # absolute, so the marker below would match a path that no snap runtime
+    # could ever have produced; refuse the whole question there instead.
+    if os.name != "posix":
+        return False
+    # The marker is tested on the path AS GIVEN first, and that ordering is the
+    # point: `/snap/bin/chromium` -- the only way Ubuntu has shipped Chromium
+    # since 19.10 -- is a symlink to `/usr/bin/snap`, so resolving first replaces
+    # the evidence with a target that carries no marker at all.
+    if "/snap/" in executable_path:
+        return True
+    # Resolving still earns its place: a browser reached by an ordinary path can
+    # be a snap package underneath, and only the resolved form says so. A path
+    # that will not resolve is reported non-snap rather than aborting a launch.
     try:
         resolved = os.path.realpath(executable_path)
     except Exception:
-        resolved = executable_path
-    return resolved.startswith("/snap/") or "/snap/" in resolved
+        return False
+    return "/snap/" in resolved
 
 
 _UA_TEMPLATE = (

--- a/tests/test_chromium_pool_slot_start.py
+++ b/tests/test_chromium_pool_slot_start.py
@@ -23,11 +23,11 @@ helper below.
 
 from __future__ import annotations
 
-import os
 import shutil
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from typing import Any
+from unittest.mock import create_autospec, patch
 
 import pytest
 
@@ -80,12 +80,10 @@ SYSTEM_BROWSER_PATH = "/usr/bin/chromium"
 def pinned_ambient_state(monkeypatch: pytest.MonkeyPatch) -> None:
     """Pin every ambient input these cases do not vary.
 
-    ``os.name`` is pinned because `_is_snap_browser` refuses to classify
-    anything as snap away from POSIX -- snap is a Linux packaging format -- so a
-    case that left it to the host would assert one budget on Linux and the other
-    on Windows. That is not hypothetical: a case elsewhere in this suite did
-    exactly that and went red on the first Windows run this repository ever
-    took. On Linux the pin changes nothing and is applied anyway.
+    The detector's own two ambient inputs are **not** pinned here: they are
+    pinned around its single call, by :func:`_pinned_detector` below, so that
+    nothing else in the slot's startup sees a rewritten ``os.name`` or
+    ``os.path.realpath``.
 
     :func:`shutil.which` is pinned to "nothing installed" although both cases
     set an explicit executable variable and never reach the ``PATH`` probe. A
@@ -107,8 +105,45 @@ def pinned_ambient_state(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(
         "KINDLY_NODRIVER_SNAP_BACKOFF_MULTIPLIER", SNAP_BACKOFF_MULTIPLIER
     )
-    monkeypatch.setattr(os, "name", "posix")
     monkeypatch.setattr(shutil, "which", lambda *_args, **_kwargs: None)
+
+
+def _pinned_detector(realpath_targets: dict[str, str]) -> Any:
+    """Build a `_is_snap_browser` double that runs the **real** one under pinned inputs.
+
+    The classification these cases assert has to be *derived* from the path --
+    that is the wiring they exist to prove -- but both of the detector's ambient
+    inputs answer differently per machine and per platform: ``os.path.realpath``
+    depends on where the developer's Chromium came from, and ``os.name`` decides
+    whether anything may classify as snap at all. Pinning either for the whole
+    slot start would be a process-global reaching well past the subject, and the
+    real :class:`tempfile.TemporaryDirectory` runs inside that window. So the
+    pins are scoped to the detector's own call.
+
+    Autospecced like the other doubles here, so a production change calling the
+    detector with the wrong arity raises rather than being quietly accepted.
+
+    Args:
+        realpath_targets: What ``os.path.realpath`` should answer, by path. A
+            path absent from the mapping resolves to itself, which is what the
+            real call does for an executable that is not a symlink.
+
+    Returns:
+        An autospec double of `_is_snap_browser` returning the real answer.
+    """
+    real_detector = worker._is_snap_browser
+
+    def _realpath(path: str, *_args: object, **_kwargs: object) -> str:
+        return realpath_targets.get(path, path)
+
+    def _classify(executable_path: str) -> bool:
+        with (
+            patch.object(worker.os, "name", "posix"),
+            patch.object(worker.os.path, "realpath", _realpath),
+        ):
+            return real_detector(executable_path)
+
+    return create_autospec(worker._is_snap_browser, side_effect=_classify)
 
 
 async def _devtools_budget_for(
@@ -123,26 +158,27 @@ async def _devtools_budget_for(
     than by doubling the resolver, so the real resolution chain runs and the
     case's subject stays the classification rather than a stand-in for it.
 
+    Four seams are installed, and they are what keeps this a unit test: the port
+    picker would bind a socket, `_launch_chromium` would spawn a real Chromium,
+    `_wait_for_devtools_ready` would speak HTTP to it, and the detector's two
+    ambient inputs would otherwise come from the host. The profile directory is
+    left real and removed again below.
+
     Args:
-        monkeypatch: pytest fixture used to set the executable variable and pin
-            ``os.path.realpath``.
+        monkeypatch: pytest fixture used to set the executable variable.
         executable_path: The browser path the slot should start.
-        realpath_targets: What ``os.path.realpath`` answers, by path. A path
-            absent from the mapping resolves to itself, which is what the real
-            call does for an executable that is not a symlink.
+        realpath_targets: What ``os.path.realpath`` answers inside the detector,
+            by path.
 
     Returns:
         The ``timeout_seconds`` `_wait_for_devtools_ready` was called with.
     """
     monkeypatch.setenv("KINDLY_BROWSER_EXECUTABLE_PATH", executable_path)
 
-    def _realpath(path: str, *_args: object, **_kwargs: object) -> str:
-        return realpath_targets.get(path, path)
-
-    monkeypatch.setattr(os.path, "realpath", _realpath)
-
     slot = chromium_pool.ChromiumSlot(slot_id=0)
+    detector = _pinned_detector(realpath_targets)
     with (
+        patch.object(worker, "_is_snap_browser", detector),
         patch.object(worker, "_launch_chromium", autospec=True),
         patch.object(worker, "_wait_for_devtools_ready", autospec=True) as wait_ready,
         patch.object(chromium_pool, "_pick_port", autospec=True, return_value=9222),
@@ -156,6 +192,9 @@ async def _devtools_budget_for(
                 slot.user_data_dir.cleanup()
                 slot.user_data_dir = None
 
+    # Asked once, and about the path the slot resolved -- not about some default
+    # reached for elsewhere.
+    detector.assert_called_once_with(executable_path)
     return float(wait_ready.call_args.kwargs["timeout_seconds"])
 
 
@@ -170,9 +209,10 @@ async def test_the_snap_launcher_path_lengthens_the_pooled_devtools_budget(
     before testing for the marker threw away the evidence. On the shipped
     defaults that is 12 s where 36 s was intended.
 
-    The classification is **derived from the path**, not injected. Both of its
-    ambient inputs are pinned -- ``os.name`` by the fixture and
-    ``os.path.realpath`` here -- so the case asserts one constant everywhere.
+    The classification is **derived from the path**, not injected: both of the
+    detector's ambient inputs are pinned around its own call, so the case
+    asserts one constant everywhere without rewriting them for the rest of the
+    slot's startup.
 
     Args:
         monkeypatch: pytest fixture used to pin this case's inputs.

--- a/tests/test_chromium_pool_slot_start.py
+++ b/tests/test_chromium_pool_slot_start.py
@@ -123,6 +123,10 @@ def _pinned_detector(realpath_targets: dict[str, str]) -> Any:
     Autospecced like the other doubles here, so a production change calling the
     detector with the wrong arity raises rather than being quietly accepted.
 
+    **`tests/test_nodriver_worker_sandbox.py::make_pinned_detector` is the same
+    nine lines**, for the other call site. Deliberately not shared -- see that
+    one's docstring for why. If you change which inputs are pinned, change both.
+
     Args:
         realpath_targets: What ``os.path.realpath`` should answer, by path. A
             path absent from the mapping resolves to itself, which is what the

--- a/tests/test_chromium_pool_slot_start.py
+++ b/tests/test_chromium_pool_slot_start.py
@@ -1,0 +1,208 @@
+"""Cover the DevTools budget a pooled Chromium slot starts its browser with.
+
+`ChromiumSlot._start` is the browser pool's counterpart to `_fetch_html`: it
+resolves an executable, picks a port, launches Chromium and waits for its
+DevTools endpoint. It shares one decision with `_fetch_html` and owns its own
+copy of it -- a snap-packaged browser is slow to open that endpoint, so its
+timeout is multiplied. The two copies can drift, and a defect in the shared
+detector reached both of them, so the budget is asserted at each call site
+rather than at one and inferred at the other.
+
+Only the budget is asserted here. Port selection, profile directories, the slot
+health probe and the pool's queueing belong to whoever tests the pool as a
+whole; this module exists because the snap allowance had no test at this call
+site at all.
+
+Nothing here starts a browser, opens a socket or reaches the network: the three
+collaborators that would (`_launch_chromium`, `_wait_for_devtools_ready` and the
+port picker) are replaced with autospec doubles, so a call with the wrong arity
+raises inside the code under test instead of being silently recorded. The real
+:class:`tempfile.TemporaryDirectory` still runs and is removed again by the
+helper below.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from kindly_web_search_mcp_server.scrape import chromium_pool
+from kindly_web_search_mcp_server.scrape import nodriver_worker as worker
+
+#: Every environment variable `ChromiumSlot._start` reads, directly or through
+#: the worker helpers it calls. Removed before each case so a case declares the
+#: whole of its own input: four of them are browser paths that CI images and
+#: developers commonly export, and any one would steer the executable resolver
+#: away from the path the case is about.
+READ_ENVIRONMENT_VARIABLES = (
+    "KINDLY_BROWSER_EXECUTABLE_PATH",
+    "BROWSER_EXECUTABLE_PATH",
+    "CHROME_BIN",
+    "CHROME_PATH",
+    "KINDLY_NODRIVER_SANDBOX",
+    "KINDLY_NODRIVER_DEVTOOLS_READY_TIMEOUT_SECONDS",
+    "KINDLY_NODRIVER_SNAP_BACKOFF_MULTIPLIER",
+    "KINDLY_CHROME_PROXY",
+    "KINDLY_CHROME_PROXY_BYPASS",
+)
+
+#: The base DevTools budget these cases configure, and the multiplier a snap
+#: browser earns. Two distinct values, so a production change that read the
+#: multiplier where it meant the base -- or the reverse -- cannot land on the
+#: expected number by coincidence.
+DEVTOOLS_READY_TIMEOUT_SECONDS = "4"
+SNAP_BACKOFF_MULTIPLIER = "3"
+
+#: The launcher a stock Ubuntu install provides. It is a symlink to
+#: ``/usr/bin/snap`` -- the snap runtime, not a browser -- which is why resolving
+#: it before testing for the ``/snap/`` marker used to classify the commonest
+#: snap Chromium as an ordinary one. Measured on Ubuntu 24.04.4.
+SNAP_LAUNCHER_PATH = "/snap/bin/chromium"
+
+#: What ``os.path.realpath`` returns for :data:`SNAP_LAUNCHER_PATH`, pinned
+#: rather than looked up so the case answers the same on a machine with no snap
+#: installed.
+SNAP_LAUNCHER_TARGET = "/usr/bin/snap"
+
+#: An ordinary distribution-packaged browser: no marker, and it resolves to
+#: itself.
+SYSTEM_BROWSER_PATH = "/usr/bin/chromium"
+
+
+@pytest.fixture(autouse=True)
+def pinned_ambient_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin every ambient input these cases do not vary.
+
+    ``os.name`` is pinned because `_is_snap_browser` refuses to classify
+    anything as snap away from POSIX -- snap is a Linux packaging format -- so a
+    case that left it to the host would assert one budget on Linux and the other
+    on Windows. That is not hypothetical: a case elsewhere in this suite did
+    exactly that and went red on the first Windows run this repository ever
+    took. On Linux the pin changes nothing and is applied anyway.
+
+    :func:`shutil.which` is pinned to "nothing installed" although both cases
+    set an explicit executable variable and never reach the ``PATH`` probe. A
+    case that leaves the real lookup in place is one whose result depends on
+    whether the developer has Chromium installed, and it would start depending
+    on it the day the resolver consults ``PATH`` first.
+
+    Args:
+        monkeypatch: pytest fixture that scopes and reverses the changes.
+    """
+    for name in READ_ENVIRONMENT_VARIABLES:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv(
+        "KINDLY_NODRIVER_DEVTOOLS_READY_TIMEOUT_SECONDS", DEVTOOLS_READY_TIMEOUT_SECONDS
+    )
+    # Configured in both cases, deliberately: the non-snap case must leave the
+    # budget alone because the browser is not snap, not because no multiplier
+    # was set.
+    monkeypatch.setenv(
+        "KINDLY_NODRIVER_SNAP_BACKOFF_MULTIPLIER", SNAP_BACKOFF_MULTIPLIER
+    )
+    monkeypatch.setattr(os, "name", "posix")
+    monkeypatch.setattr(shutil, "which", lambda *_args, **_kwargs: None)
+
+
+async def _devtools_budget_for(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    executable_path: str,
+    realpath_targets: dict[str, str],
+) -> float:
+    """Start one pooled slot and report the DevTools budget it waited with.
+
+    The executable is supplied through ``KINDLY_BROWSER_EXECUTABLE_PATH`` rather
+    than by doubling the resolver, so the real resolution chain runs and the
+    case's subject stays the classification rather than a stand-in for it.
+
+    Args:
+        monkeypatch: pytest fixture used to set the executable variable and pin
+            ``os.path.realpath``.
+        executable_path: The browser path the slot should start.
+        realpath_targets: What ``os.path.realpath`` answers, by path. A path
+            absent from the mapping resolves to itself, which is what the real
+            call does for an executable that is not a symlink.
+
+    Returns:
+        The ``timeout_seconds`` `_wait_for_devtools_ready` was called with.
+    """
+    monkeypatch.setenv("KINDLY_BROWSER_EXECUTABLE_PATH", executable_path)
+
+    def _realpath(path: str, *_args: object, **_kwargs: object) -> str:
+        return realpath_targets.get(path, path)
+
+    monkeypatch.setattr(os.path, "realpath", _realpath)
+
+    slot = chromium_pool.ChromiumSlot(slot_id=0)
+    with (
+        patch.object(worker, "_launch_chromium", autospec=True),
+        patch.object(worker, "_wait_for_devtools_ready", autospec=True) as wait_ready,
+        patch.object(chromium_pool, "_pick_port", autospec=True, return_value=9222),
+    ):
+        try:
+            await slot._start(user_agent="kindly-test-agent", port_range=None, diagnostics=None)
+        finally:
+            # `_start` creates a real profile directory; the slot's own teardown
+            # would also kill a process that was never launched here.
+            if slot.user_data_dir is not None:
+                slot.user_data_dir.cleanup()
+                slot.user_data_dir = None
+
+    return float(wait_ready.call_args.kwargs["timeout_seconds"])
+
+
+async def test_the_snap_launcher_path_lengthens_the_pooled_devtools_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Multiply the pooled DevTools budget for the Ubuntu snap launcher
+
+    A snap Chromium is the browser that most needs the longer budget, and until
+    the detector was repaired it was the one browser certain never to get it:
+    ``/snap/bin/chromium`` is a symlink to ``/usr/bin/snap``, and resolving it
+    before testing for the marker threw away the evidence. On the shipped
+    defaults that is 12 s where 36 s was intended.
+
+    The classification is **derived from the path**, not injected. Both of its
+    ambient inputs are pinned -- ``os.name`` by the fixture and
+    ``os.path.realpath`` here -- so the case asserts one constant everywhere.
+
+    Args:
+        monkeypatch: pytest fixture used to pin this case's inputs.
+    """
+    budget = await _devtools_budget_for(
+        monkeypatch,
+        executable_path=SNAP_LAUNCHER_PATH,
+        realpath_targets={SNAP_LAUNCHER_PATH: SNAP_LAUNCHER_TARGET},
+    )
+
+    assert budget == 12.0
+
+
+async def test_a_system_browser_path_leaves_the_pooled_devtools_budget_alone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Leave the pooled DevTools budget unmultiplied for a system browser
+
+    The negative polarity, and it is load-bearing rather than symmetric: a
+    ``_start`` that multiplied unconditionally would satisfy the case above on
+    its own. Nothing in this repository asserted this branch before -- the pool
+    had no test module -- so the mutation that deletes its ``if`` was live.
+
+    Args:
+        monkeypatch: pytest fixture used to pin this case's inputs.
+    """
+    budget = await _devtools_budget_for(
+        monkeypatch,
+        executable_path=SYSTEM_BROWSER_PATH,
+        realpath_targets={},
+    )
+
+    assert budget == 4.0

--- a/tests/test_coverage_configuration.py
+++ b/tests/test_coverage_configuration.py
@@ -215,9 +215,18 @@ INHERITED_COVERAGE_STARTUP_VARIABLES = (
 PROBE_MODULE = f"{PACKAGE}.utils.logging"
 PROBE_REPORT_PATH = f"src/{PACKAGE}/utils/logging.py"
 
-# The module with no test file anywhere -- 213 statements, and the concrete gap
-# that made control 1 necessary. It is the observable for both the whole-package
-# claim and the exemption claim.
+# The module that made control 1 necessary -- 213 statements, and the observable
+# for both the whole-package claim and the exemption claim.
+#
+# It was chosen when nothing in the suite referenced it at all. That is no longer
+# true: `tests/test_chromium_pool_slot_start.py` imports it and drives
+# `ChromiumSlot._start`. The choice still holds, and for a reason that does not
+# depend on the module staying untested: control 1 runs a **standalone probe
+# script** that imports one unrelated module, so nothing this suite does reaches
+# this file inside that probe. What the module has to be is unimported *by the
+# probe*, not unimported by the repository -- stated here because the original
+# phrasing said the latter and would have gone quietly false without any test
+# noticing.
 UNEXECUTED_REPORT_PATH = f"src/{PACKAGE}/scrape/chromium_pool.py"
 
 # The opening of coverage.py's warning for an option it does not know. Spelled
@@ -803,9 +812,11 @@ def test_the_base_configuration_reports_an_unexecuted_module_at_zero(
 
     This is control 1, and the one observable that proves ``source_pkgs`` is
     doing its job. Under coverage.py's defaults the report contains only files
-    that were observed executing, so ``chromium_pool.py`` -- which no test
-    imports -- would be absent from the report rather than visibly uncovered,
-    and would drag nothing down.
+    that were observed executing, so ``chromium_pool.py`` -- which the probe
+    script below never imports -- would be absent from the report rather than
+    visibly uncovered, and would drag nothing down. See
+    :data:`UNEXECUTED_REPORT_PATH` for why "the probe never imports it" is the
+    property that matters here, and not "no test imports it".
 
     ``num_statements`` is asserted alongside the zero because a module reported
     with no statements at all would satisfy ``covered_lines == 0`` while proving

--- a/tests/test_nodriver_worker_launch_resolvers.py
+++ b/tests/test_nodriver_worker_launch_resolvers.py
@@ -861,6 +861,42 @@ def test_no_path_is_classified_as_snap_away_from_posix(
     assert _is_snap_browser(UBUNTU_SNAP_LAUNCHER) is False
 
 
+def test_a_snap_path_is_still_classified_as_snap_when_it_cannot_be_resolved(
+    posix_platform: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Answer from the path alone when ``realpath`` fails on a ``/snap/`` path
+
+    The ordering case. The marker is tested on the path as given **before** the
+    resolver is called, and this is the only case that can tell that ordering
+    from the tidier-looking arrangement a future reader will reach for:
+
+    .. code-block:: python
+
+        try:
+            resolved = os.path.realpath(executable_path)
+        except Exception:
+            return False
+        return "/snap/" in executable_path or "/snap/" in resolved
+
+    That version satisfies every other case in this module and at both call
+    sites, and answers ``False`` here -- where the shipped function and the
+    repaired one both answer ``True``. It is a live, non-equivalent mutation of
+    the one property this repair exists to establish, so it gets a case rather
+    than a comment.
+
+    Args:
+        posix_platform: fixture pinning ``os.name``.
+        monkeypatch: pytest fixture used to make ``os.path.realpath`` fail.
+    """
+    def _raising(_path: str, *_args: object, **_kwargs: object) -> str:
+        raise OSError("filesystem is unavailable")
+
+    monkeypatch.setattr(os.path, "realpath", _raising)
+
+    assert _is_snap_browser(UBUNTU_SNAP_LAUNCHER) is True
+
+
 def test_a_path_that_cannot_be_resolved_is_not_classified_as_snap(
     posix_platform: None,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_nodriver_worker_launch_resolvers.py
+++ b/tests/test_nodriver_worker_launch_resolvers.py
@@ -699,6 +699,19 @@ UBUNTU_SNAP_LAUNCHER_TARGET = "/usr/bin/snap"
 #: An ordinary system browser: no marker in the path, and it resolves to itself.
 SYSTEM_BROWSER = "/usr/bin/chromium"
 
+#: The same launcher on a distribution that is **not** Ubuntu. snapd mounts snaps
+#: under ``/var/lib/snapd/snap`` and puts ``/var/lib/snapd/snap/bin`` on ``PATH``;
+#: ``/snap`` exists there only if an administrator creates the symlink by hand,
+#: which classic confinement requires and nothing else does (ArchWiki, *Snap*).
+#:
+#: It is here because it is the only shape that distinguishes the marker rule the
+#: detector implements -- ``"/snap/" in path`` -- from the ``startswith("/snap/")``
+#: the shipped function used and that a later reader will be tempted to restore.
+#: Every other path in this module carries the marker at position 0, so without
+#: this constant that mutation survives the whole suite while quietly denying the
+#: snap allowance to every snap browser on Fedora, Arch and Debian.
+SNAPD_MOUNT_LAUNCHER = "/var/lib/snapd/snap/bin/chromium"
+
 
 def _realpath_returning(targets: dict[str, str]) -> Callable[..., str]:
     """Build an :func:`os.path.realpath` stand-in with a fixed answer table.
@@ -784,6 +797,37 @@ def test_a_snap_path_with_nothing_to_resolve_is_classified_as_snap(
     assert _is_snap_browser("/snap/bin/chromium-for-tests") is True
 
 
+def test_a_launcher_under_the_snapd_mount_point_is_classified_as_snap(
+    posix_platform: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Classify the same launcher as snap where snapd mounts outside ``/snap``
+
+    The case above is the Ubuntu shape, where the marker happens to sit at the
+    start of the path. Off Ubuntu it does not: snapd mounts under
+    ``/var/lib/snapd/snap`` and ``/snap`` is a hand-made symlink that only
+    classic confinement needs. The launcher is a symlink to ``/usr/bin/snap``
+    there too, so the same defect applies -- and the same repair, only if the
+    marker is matched anywhere in the path rather than at its start.
+
+    Without this case ``"/snap/" in executable_path`` can be narrowed to
+    ``executable_path.startswith("/snap/")`` -- the spelling the shipped function
+    used -- with the whole suite still green, reintroducing this bug for every
+    snap browser on Fedora, Arch and Debian. Measured.
+
+    Args:
+        posix_platform: fixture pinning ``os.name``.
+        monkeypatch: pytest fixture used to pin ``os.path.realpath``.
+    """
+    monkeypatch.setattr(
+        os.path,
+        "realpath",
+        _realpath_returning({SNAPD_MOUNT_LAUNCHER: UBUNTU_SNAP_LAUNCHER_TARGET}),
+    )
+
+    assert _is_snap_browser(SNAPD_MOUNT_LAUNCHER) is True
+
+
 def test_a_browser_resolving_into_the_snap_tree_is_classified_as_snap(
     posix_platform: None,
     monkeypatch: pytest.MonkeyPatch,
@@ -795,6 +839,13 @@ def test_a_browser_resolving_into_the_snap_tree_is_classified_as_snap(
     Deleting the resolved-path test to keep the given-path one would fix the
     defect above and open this hole in its place, so both halves are asserted.
 
+    The target deliberately carries the marker **mid-path**, under snapd's own
+    mount point rather than under ``/snap``. It is the more representative real
+    answer off Ubuntu, and it is what stops ``"/snap/" in resolved`` being
+    narrowed back to ``resolved.startswith("/snap/")`` -- the spelling the shipped
+    function used, which survives every prefix-shaped case. See
+    :data:`SNAPD_MOUNT_LAUNCHER`.
+
     Args:
         posix_platform: fixture pinning ``os.name``.
         monkeypatch: pytest fixture used to pin ``os.path.realpath``.
@@ -803,7 +854,7 @@ def test_a_browser_resolving_into_the_snap_tree_is_classified_as_snap(
         os.path,
         "realpath",
         _realpath_returning(
-            {SYSTEM_BROWSER: "/snap/chromium/2917/usr/lib/chromium/chrome"}
+            {SYSTEM_BROWSER: "/var/lib/snapd/snap/chromium/2917/usr/lib/chromium/chrome"}
         ),
     )
 
@@ -846,6 +897,13 @@ def test_no_path_is_classified_as_snap_away_from_posix(
     now rests on an explicit guard instead. The realpath pin below reproduces the
     measured Windows answer, so the case fails for the right reason when the
     guard is deleted rather than passing for the old one.
+
+    **One equivalent mutant, triaged here rather than chased.** Rewriting the
+    guard as ``if os.name == "nt": return False`` survives this case and the whole
+    suite. It is equivalent on any interpreter that can run this package:
+    CPython sets ``os.name`` to ``"posix"`` or ``"nt"`` and to nothing else, so
+    the two spellings partition the same inputs. Measured. No test should be
+    written for it.
 
     Args:
         monkeypatch: pytest fixture used to pin ``os.name`` and
@@ -897,27 +955,50 @@ def test_a_snap_path_is_still_classified_as_snap_when_it_cannot_be_resolved(
     assert _is_snap_browser(UBUNTU_SNAP_LAUNCHER) is True
 
 
+@pytest.mark.parametrize(
+    "failure",
+    [
+        pytest.param(OSError("filesystem is unavailable"), id="filesystem-error"),
+        pytest.param(
+            ValueError("embedded null character in path"), id="embedded-null"
+        ),
+    ],
+)
 def test_a_path_that_cannot_be_resolved_is_not_classified_as_snap(
     posix_platform: None,
     monkeypatch: pytest.MonkeyPatch,
+    failure: Exception,
 ) -> None:
     """Report a browser whose path will not resolve as non-snap rather than raising
 
-    ``realpath`` can fail -- an embedded null raises :class:`ValueError`, and a
-    filesystem error raises :class:`OSError`. A classification is not worth
-    aborting a browser launch over, so the failure answers ``False``.
+    ``realpath`` can fail two ways, and both are driven here rather than named
+    and left: a filesystem error raises :class:`OSError`, and an embedded null
+    raises :class:`ValueError` (measured --
+    ``os.path.realpath("/usr/bin/chromium\x00")`` reports *lstat: embedded null
+    character in path*). A classification is not worth aborting a browser launch
+    over, so either failure answers ``False``.
+
+    Driving both is what keeps the ``except Exception:`` clause honest. Narrowing
+    it to ``except OSError:`` -- which this repository's own ``ruff`` run
+    actively suggests, reporting ``BLE001`` on that very line -- survives an
+    ``OSError``-only case and turns the null path into an uncaught raise out of a
+    browser launch. Neither failure is reachable from production input today
+    (the path comes from the environment or from `shutil.which`, and neither can
+    carry a null), which is why this is a parametrized pair rather than a wider
+    harness.
 
     The input carries no marker of its own, deliberately: a ``/snap/`` path never
     reaches the resolver at all, so a case using one would pass whatever the
     ``except`` branch did and could not tell ``return False`` from ``return
-    True``.
+    True``. The case above pins that ordering separately.
 
     Args:
         posix_platform: fixture pinning ``os.name``.
         monkeypatch: pytest fixture used to make ``os.path.realpath`` fail.
+        failure: The exception ``os.path.realpath`` raises for this row.
     """
     def _raising(_path: str, *_args: object, **_kwargs: object) -> str:
-        raise OSError("filesystem is unavailable")
+        raise failure
 
     monkeypatch.setattr(os.path, "realpath", _raising)
 

--- a/tests/test_nodriver_worker_launch_resolvers.py
+++ b/tests/test_nodriver_worker_launch_resolvers.py
@@ -36,6 +36,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from kindly_web_search_mcp_server.scrape.nodriver_worker import (
     _build_chromium_launch_args,
+    _is_snap_browser,
     _resolve_browser_executable_path,
     _resolve_sandbox_enabled,
     _resolve_start_retry_attempts,
@@ -676,3 +677,212 @@ def test_a_base_argument_already_present_is_not_repeated() -> None:
 
     assert args.count("--disable-logging") == 1
     assert args[-1] == "--custom-flag"
+
+
+# --------------------------------------------------------------------------
+# _is_snap_browser
+# --------------------------------------------------------------------------
+
+#: The launcher a stock Ubuntu install puts on ``PATH``. It is a **symlink to**
+#: ``/usr/bin/snap`` -- the snap runtime, not the browser -- which is what makes
+#: this the case worth writing: resolving the path first replaces the only
+#: evidence that the browser is snap-packaged with a target that carries no
+#: marker at all. Measured on Ubuntu 24.04.4:
+#: ``lrwxrwxrwx /snap/bin/chromium -> /usr/bin/snap``.
+UBUNTU_SNAP_LAUNCHER = "/snap/bin/chromium"
+
+#: What :func:`os.path.realpath` returns for :data:`UBUNTU_SNAP_LAUNCHER`. Pinned
+#: rather than derived so the case answers the same on a machine with no snap
+#: installed, and on Windows, where ``realpath`` gives a third answer again.
+UBUNTU_SNAP_LAUNCHER_TARGET = "/usr/bin/snap"
+
+#: An ordinary system browser: no marker in the path, and it resolves to itself.
+SYSTEM_BROWSER = "/usr/bin/chromium"
+
+
+def _realpath_returning(targets: dict[str, str]) -> Callable[..., str]:
+    """Build an :func:`os.path.realpath` stand-in with a fixed answer table.
+
+    Args:
+        targets: Mapping from a path to what ``realpath`` should return for it.
+            A path absent from the mapping resolves to itself, which is what the
+            real call does for a path that is not a symlink.
+
+    Returns:
+        A callable with :func:`os.path.realpath`'s single-argument shape.
+    """
+    def _realpath(path: str, *_args: object, **_kwargs: object) -> str:
+        return targets.get(path, path)
+
+    return _realpath
+
+
+@pytest.fixture
+def posix_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin ``os.name`` to ``"posix"`` for the duration of one case.
+
+    `_is_snap_browser` has exactly two ambient inputs, and this is the second
+    one: snap is a Linux packaging format, so the function answers ``False`` for
+    every path where ``os.name`` is not ``"posix"``. A case that leaves it to the
+    host asserts one thing on Linux and its opposite on Windows -- which is the
+    failure the cross-platform milestone actually hit, in a case that derived a
+    snap classification from a path shape and expected a constant.
+
+    On Linux this pin is a no-op and is applied anyway, because a pin that only
+    exists where it changes nothing is a pin nobody notices has gone missing.
+
+    Args:
+        monkeypatch: pytest fixture that scopes and reverses the change.
+    """
+    monkeypatch.setattr(os, "name", "posix")
+
+
+def test_the_ubuntu_snap_launcher_is_classified_as_snap(
+    posix_platform: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Classify ``/snap/bin/chromium`` as snap even though it resolves elsewhere
+
+    This is the regression case. The shipped function resolved the path before
+    testing it, so the single commonest way to have a snap Chromium -- the only
+    way Ubuntu has offered since 19.10 -- classified as **non**-snap and was
+    denied the longer DevTools budget the multiplier exists to give it.
+
+    A browser invoked as ``/snap/bin/chromium`` is a snap browser whatever the
+    launcher symlink points at, so the marker is tested on the path as given.
+
+    Args:
+        posix_platform: fixture pinning ``os.name``.
+        monkeypatch: pytest fixture used to pin ``os.path.realpath``.
+    """
+    monkeypatch.setattr(
+        os.path,
+        "realpath",
+        _realpath_returning({UBUNTU_SNAP_LAUNCHER: UBUNTU_SNAP_LAUNCHER_TARGET}),
+    )
+
+    assert _is_snap_browser(UBUNTU_SNAP_LAUNCHER) is True
+
+
+def test_a_snap_path_with_nothing_to_resolve_is_classified_as_snap(
+    posix_platform: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Classify a ``/snap/`` path that is not a symlink as snap
+
+    The shape the shipped function got right, kept under test because it is the
+    shape every existing test in the tree uses to reach the snap branch: a path
+    under ``/snap/`` that does not exist has no symlink for ``realpath`` to
+    follow, so both the given and the resolved form carry the marker.
+
+    Args:
+        posix_platform: fixture pinning ``os.name``.
+        monkeypatch: pytest fixture used to pin ``os.path.realpath``.
+    """
+    monkeypatch.setattr(os.path, "realpath", _realpath_returning({}))
+
+    assert _is_snap_browser("/snap/bin/chromium-for-tests") is True
+
+
+def test_a_browser_resolving_into_the_snap_tree_is_classified_as_snap(
+    posix_platform: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Classify a marker-free path that resolves into ``/snap/`` as snap
+
+    Resolving is still done, and this is why: a browser reached by an ordinary
+    path can be a snap package underneath, and only the resolved form says so.
+    Deleting the resolved-path test to keep the given-path one would fix the
+    defect above and open this hole in its place, so both halves are asserted.
+
+    Args:
+        posix_platform: fixture pinning ``os.name``.
+        monkeypatch: pytest fixture used to pin ``os.path.realpath``.
+    """
+    monkeypatch.setattr(
+        os.path,
+        "realpath",
+        _realpath_returning(
+            {SYSTEM_BROWSER: "/snap/chromium/2917/usr/lib/chromium/chrome"}
+        ),
+    )
+
+    assert _is_snap_browser(SYSTEM_BROWSER) is True
+
+
+def test_an_ordinary_system_browser_is_not_classified_as_snap(
+    posix_platform: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Leave a distribution-packaged browser unclassified, so it keeps the plain budget
+
+    The negative polarity of the classification. Without it, a function that
+    returned ``True`` unconditionally would satisfy every case above, and the
+    snap multiplier would silently apply to every browser on the machine.
+
+    Args:
+        posix_platform: fixture pinning ``os.name``.
+        monkeypatch: pytest fixture used to pin ``os.path.realpath``.
+    """
+    monkeypatch.setattr(os.path, "realpath", _realpath_returning({}))
+
+    assert _is_snap_browser(SYSTEM_BROWSER) is False
+
+
+def test_no_path_is_classified_as_snap_away_from_posix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    r"""Answer ``False`` for every path where ``os.name`` is not ``"posix"``
+
+    Snap is a Linux packaging format and no Windows machine has one, so this is
+    the correct answer rather than a limitation. It used to fall out of an
+    accident: a path with a single leading slash is not absolute on Windows, so
+    ``realpath`` joins it against the current drive and normalises the
+    separators -- ``/snap/bin/chromium`` becomes ``D:\snap\bin\chromium`` and the
+    marker is erased. Measured against the shipped function on a
+    ``windows-latest`` runner, where the drive happened to be ``D:``.
+
+    Testing the path **as given** is what removes that accident, so the answer
+    now rests on an explicit guard instead. The realpath pin below reproduces the
+    measured Windows answer, so the case fails for the right reason when the
+    guard is deleted rather than passing for the old one.
+
+    Args:
+        monkeypatch: pytest fixture used to pin ``os.name`` and
+            ``os.path.realpath``.
+    """
+    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.setattr(
+        os.path,
+        "realpath",
+        _realpath_returning({UBUNTU_SNAP_LAUNCHER: r"D:\snap\bin\chromium"}),
+    )
+
+    assert _is_snap_browser(UBUNTU_SNAP_LAUNCHER) is False
+
+
+def test_a_path_that_cannot_be_resolved_is_not_classified_as_snap(
+    posix_platform: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Report a browser whose path will not resolve as non-snap rather than raising
+
+    ``realpath`` can fail -- an embedded null raises :class:`ValueError`, and a
+    filesystem error raises :class:`OSError`. A classification is not worth
+    aborting a browser launch over, so the failure answers ``False``.
+
+    The input carries no marker of its own, deliberately: a ``/snap/`` path never
+    reaches the resolver at all, so a case using one would pass whatever the
+    ``except`` branch did and could not tell ``return False`` from ``return
+    True``.
+
+    Args:
+        posix_platform: fixture pinning ``os.name``.
+        monkeypatch: pytest fixture used to make ``os.path.realpath`` fail.
+    """
+    def _raising(_path: str, *_args: object, **_kwargs: object) -> str:
+        raise OSError("filesystem is unavailable")
+
+    monkeypatch.setattr(os.path, "realpath", _raising)
+
+    assert _is_snap_browser(SYSTEM_BROWSER) is False

--- a/tests/test_nodriver_worker_sandbox.py
+++ b/tests/test_nodriver_worker_sandbox.py
@@ -199,26 +199,49 @@ class StubChromiumProcess:
         return f"<StubChromiumProcess pid={self.pid}>"
 
 
-def _realpath_returning(targets: dict[str, str]) -> Any:
-    """Build an :func:`os.path.realpath` stand-in with a fixed answer table.
+def make_pinned_detector(realpath_targets: dict[str, str]) -> Any:
+    """Build a `_is_snap_browser` double that runs the **real** one under pinned inputs.
 
-    `_is_snap_browser` reads ``os.path.realpath``, whose answer depends on the
-    platform and on where the developer's Chromium came from. The two cases that
-    derive a snap classification from a path pin it through this helper so they
-    assert the same constant everywhere.
+    The two cases that derive a snap classification from a path need the real
+    derivation -- that is the wiring they exist to assert -- but both of the
+    detector's ambient inputs answer differently per machine and per platform:
+    ``os.path.realpath`` depends on where the developer's Chromium came from,
+    and ``os.name`` decides whether anything may classify as snap at all.
+
+    Pinning either one for the whole `_fetch_html` call would be a process-global
+    reaching far past the code under test, and ``os.name`` in particular is read
+    by three other things inside that call. So the pins are scoped to the
+    detector's own invocation instead: outside this one call, the run sees the
+    real values. That is a narrower seam than injecting an answer, which is what
+    the cross-platform milestone had to settle for, and it gives up none of the
+    wiring.
+
+    The double is built with :func:`create_autospec` like every other double in
+    this module, so production calling the detector with the wrong arity raises
+    rather than being quietly accepted, and the case can assert which path it was
+    asked about.
 
     Args:
-        targets: Mapping from a path to what ``realpath`` should return for it.
-            A path absent from the mapping resolves to itself, which is what the
+        realpath_targets: What ``os.path.realpath`` should answer, by path. A
+            path absent from the mapping resolves to itself, which is what the
             real call does for an executable that is not a symlink.
 
     Returns:
-        A callable with :func:`os.path.realpath`'s single-argument shape.
+        An autospec double of `_is_snap_browser` returning the real answer.
     """
-    def _realpath(path: str, *_args: object, **_kwargs: object) -> str:
-        return targets.get(path, path)
+    real_detector = nodriver_worker._is_snap_browser
 
-    return _realpath
+    def _realpath(path: str, *_args: object, **_kwargs: object) -> str:
+        return realpath_targets.get(path, path)
+
+    def _classify(executable_path: str) -> bool:
+        with (
+            patch.object(nodriver_worker.os, "name", "posix"),
+            patch.object(nodriver_worker.os.path, "realpath", _realpath),
+        ):
+            return real_detector(executable_path)
+
+    return create_autospec(nodriver_worker._is_snap_browser, side_effect=_classify)
 
 
 def make_browser_double(
@@ -714,9 +737,12 @@ class TestNodriverWorkerSandbox(unittest.IsolatedAsyncioTestCase):
         Production is right and is left alone: snap is a Linux packaging format
         and does not exist on Windows.
 
-        What the seam gives up is the wiring from a *path shape* to the answer,
-        which belongs to plan step E5-4, the resolver step that owns
-        `_is_snap_browser` outright.
+        What the seam gives up is the wiring from a *path shape* to the answer.
+        That wiring has since been restored, in the two cases below this pair
+        that derive the classification instead of injecting it -- so this
+        paragraph records what the seam costs, not a gap that is still open.
+        `_is_snap_browser` is no longer plan step E5-4's; it left that step with
+        its tests when the Ubuntu misclassification was repaired.
         What it keeps is the wiring that matters to the backoff, asserted below:
         that the detector is consulted at all, that it is asked about the
         executable path the caller supplied, and that its answer is what selects
@@ -848,17 +874,20 @@ class TestNodriverWorkerSandbox(unittest.IsolatedAsyncioTestCase):
         36 s was intended, and a content fetch that fails on a machine which
         would otherwise have worked.
 
-        **Two process globals are pinned here, and both are ambient inputs of the
-        function under test rather than conveniences.** `_is_snap_browser` reads
-        ``os.path.realpath`` -- whose answer depends on what the developer's
-        Chromium is, and on the platform -- and ``os.name``, because snap is a
-        Linux packaging format and nothing classifies as snap elsewhere. Pinning
-        both is what lets this case assert one constant on every platform. The
-        alternative, a platform-gated skip, is the skew the baseline ledger
-        exists to keep out; the alternative of leaving them ambient is exactly
-        how a case here once asserted the multiplied series on Linux and failed
-        on Windows.
+        **The detector's two ambient inputs are pinned, and only for the length of
+        its own call.** ``os.path.realpath`` answers differently depending on
+        what the developer's Chromium is; ``os.name`` decides whether anything
+        may classify as snap at all. Pinning either for the whole `_fetch_html`
+        call would be a process-global reaching well past the subject -- three
+        other things inside that call read ``os.name`` -- so
+        :func:`make_pinned_detector` scopes both to the detector invocation.
+        Leaving them ambient instead is exactly how a case in this module once
+        asserted the multiplied series on Linux and failed on Windows, and the
+        remaining alternative, a platform-gated skip, is the skew the baseline
+        ledger exists to keep out.
         """
+        detector = make_pinned_detector({SNAP_LAUNCHER_PATH: SNAP_LAUNCHER_TARGET})
+
         with (
             orchestration_harness(
                 environment={
@@ -866,15 +895,13 @@ class TestNodriverWorkerSandbox(unittest.IsolatedAsyncioTestCase):
                     "KINDLY_NODRIVER_SNAP_BACKOFF_MULTIPLIER": "3",
                 }
             ) as doubles,
-            patch.object(nodriver_worker.os, "name", "posix"),
-            patch.object(
-                nodriver_worker.os.path,
-                "realpath",
-                _realpath_returning({SNAP_LAUNCHER_PATH: SNAP_LAUNCHER_TARGET}),
-            ),
+            patch.object(nodriver_worker, "_is_snap_browser", detector),
         ):
             await fetch_html(browser_executable_path=SNAP_LAUNCHER_PATH)
 
+        # Asked once, and about the path the caller gave -- not about some
+        # default the resolver reached for.
+        detector.assert_called_once_with(SNAP_LAUNCHER_PATH)
         # 4 * 3. Two distinct values, so a production change reading the
         # multiplier where it means the base -- or the reverse -- cannot land on
         # the same number by coincidence.
@@ -891,10 +918,12 @@ class TestNodriverWorkerSandbox(unittest.IsolatedAsyncioTestCase):
         is configured here and must be ignored because the browser is not snap,
         not because none was set.
 
-        The same two globals are pinned, and ``realpath`` answers with the path
-        itself -- the way a real lookup answers for an executable that is not a
-        symlink.
+        The detector is pinned the same way, with ``realpath`` answering with the
+        path itself -- the way a real lookup answers for an executable that is
+        not a symlink.
         """
+        detector = make_pinned_detector({})
+
         with (
             orchestration_harness(
                 environment={
@@ -902,13 +931,11 @@ class TestNodriverWorkerSandbox(unittest.IsolatedAsyncioTestCase):
                     "KINDLY_NODRIVER_SNAP_BACKOFF_MULTIPLIER": "3",
                 }
             ) as doubles,
-            patch.object(nodriver_worker.os, "name", "posix"),
-            patch.object(
-                nodriver_worker.os.path, "realpath", _realpath_returning({})
-            ),
+            patch.object(nodriver_worker, "_is_snap_browser", detector),
         ):
             await fetch_html(browser_executable_path=BROWSER_PATH)
 
+        detector.assert_called_once_with(BROWSER_PATH)
         self.assertEqual(doubles.wait_ready.call_args.kwargs["timeout_seconds"], 4.0)
 
     async def test_does_not_retry_a_non_retryable_error(self) -> None:

--- a/tests/test_nodriver_worker_sandbox.py
+++ b/tests/test_nodriver_worker_sandbox.py
@@ -106,27 +106,41 @@ READ_ENVIRONMENT_VARIABLES = (
 #: timing of these tests depend on where the developer's Chromium came from.
 BROWSER_PATH = "/usr/bin/chromium-for-tests"
 
-#: A browser path that `_is_snap_browser` classifies as snap-packaged. It is
-#: fabricated rather than the real `/snap/bin/chromium`, and that is worth a
-#: sentence: on Ubuntu `/snap/bin/chromium` is a symlink to `/usr/bin/snap`, and
-#: `_is_snap_browser` calls `os.path.realpath` first -- so it answers **False**
-#: for the single most common way to have a snap Chromium (measured on Ubuntu
-#: 24.04). A non-existent path under `/snap/` has no symlink to follow and is
-#: classified correctly. The production defect that implies is reported, not
-#: fixed here; a test that used the real path would silently assert the
-#: non-snap branch, which is what the previous version of this file did.
+#: A browser path `_is_snap_browser` classifies as snap-packaged. Fabricated
+#: rather than real, and it no longer has to be: the detector used to resolve the
+#: path before testing it for the ``/snap/`` marker, so only a ``/snap/`` path
+#: that does **not** exist -- one with no symlink for ``realpath`` to follow --
+#: reached the snap branch at all. That was an open production defect and is now
+#: fixed; the marker is tested on the path as given. The constant stays
+#: fabricated because it belongs to the two cases below that *inject* the
+#: classification, where the path is a label rather than an input.
 #:
-#: **On Windows nothing classifies as snap, whatever the path.** A path with a single
-#: leading slash is not absolute there, so `os.path.realpath` joins it against the
-#: current working drive and normalises the separators: this value resolves to
-#: ``<drive>:\snap\bin\chromium-for-tests`` and the ``/snap/`` marker is gone --
-#: measured against the shipped function on a `windows-latest` runner, where the
-#: drive happened to be ``D:``. That is correct
-#: behaviour, snap being a Linux packaging format, and it is why the backoff case
-#: below injects the classification instead of deriving it from this constant. The
-#: constant is still what that case hands to the detector, so it still records what
-#: a snap-packaged browser's path looks like.
+#: The real launcher, which used to be the trap, is :data:`SNAP_LAUNCHER_PATH`
+#: and is what the two derived cases use.
+#:
+#: **Nothing classifies as snap away from POSIX, whatever the path.** That was
+#: once an accident of `os.path.realpath` -- a path with a single leading slash
+#: is not absolute on Windows, so it was joined against the current drive and its
+#: separators normalised, erasing the marker (measured against the shipped
+#: function on a `windows-latest` runner, where the drive happened to be ``D:``).
+#: Testing the path as given removed that accident, so an explicit ``os.name``
+#: guard carries the answer instead. It is still the correct answer -- snap is a
+#: Linux packaging format -- which is why every case that *derives* a
+#: classification pins ``os.name`` as well as ``os.path.realpath``.
 SNAP_BROWSER_PATH = "/snap/bin/chromium-for-tests"
+
+#: The launcher a stock Ubuntu install actually provides, and a symlink to
+#: ``/usr/bin/snap`` rather than to a browser (measured on Ubuntu 24.04.4:
+#: ``lrwxrwxrwx /snap/bin/chromium -> /usr/bin/snap``). Ubuntu has shipped
+#: Chromium only as a snap since 19.10, so this is the commonest snap browser
+#: path in existence -- and, until the detector was repaired, the one path that
+#: was certain to be denied the snap allowance.
+SNAP_LAUNCHER_PATH = "/snap/bin/chromium"
+
+#: What ``os.path.realpath`` returns for :data:`SNAP_LAUNCHER_PATH`. Pinned in
+#: the cases that use it rather than looked up, so they answer the same on a
+#: machine with no snap installed.
+SNAP_LAUNCHER_TARGET = "/usr/bin/snap"
 
 #: A ceiling on any single `_fetch_html` call, guarding a hang that makes no
 #: progress -- an await that never resolves. Five seconds is fifty times the
@@ -183,6 +197,28 @@ class StubChromiumProcess:
     def __repr__(self) -> str:
         """Return a form that names the attempt in an assertion message."""
         return f"<StubChromiumProcess pid={self.pid}>"
+
+
+def _realpath_returning(targets: dict[str, str]) -> Any:
+    """Build an :func:`os.path.realpath` stand-in with a fixed answer table.
+
+    `_is_snap_browser` reads ``os.path.realpath``, whose answer depends on the
+    platform and on where the developer's Chromium came from. The two cases that
+    derive a snap classification from a path pin it through this helper so they
+    assert the same constant everywhere.
+
+    Args:
+        targets: Mapping from a path to what ``realpath`` should return for it.
+            A path absent from the mapping resolves to itself, which is what the
+            real call does for an executable that is not a symlink.
+
+    Returns:
+        A callable with :func:`os.path.realpath`'s single-argument shape.
+    """
+    def _realpath(path: str, *_args: object, **_kwargs: object) -> str:
+        return targets.get(path, path)
+
+    return _realpath
 
 
 def make_browser_double(
@@ -794,6 +830,86 @@ class TestNodriverWorkerSandbox(unittest.IsolatedAsyncioTestCase):
         # 0.5 * 2**0, then 0.5 * 2**1, unmultiplied. The trailing 0.1 is the
         # profile flush, as above.
         self.assertEqual(recorded, [0.5, 1.0, 0.1])
+
+    async def test_snap_launcher_path_lengthens_the_devtools_budget(self) -> None:
+        """Give the Ubuntu snap launcher the multiplied DevTools budget, from its path alone
+
+        The wiring the cross-platform milestone gave up, restored. The two
+        backoff cases above inject the classification through a seam, so between
+        them they prove that *an answer* selects the multiplier -- not that this
+        path produces that answer. This case derives it: it hands `_fetch_html`
+        the real ``/snap/bin/chromium`` and reads back the budget
+        `_wait_for_devtools_ready` was given.
+
+        A snap Chromium is the browser that most needs the longer budget, and
+        before the detector was repaired it was the only one that never got it:
+        `/snap/bin/chromium` is a symlink to ``/usr/bin/snap``, and resolving it
+        first threw away the marker. On the shipped defaults that is 12 s where
+        36 s was intended, and a content fetch that fails on a machine which
+        would otherwise have worked.
+
+        **Two process globals are pinned here, and both are ambient inputs of the
+        function under test rather than conveniences.** `_is_snap_browser` reads
+        ``os.path.realpath`` -- whose answer depends on what the developer's
+        Chromium is, and on the platform -- and ``os.name``, because snap is a
+        Linux packaging format and nothing classifies as snap elsewhere. Pinning
+        both is what lets this case assert one constant on every platform. The
+        alternative, a platform-gated skip, is the skew the baseline ledger
+        exists to keep out; the alternative of leaving them ambient is exactly
+        how a case here once asserted the multiplied series on Linux and failed
+        on Windows.
+        """
+        with (
+            orchestration_harness(
+                environment={
+                    "KINDLY_NODRIVER_DEVTOOLS_READY_TIMEOUT_SECONDS": "4",
+                    "KINDLY_NODRIVER_SNAP_BACKOFF_MULTIPLIER": "3",
+                }
+            ) as doubles,
+            patch.object(nodriver_worker.os, "name", "posix"),
+            patch.object(
+                nodriver_worker.os.path,
+                "realpath",
+                _realpath_returning({SNAP_LAUNCHER_PATH: SNAP_LAUNCHER_TARGET}),
+            ),
+        ):
+            await fetch_html(browser_executable_path=SNAP_LAUNCHER_PATH)
+
+        # 4 * 3. Two distinct values, so a production change reading the
+        # multiplier where it means the base -- or the reverse -- cannot land on
+        # the same number by coincidence.
+        self.assertEqual(
+            doubles.wait_ready.call_args.kwargs["timeout_seconds"], 12.0
+        )
+
+    async def test_a_system_browser_path_leaves_the_devtools_budget_alone(self) -> None:
+        """Leave the DevTools budget unmultiplied for a distribution-packaged browser
+
+        The negative polarity of the case above, and it is load-bearing for the
+        same reason its backoff counterpart is: a `_fetch_html` that multiplied
+        unconditionally would satisfy the affirmative case alone. The multiplier
+        is configured here and must be ignored because the browser is not snap,
+        not because none was set.
+
+        The same two globals are pinned, and ``realpath`` answers with the path
+        itself -- the way a real lookup answers for an executable that is not a
+        symlink.
+        """
+        with (
+            orchestration_harness(
+                environment={
+                    "KINDLY_NODRIVER_DEVTOOLS_READY_TIMEOUT_SECONDS": "4",
+                    "KINDLY_NODRIVER_SNAP_BACKOFF_MULTIPLIER": "3",
+                }
+            ) as doubles,
+            patch.object(nodriver_worker.os, "name", "posix"),
+            patch.object(
+                nodriver_worker.os.path, "realpath", _realpath_returning({})
+            ),
+        ):
+            await fetch_html(browser_executable_path=BROWSER_PATH)
+
+        self.assertEqual(doubles.wait_ready.call_args.kwargs["timeout_seconds"], 4.0)
 
     async def test_does_not_retry_a_non_retryable_error(self) -> None:
         """Surface an unrecognised startup failure at once instead of retrying it

--- a/tests/test_nodriver_worker_sandbox.py
+++ b/tests/test_nodriver_worker_sandbox.py
@@ -725,17 +725,25 @@ class TestNodriverWorkerSandbox(unittest.IsolatedAsyncioTestCase):
         exponent, dropping the multiplier, and dropping both.
 
         **The snap classification is injected here, not derived from the path,
-        and that is a platform repair rather than a convenience.**
-        `_is_snap_browser` calls `os.path.realpath`, whose result is
-        platform-dependent: Windows rewrites the separators and prepends a drive
-        letter, so ``/snap/bin/...`` resolves to ``D:\snap\bin\...`` and the
-        ``/snap/`` marker the detector keys on cannot survive. Measured against
-        the shipped function on a `windows-latest` runner. **No path whatsoever
-        classifies as snap there**, so a case deriving the answer from a path
-        asserts the multiplied series on POSIX and the un-multiplied one on
-        Windows -- this one did, and failed there with ``[0.5, 1.0, 0.1]``.
-        Production is right and is left alone: snap is a Linux packaging format
-        and does not exist on Windows.
+        and that is a platform repair rather than a convenience.** When this was
+        written, `_is_snap_browser` answered from `os.path.realpath` alone, whose
+        result is platform-dependent: Windows rewrites the separators and
+        prepends a drive letter, so ``/snap/bin/...`` resolved to
+        ``D:\snap\bin\...`` and the ``/snap/`` marker the detector keys on could
+        not survive. Measured against the function as it shipped then, on a
+        `windows-latest` runner. **No path whatsoever classifies as snap there**,
+        so a case deriving the answer from a path asserted the multiplied series
+        on POSIX and the un-multiplied one on Windows -- this one did, and failed
+        there with ``[0.5, 1.0, 0.1]``. Production is right and is left alone:
+        snap is a Linux packaging format and does not exist on Windows.
+
+        **That mechanism is gone; the answer is not.** The detector now tests the
+        marker on the path as given, which the resolver can no longer erase, and
+        an explicit ``os.name`` guard carries the Windows answer instead -- so on
+        Windows the function returns before `os.path.realpath` is called at all.
+        The injection here still earns its place: it keeps this case's subject
+        the backoff arithmetic rather than the classification, and the derived
+        cases below cover the wiring it gives up.
 
         What the seam gives up is the wiring from a *path shape* to the answer.
         That wiring has since been restored, in the two cases below this pair

--- a/tests/test_nodriver_worker_sandbox.py
+++ b/tests/test_nodriver_worker_sandbox.py
@@ -221,6 +221,13 @@ def make_pinned_detector(realpath_targets: dict[str, str]) -> Any:
     rather than being quietly accepted, and the case can assert which path it was
     asked about.
 
+    **`tests/test_chromium_pool_slot_start.py::_pinned_detector` is the same nine
+    lines**, for the pool's copy of this call site. They are deliberately not
+    shared: what differs between them is the reasoning, which is each module's
+    own, and the only home for a shared double here is `tests/doubles/`, a package
+    scoped to the worker Protocol harness and inside the type gate's declared
+    surface. If you change which inputs are pinned, change both.
+
     Args:
         realpath_targets: What ``os.path.realpath`` should answer, by path. A
             path absent from the mapping resolves to itself, which is what the


### PR DESCRIPTION
## Context for the Product Owner

**The server sometimes failed to fetch a page on exactly the machines it should have worked best on.**

To read a page that needs JavaScript, the server drives a headless Chromium and waits for it to open a debug port. Snap-packaged browsers are slow to open that port, so the code already granted them a longer budget — **36 seconds instead of 12** — and more patient retries between attempts.

That allowance never reached a single snap browser in the field. On Ubuntu, which has shipped Chromium only as a snap since 19.10, `/snap/bin/chromium` is a symlink to `/usr/bin/snap`, and the detector followed the symlink before checking whether the path looked like a snap. The link target carries no snap marker, so the browser that most needed the extra time was the one browser certain never to get it. The user-visible result is a failed content fetch on a machine that would otherwise have succeeded — on the commonest Linux deployment target there is.

The defect was found on 2026-09-01 while writing an unrelated test, reported and deliberately not fixed there, and carried as a known-wrong answer across four subsequent pieces of work. This change closes it, and closes it in the place a fix belongs rather than inside a testing step.

**What changes for a user:** a snap Chromium now gets the startup budget the code always intended for it. Nothing else about page fetching changes. On Windows the answer is the same as before — nothing is a snap there, because snap is a Linux packaging format.

**What changes for the team:** the browser pool had no test file at all; it has one now. And the planned step that was instructed to write tests *asserting the known-wrong answer* is told instead to assert the corrected one, so nobody spends a day encoding a defect.

---

## The change

`_is_snap_browser` resolved the path before testing it for the `/snap/` marker:

```python
resolved = os.path.realpath(executable_path)
return resolved.startswith("/snap/") or "/snap/" in resolved
```

Measured on Ubuntu 24.04.4 / CPython 3.13.15 against the shipped function:

```
path                            exists  islink  realpath          is_snap
/snap/bin/chromium              True    True    /usr/bin/snap     False   <-- the real one
/snap/bin/chromium-for-tests    False   False   (unchanged)       True
/usr/bin/chromium               False   False   (unchanged)       False
```

Only a `/snap/` path that does **not** exist classified correctly, because there was no symlink for `realpath` to follow.

The repair tests the marker on the path **as given** first, then on the resolved path:

```python
if os.name != "posix":
    return False
if "/snap/" in executable_path:
    return True
try:
    resolved = os.path.realpath(executable_path)
except Exception:
    return False
return "/snap/" in resolved
```

Re-measured on the same host, `/snap/bin/chromium` is now `True` and `/usr/bin/chromium` still `False`.

Three points that are not obvious from the diff:

- **Resolving still earns its place.** A browser reached by an ordinary path can be a snap package underneath, and only the resolved form says so. Both halves have their own case.
- **The marker is matched anywhere in the path, not as a prefix**, and that is a requirement rather than a spelling. snapd mounts snaps under `/var/lib/snapd/snap` and puts `/var/lib/snapd/snap/bin` on `PATH`; `/snap` exists only where an administrator hand-creates the symlink classic confinement needs (ArchWiki, *Snap*). Off Ubuntu the launcher is `/var/lib/snapd/snap/bin/chromium`, marker mid-path — so a prefix test would deny the allowance to every snap browser on Fedora, Arch and Debian.
- **The Windows guard is new, and preserves the old answer.** Nothing classified as snap on Windows before, but only by accident: a leading-slash path is not absolute there, so `realpath` joined it against the current drive and erased the marker (measured on a `windows-latest` runner during the suite-green milestone). Testing the path as given removes that accident, so the correct answer needed an explicit guard rather than a side effect. `os.name` and not `sys.platform`, per the convention this repo records; POSIX and not Linux, because macOS answered the marker before the guard existed and narrowing it would be a behaviour change made for tidiness.
- **A dead disjunct went with it.** `resolved.startswith("/snap/")` was subsumed by the substring test beside it and could never change an answer.

## Tests

Eleven cases, each with a mutation it is the only one to kill — measured by applying each mutation and reading back which case failed, not asserted.

**Component** (`tests/test_nodriver_worker_launch_resolvers.py`, nine cases): the Ubuntu launcher; the same launcher under snapd's own mount point, marker mid-path; a `/snap/` path with nothing to resolve; a marker-free path resolving into the snap tree, also mid-path; an ordinary system browser; the non-POSIX guard; a `realpath` that raises on a `/snap/` path; and a `realpath` that raises on a marker-free path, driven for both `OSError` and `ValueError`.

One equivalent mutant is triaged in a docstring rather than chased: rewriting the guard as `os.name == "nt"` survives, and is equivalent on any interpreter that can run this package.

That last one is the ordering case, and it was added by review. The tidier-looking rearrangement below passes every other case in this branch and answers `False` where both the shipped and the repaired function answer `True`:

```python
try: resolved = os.path.realpath(p)
except Exception: return False
return "/snap/" in p or "/snap/" in resolved
```

**Call sites** (`tests/test_nodriver_worker_sandbox.py` and the new `tests/test_chromium_pool_slot_start.py`, two cases each): the budget handed to `_wait_for_devtools_ready` is `base × multiplier` for the snap launcher and `base` for a system browser, with the classification **derived from the path** rather than injected. That restores the path-shape wiring the cross-platform milestone had to give up, and covers a pooled call site that had no test module.

The detector's two ambient inputs are pinned around **its own call only**, by an autospec double whose side effect calls the real function. Pinning them for a whole `_fetch_html` call was drafted and rejected on measurement: `os.name` is read three more times inside that coroutine, it selects `pathlib.Path`'s flavour at construction, and `tempfile.gettempdir()` consults it cold — so the pin's safety would have rested on which collaborators the harness happens to double.

## Reviews taken

A `system-design-reviewer` pass on the requirements and a `code-reviewer` pass on the diff, plus a second, narrow design pass on one policy question the code review declined to decide itself.

The design review found a **surviving non-equivalent mutant** — the tidier rearrangement shown above — and a **contradiction inside the first commit**, where a test docstring and the design document disagreed about who owns `_is_snap_browser`. The code review found the **prefix-vs-substring gap**, which is the finding that mattered most: it would have passed review, passed the suite, and reintroduced this bug on every non-Ubuntu snap host. It also found the `except Exception` narrowing and two more stale sentences. All taken.

The narrow design pass asked whether the new pool module falsifies §10.4's "`omit` names the modules with no hermetic seam". Answer: **no correction obligatory** — the classification is file-granular by the document's own words, and §10.4 already names `chromium_pool.py` as an L1 test target. Not widened. It did flag one branch-created gap, now closed: the hand-off to E7-3 says the new module's two cases are unmarked and must stay so.

**One pre-existing item, mentioned and deliberately not fixed:** the snap multiplier is applied *after* `_resolve_devtools_ready_timeout_seconds()` has clamped to ≤120 s, so the product escapes that ceiling. Unchanged by this diff and not this change's business.

## Documents corrected in the same change

`TEST_SUITE.md` §3.1 and §14; §8 block A item 5 and the ledger's Windows probe (annotated as superseded, not rewritten — they are recorded measurements); §10.4's `source_pkgs` rationale and §1.2's inventory row; the plan's E5-4 entry, which hands `_is_snap_browser` back *with its tests*, and E7-3, which now owns the new pool module; and `SNAP_BROWSER_PATH`'s comment plus two comments in `test_coverage_configuration.py` that claimed `chromium_pool.py` had no test anywhere. That guard's control uses a standalone probe script, so it would **not** have gone red — the comment now names the property it actually depends on.

One invariant is newly written down, confirmed by web search rather than recalled: snapd dispatches on the name a binary is invoked as, and every `/snap/bin/<app>` is a symlink to `/usr/bin/snap` — so the executable path must never be `realpath`-resolved *before launch*, or the snap CLI starts instead of Chromium. It is not resolved today; the variable holding it is called `resolved_browser_executable_path`, which is why the invariant now has a sentence.

## Verification

- `.venv/bin/python -m pytest -q`: **526 → 539 passed**, 2 skipped, 16 subtests, on Linux / CPython 3.13.15. Nothing removed — compared as a node-id set via the baseline-ledger guard, not as counts.
- `scripts/check_plan_dag.py` exits 0. `mypy` is clean on its scoped surface (4 files). The review system's own 482 tests pass. `ruff check` on the changed test files is clean, and unchanged at 32 findings on `nodriver_worker.py`, which is not clean at baseline.

**Not covered, deliberately:** this is not proved on a real Windows host — the repo has no cross-platform lane yet. The Windows guard is asserted by pinning `os.name`, which tests the guard and not the platform. The observable answer there is unchanged from the measured one, but that is an argument, and this repository's own rule is that arguments do not cover platforms.

**Note:** Serena's Python language server would not start in this worktree, so the code was navigated with grep and read rather than the symbol tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
