### PR TITLE
Correct a shipped docstring, and record two follow-ups where their owners will read them

### DIFF
--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -867,7 +867,22 @@ duplicating tests or touching the same files.
   *Verify:* grouped by behaviour. **Numeric env parsing**
   (`_resolve_retry_backoff_seconds`, `_resolve_devtools_ready_timeout_seconds`,
   `_resolve_worker_timeout_seconds`, `_resolve_snap_backoff_multiplier`): unset,
-  blank, malformed, zero, negative. **String and list normalisation**
+  blank, malformed, zero, negative.
+  **Added scope: the DevTools ceiling does not hold, and this step characterises
+  that.** `_resolve_devtools_ready_timeout_seconds` clamps to `[0.5, 120]` and
+  both call sites then multiply the *clamped* value by
+  `_resolve_snap_backoff_multiplier`, which clamps to `[1, 20]`. Measured against
+  the shipped resolvers: with `KINDLY_NODRIVER_DEVTOOLS_READY_TIMEOUT_SECONDS=500`
+  the base is correctly clamped to `120.0`, and the product handed to
+  `_wait_for_devtools_ready` is **2400 s** — the ceiling defeated by a factor of
+  twenty. Defaults are unaffected (12 x 3 = 36 s), so this needs both variables
+  set deliberately, and the worker path is bounded from outside by the parent's
+  total budget; the pooled path is bounded only by the server's tool timeout.
+  Pin the product for a snap browser at the clamped maximum and name the
+  inconsistency in the docstring. **Characterise, do not repair** — the ordering
+  is a production decision, and this step does not change production. Found while
+  fixing the snap-detection defect; deliberately left there rather than widened
+  into. **String and list normalisation**
   (`_resolve_chrome_proxy`, `_resolve_chrome_proxy_bypass`, `_split_no_proxy_value`):
   unset, blank, single value, comma-separated with surrounding whitespace,
   duplicate entries. **Version and user-agent**
@@ -1109,6 +1124,21 @@ duplicating tests or touching the same files.
   are hermetic and belong in the fast lane. Every claim this step adds there
   needs its own `chromium` or `subsystem` marker, or a step written against a
   locally installed Chromium quietly acquires cases that run everywhere.
+  **Added scope: settle one §10.4 sentence this step is now the owner of.** §10.4
+  holds two positions about hermetic tests on `omit`-ed modules and nothing
+  reconciles them. One blesses the practice — "an L1 test on an omitted module,
+  which is already this suite's practice" — and names `chromium_pool.py` as a
+  target. The other, written by E2-4 for its own two termination helpers,
+  discourages the same shape: "the module is outside the gate, so a hermetic test
+  here earns no coverage while blurring the classification", and its stated
+  reason is a property of the *gate* rather than of `worker_runner.py`, so it
+  reads as if it generalises. `tests/test_chromium_pool_slot_start.py` is exactly
+  the shape E2-4 declined, in a module the other sentence names as a target. The
+  tension predates that module and was not created by it — a design review
+  confirmed no correction was obligatory on the branch that added it. One
+  sentence settles it: either scope E2-4's rule explicitly to `worker_runner.py`'s
+  process-termination helpers, or generalise it and say why the pooled DevTools
+  budget is an exception.
 
 ---
 

--- a/src/kindly_web_search_mcp_server/scrape/nodriver_worker.py
+++ b/src/kindly_web_search_mcp_server/scrape/nodriver_worker.py
@@ -355,8 +355,11 @@ def _is_snap_browser(executable_path: str) -> bool:
     """Report whether a browser executable is snap-packaged.
 
     A snap-packaged Chromium is markedly slower to open its DevTools endpoint
-    than a distribution-packaged one, so the caller multiplies both the
-    DevTools-ready timeout and the retry backoff for one. The marker ``/snap/``
+    than a distribution-packaged one, so a caller that gets ``True`` here
+    multiplies the time it allows. The two callers do not allow the same
+    things: `_fetch_html` multiplies the DevTools-ready timeout **and** its
+    retry backoff, while :meth:`chromium_pool.ChromiumSlot._start` multiplies
+    the timeout only -- it has no retry loop to slow down. The marker ``/snap/``
     is matched anywhere in the path, on the path as supplied and then on its
     resolved form; the reasoning for the ordering, for the POSIX guard, and for
     matching a substring rather than a prefix is recorded in


### PR DESCRIPTION
## Context for the Product Owner

**No behaviour changes.** This is the tail of the snap-detection fix (#71): one inaccurate sentence in the shipped code, and two known issues written down where the people who will work on those areas next will actually see them.

The automated reviewer caught the docstring inaccuracy after #71 had already merged, so it ships as its own small change.

## 1. A docstring that was wrong about one of its two callers

`_is_snap_browser` claimed "the caller multiplies both the DevTools-ready timeout and the retry backoff". That is true of `_fetch_html` and false of `ChromiumSlot._start`, which multiplies the timeout only — the pool has no retry loop. Verified at both call sites and corrected to name them separately.

## 2. The DevTools ceiling does not hold — recorded on the step that owns those resolvers

`_resolve_devtools_ready_timeout_seconds` clamps to `[0.5, 120]`. Both call sites then multiply the **clamped** value by `_resolve_snap_backoff_multiplier`, which clamps to `[1, 20]`. Measured against the shipped resolvers:

```
env=unset/unset  clamped_base=  12.0 (ceiling 120)  mult= 3.0  product=   36.0s
env=  500/   20  clamped_base= 120.0 (ceiling 120)  mult=20.0  product= 2400.0s
```

The base clamp works. The product then defeats it by a factor of twenty — 40 minutes of DevTools wait from a ceiling that reads as two.

**Assessed medium, not high**, and the reasoning is in the plan entry: the defaults are safe (36 s), it takes two variables set deliberately, the worker path is bounded from outside by the parent's total budget, and the pooled path by the server's tool timeout. Added to E5-4's scope as a **characterise, do not repair** item — the ordering is a production decision and that step does not change production.

## 3. One §10.4 sentence needs settling, by the step that now owns the pool

§10.4 holds two positions about hermetic tests on `omit`-ed modules: one blesses the practice and names `chromium_pool.py` as a target, the other — E2-4's rule for its own two termination helpers — discourages the same shape, for a reason phrased as a property of the gate rather than of that module. #71's new pool module sits between them.

The tension predates that module; a design review on #71 confirmed no correction was obligatory there, and it was deliberately not widened into. E7-3 owns the pool module now, so the one-sentence decision is recorded in its entry.

## Verification

539 passed, 2 skipped, 16 subtests. `scripts/check_plan_dag.py` exits 0. The review system's 482 tests pass. `ruff` unchanged on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)