### PR TITLE
Make every declared job cap one its runner will actually honour

### DIFF
--- a/.github/review/README.md
+++ b/.github/review/README.md
@@ -158,7 +158,7 @@ step 2 above.
 ## Changing the review system
 
 `.github/workflows/ci.yml` runs `tests/test_review_scripts.py` on every pull
-request — 512 tests over the selector, the classifier, the notices, the redactor,
+request — 513 tests over the selector, the classifier, the notices, the redactor,
 the schema and the workflow's own wiring. Run them locally the same way:
 
 ```bash

--- a/.github/review/README.md
+++ b/.github/review/README.md
@@ -158,7 +158,7 @@ step 2 above.
 ## Changing the review system
 
 `.github/workflows/ci.yml` runs `tests/test_review_scripts.py` on every pull
-request — 502 tests over the selector, the classifier, the notices, the redactor,
+request — 512 tests over the selector, the classifier, the notices, the redactor,
 the schema and the workflow's own wiring. Run them locally the same way:
 
 ```bash

--- a/.github/review/README.md
+++ b/.github/review/README.md
@@ -89,8 +89,9 @@ To enable the workflow on this repository:
 
 1. Grant this repository access to the three settings above (organisation
    settings → Secrets and variables → Actions → each item → repository access).
-2. Nothing to do for runners — the workflows use the GitHub-hosted
-   `ubuntu-slim` label, so no runner group has to be granted.
+2. Nothing to do for runners — the workflows use GitHub-hosted labels
+   (`ubuntu-latest` for the review, `ubuntu-slim` for the two CI jobs), so no
+   runner group has to be granted.
 
    ⚠️ **Why not the self-hosted fleet, since the organisation has one:** a runner
    group carries an *"Allow public repositories"* setting that is **off by
@@ -102,8 +103,16 @@ To enable the workflow on this repository:
    unreachable runner label is completely silent — no error, no annotation, no
    timeout. Measured here before the move: three jobs queued for over fifteen
    minutes while a GitHub-hosted job on the same pull request finished in 55
-   seconds. `ubuntu-slim` is organisation-configured, so if the org stops
-   offering it this returns; `ubuntu-latest` is the always-available fallback.
+   seconds. Both labels used here are GitHub's own standard public ones, so
+   neither depends on an organisation grant.
+
+   🔴 **`ubuntu-slim` has a 15-minute job ceiling that no setting can raise.**
+   GitHub's runner reference: *"The job timeout for single-CPU runners is 15
+   minutes."* The review job used to run there with `timeout-minutes: 60` and was
+   killed mid-run five times before anyone paired the two lines; it now runs on
+   `ubuntu-latest`, whose ceiling is six hours. The two CI jobs stay on
+   `ubuntu-slim`, which is what that label is for. A test fails if any job ever
+   declares a cap its runner will not honour.
 3. Open a pull request. The `review` check appears on it.
 4. Once it has run green once, make `review` a required status check on `main`.
 
@@ -127,13 +136,18 @@ a per-attempt table. The two outcomes mean different things:
 - **`fatal`** — the workflow or its settings. The diagnostic names which. The
   most common causes are one of the three `KITTY_*` settings missing or not valid
   JSON, and an egress document that parses but disables the gateway.
+- **`cancelled`** — the run did not finish. Either it hit the job cap, or a newer
+  commit superseded it (the workflow cancels an in-flight review on a new push).
+  Nothing is wrong with the change and nothing is wrong with the workflow: if a
+  newer commit superseded this run, its own review reports; otherwise re-run.
+  This appears in the run summary only — no comment is posted, so that a rapid
+  push sequence does not comment once per superseded run.
 
 One case is worth knowing in advance because it is easy to misdiagnose: **if the
 job starts failing at `Install kitty-bridge and Claude CLI`, that is the runner,
 not the settings.** It is reported as `fatal` and points at the `KITTY_*`
-settings, which will all be fine. On a slim image the likely cause is a missing
-package — check the preflight step's warnings first — and `ubuntu-latest` is the
-fuller image to compare against.
+settings, which will all be fine. The likely cause is a package missing from the runner
+image — check the preflight step's warnings first.
 
 And one that is not a failure at all: **a check that never appears, or appears
 and stays queued for ever, is a runner-label problem, not a review problem.** See
@@ -144,7 +158,7 @@ step 2 above.
 ## Changing the review system
 
 `.github/workflows/ci.yml` runs `tests/test_review_scripts.py` on every pull
-request — 482 tests over the selector, the classifier, the notices, the redactor,
+request — 502 tests over the selector, the classifier, the notices, the redactor,
 the schema and the workflow's own wiring. Run them locally the same way:
 
 ```bash

--- a/.github/review/rules/ci.md
+++ b/.github/review/rules/ci.md
@@ -118,14 +118,40 @@ that overrides the child's endpoint and credentials.
 - A step that runs between `Interpret` and `Resolve` and can fail without
   `continue-on-error` will suppress a review that had already succeeded, because
   the later steps carry an implicit `success()`.
+- 🔴 **`Resolve outcome` carries `always()`; the steps that speak to the pull
+  request must not.** A cancelled job skips every step on the implicit
+  `success()`, which used to include `Resolve outcome` — leaving `Write run
+  summary` to default to `fatal` and announce a misconfigured workflow about a
+  run that was merely killed at a cap. That is a wrong instruction: the correct
+  response to a cap kill is to re-run. But `cancel-in-progress: true` makes
+  superseded cancellations routine, so `always()` on `Build failure notice`,
+  `Post failure notice` or `Fail when no review was produced` would comment and
+  annotate on every rapid push. Flag a change that adds `always()` to any of
+  those three, and flag one that removes it from `Resolve outcome`.
 
 ## Runner and caps
 
-- `runs-on: ubuntu-slim` — GitHub-hosted, **not** the self-hosted fleet the
-  upstream repository uses. This repository is public, and a runner group's
-  "Allow public repositories" setting is off by default, so it reaches no
-  self-hosted group at all. A change that moves this back to `[self-hosted, ...]`
-  needs to say what changed about that grant, or it will silently never run.
+- `runs-on: ubuntu-latest` for the review job, `ubuntu-slim` for the two `ci.yml`
+  jobs — GitHub-hosted, **not** the self-hosted fleet the upstream repository
+  uses. This repository is public, and a runner group's "Allow public
+  repositories" setting is off by default, so it reaches no self-hosted group at
+  all. A change that moves either back to `[self-hosted, ...]` needs to say what
+  changed about that grant, or it will silently never run.
+- 🔴 **A `timeout-minutes:` above the runner's platform ceiling is a fiction, and
+  nothing warns.** `ubuntu-slim` is a single-CPU runner with a **15-minute job
+  ceiling that cannot be raised from configuration** (GitHub: *"The job timeout
+  for single-CPU runners is 15 minutes. If a job reaches this limit, the job is
+  terminated and fails."*). The review job declared 60 on that label and was
+  killed mid-run five times on a merge-gating check before anyone paired the two
+  lines. Ordinary GitHub-hosted labels are 6 hours. **Flag any change that moves
+  a `runs-on:` or a `timeout-minutes:` without saying what it did with the
+  other** — `DeclaredJobCapIsEnforceableTests` pairs them, and a change that
+  weakens or deletes that guard to make an edit pass is a critical finding.
+- ⚠️ **`ubuntu-slim` is one of GitHub's STANDARD PUBLIC labels, not something the
+  organisation grants.** An earlier version of this file and of the workflow said
+  the opposite, and that belief is why a documented platform limit was hunted for
+  in organisation settings. Its distinguishing property is the ceiling above, not
+  its availability.
 - 🔴 **An unreachable runner label is completely silent, and that is the most
   expensive thing to know about this file.** A job asking for a label nothing
   offers queues **for ever** — no error, no annotation, no timeout. A typo and an
@@ -134,20 +160,25 @@ that overrides the child's endpoint and credentials.
   55 seconds. So flag any change to a `runs-on:` label that the pull request does
   not explain, and treat "the check never appeared" as a label question first.
   `ubuntu-latest` is the always-available fallback.
-- **A slim image is the one most likely to be missing a tool the action shells
-  out to.** `unzip` is the known case and the preflight step covers it. A change
-  that adds a step invoking a new tool should add it to that preflight call —
-  nothing else will catch it, and it will fail inside a third-party action's log
-  rather than at a step that names the package.
+- **A runner image may be missing a tool the action shells out to.** `unzip` is
+  the known case and the preflight step covers it. A change that adds a step
+  invoking a new tool should add it to that preflight call — nothing else will
+  catch it, and it will fail inside a third-party action's log rather than at a
+  step that names the package. ⚠️ The slim-image argument this bullet used to
+  carry is **expired**: the preflight's only caller moved to `ubuntu-latest`,
+  which carries `unzip`. The reason that survives is the one that never depended
+  on the image — `unzip` is invoked inside a third-party action two levels down
+  and is named nowhere in this repository, so no scan of `run:` blocks finds it.
 - A capability label declares memory and **nothing else**, which is why
   `ci_preflight.sh` probes for `unzip` before the action shells out to it. The
   fleet is not homogeneous. A new job that invokes a tool without a preflight call
   fails only when placement is unlucky, and the re-run passes — the most expensive
   failure class there is.
-- `timeout-minutes` is a backstop, sized for two attempts' tails. `API_TIMEOUT_MS`
-  is what bounds a single hung call and must stay well below it, so a hang fails
-  as a timeout with a diagnostic rather than being killed by the job cap with
-  none.
+- `timeout-minutes` is a backstop, sized for two attempts' tails, and is only a
+  backstop when the runner will honour it — see the ceiling bullet above.
+  `API_TIMEOUT_MS` is what bounds a single hung call and must stay well below it,
+  so a hang fails as a timeout with a diagnostic rather than being killed by the
+  job cap with none.
 
 ## Forks
 

--- a/.github/review/scripts/build_run_summary.py
+++ b/.github/review/scripts/build_run_summary.py
@@ -116,11 +116,15 @@ def _headline(result: str, provider: str) -> list[str]:
     """Build the opening lines stating what the run achieved.
 
     Args:
-        result: Resolved run outcome: ``ok``, ``exhausted`` or ``fatal``.
+        result: Resolved run outcome: ``ok``, ``exhausted``, ``cancelled`` or
+            ``fatal``.
         provider: Winning tier label, empty unless the result is ``ok``.
 
     Returns:
         Markdown lines.
+
+    Raises:
+        ValueError: The result is not one of the four `Resolve outcome` emits.
     """
 
     if result == "ok":
@@ -143,6 +147,40 @@ def _headline(result: str, provider: str) -> list[str]:
             "means the change would otherwise merge unreviewed. That is why "
             "this outcome is red rather than green.*",
         ]
+    if result == "cancelled":
+        # 🔴 The run was cut short. Two things cause it and both want the same
+        # response, which is why they share one branch rather than being guessed
+        # between: the job cap fired, or a newer push superseded this run
+        # (`concurrency.cancel-in-progress: true`).
+        #
+        # 🔴 **This branch exists because its absence was a wrong INSTRUCTION.**
+        # `Resolve outcome` carried no `if:`, so a cancellation skipped it and
+        # this renderer fell back to `${RESULT:-fatal}` -- announcing that the
+        # workflow needed fixing about a run that was merely killed at a cap.
+        # Measured on five killed jobs; the correct action was always to re-run.
+        return [
+            "## No review this run — the run did not finish",
+            "",
+            "**This check fails**, because the pull request has not been "
+            "reviewed. Nothing is wrong with the change, and nothing is wrong "
+            "with the workflow: the run was cancelled before it could report.",
+            "",
+            "Either it reached the job's time cap, or a newer commit superseded "
+            "it. If a newer commit superseded this run, its own review reports "
+            "and there is nothing to do here; otherwise **re-run this job**.",
+        ]
+    if result != "fatal":
+        # 🔴 A bare fall-through stood here, so ANY unrecognised value rendered
+        # the failure headline below -- a wrong-but-plausible verdict from a
+        # typo, on the surface an operator opens first. The sibling notice
+        # builder closed its own vocabulary for exactly this reason; refusing is
+        # louder than answering confidently about a run nobody classified.
+        raise ValueError(
+            f"unknown result {result!r}: the vocabulary is closed to 'ok', "
+            "'exhausted', 'cancelled' and 'fatal', which is the alphabet "
+            "`Resolve outcome` emits. Rendering an unknown value would announce "
+            "the workflow as broken about a run that was never classified."
+        )
     # 🔴 upstream. This ended "so re-running will not clear it" -- word for word
     # the claim removed from the pull request comment and the `::error::` line.
     # §14.3 treats the three as ONE voice, and this is the surface an operator
@@ -175,7 +213,8 @@ def build(
     """Build the job summary in Markdown.
 
     Args:
-        result: Resolved run outcome: ``ok``, ``exhausted`` or ``fatal``.
+        result: Resolved run outcome: ``ok``, ``exhausted``, ``cancelled`` or
+            ``fatal``.
         provider: Winning tier label, empty unless the result is ``ok``.
         tiers: Every provider attempt, whether or not it ran.
         egress_cause: Why the egress gate refused, verbatim from
@@ -269,7 +308,12 @@ def main() -> int:
     """
 
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--result", required=True)
+    # 🔴 Closed, not open. This is fed `${{ steps.outcome.outputs.result }}` with a
+    # `${RESULT:-fatal}` shell default, and an unrecognised value used to render the
+    # "workflow needs fixing" headline rather than being refused.
+    parser.add_argument(
+        "--result", required=True, choices=["ok", "exhausted", "cancelled", "fatal"]
+    )
     parser.add_argument("--provider", default="")
     parser.add_argument(
         "--tier",

--- a/.github/review/scripts/ci_preflight.sh
+++ b/.github/review/scripts/ci_preflight.sh
@@ -22,12 +22,22 @@
 # per label rather than heterogeneous -- so the "unlucky placement" shape does not
 # apply here.
 #
-# 🔴 **The risk it is kept for is different and just as real: a SLIM IMAGE.** Being
-# slim is precisely a claim to carry fewer packages than the full image, and `unzip`
-# -- which `anthropics/claude-code-action` shells out to, two levels down, without
-# ever naming it in this repository -- is exactly what gets trimmed. Uniform means
-# every run fails the same way rather than one in three, which is easier to diagnose
-# and no less broken.
+# 🔴 **The SLIM-IMAGE argument that stood here is FALSIFIED, and is corrected rather
+# than deleted.** It read that the risk kept this script alive because a slim image is
+# precisely a claim to carry fewer packages, and `unzip` is what gets trimmed. That was
+# true while `claude-code-review.yml` ran on `ubuntu-slim`. It no longer does -- that
+# job is this script's only caller, and it moved to `ubuntu-latest`, which carries
+# `unzip`. Leaving the sentence would have left this file asserting the opposite of the
+# workflow that calls it, one file apart, which is the partial-fix shape this
+# repository keeps having to remove.
+#
+# 🔴 **The reason that survives is the one that never depended on the image.** `unzip`
+# is shelled out to by `anthropics/claude-code-action`, two levels down, and is named
+# NOWHERE in this repository -- so no scan of `run:` blocks can find it, and only
+# probing for the capabilities a job's ACTIONS need will. That argument held on the
+# self-hosted fleet, held on `ubuntu-slim`, and holds now. The script is a no-op on a
+# runner that already carries the package, which is the point: it costs nothing when it
+# is not needed and names the package when it is.
 #
 # ⚠️ On a GitHub-hosted runner this should SELF-HEAL rather than fail: the job has
 # passwordless sudo, so a missing package is installed and a warning emitted. Read

--- a/.github/review/tests/test_review_scripts.py
+++ b/.github/review/tests/test_review_scripts.py
@@ -180,11 +180,36 @@ def _declared_jobs(path):
         for m in re.finditer(r"^  ([A-Za-z_][A-Za-z0-9_-]*):[ \t]*$", section, re.M)
     ]
 
+    # 🔴 **Anything at job depth this parser did not recognise is an ERROR, not a
+    # job it silently skipped.** The mark pattern is end-anchored, so a
+    # flow-mapping job -- `sneaky: {runs-on: ubuntu-slim, timeout-minutes: 99}`,
+    # legal YAML that GitHub accepts -- matches nothing and vanishes. Measured:
+    # appended to `ci.yml` it left the sweep finding three jobs, still equal to
+    # the recorded set, with every check green and a 99-minute cap declared on a
+    # 15-minute runner. Pinning the job SET catches deletions and renames; only
+    # this catches an ADDITION in a spelling the parser cannot read.
+    unresolved = [
+        line
+        for line in section.splitlines()
+        if re.match(r"^  (?![ #])\S", line)
+        and not re.match(r"^  [A-Za-z_][A-Za-z0-9_-]*:[ \t]*$", line)
+    ]
+    assert not unresolved, (
+        f"{path.name}: line(s) at job depth this parser cannot resolve, so the "
+        f"job they declare would escape every check below: {unresolved}"
+    )
+
     jobs = []
     for index, (name, start) in enumerate(marks):
         end = marks[index + 1][1] if index + 1 < len(marks) else len(section)
         body = section[start:end]
-        runner = re.findall(r"^ {4}runs-on:[ \t]*(\S.*?)[ \t]*$", body, re.M)
+        # ⚠️ A trailing `# comment` is legal after a scalar and must not become
+        # part of the label -- otherwise the failure below reads "add
+        # 'ubuntu-slim  # cheap' to the ceiling table", which is an instruction
+        # to record a comment as a runner.
+        runner = re.findall(
+            r"^ {4}runs-on:[ \t]*(\S.*?)[ \t]*(?:#.*)?$", body, re.M
+        )
         timeout = re.findall(r"^ {4}timeout-minutes:[ \t]*(\d+)[ \t]*$", body, re.M)
         jobs.append(
             {
@@ -3548,6 +3573,12 @@ def resolve_outcome(
         out = Path(tmp) / "out"
         out.touch()
         env = dict(os.environ)
+        # 🔴 Popped before anything sets it. `env` is inherited from the real
+        # environment, so a developer or runner that happens to export
+        # `JOB_STATUS` would leave the unset case below testing the SET path --
+        # the exact hole the conditional set at the end of this block exists to
+        # close. A control that only holds on a clean machine is no control.
+        env.pop("JOB_STATUS", None)
         # Forward slashes: a Windows temp path reaches bash with backslashes,
         # which it reads as escapes and then cannot open for redirection.
         env.update(
@@ -3574,6 +3605,12 @@ def resolve_outcome(
             if "=" in line:
                 key, _, value = line.partition("=")
                 parsed[key] = value
+        # 🔴 The step's own stdout, carried alongside its outputs. Asserting the
+        # log line against the `run:` SOURCE reads the comments too -- and this
+        # step's comments explain the echo, so a source assertion passed with
+        # the echo itself deleted. Measured: that mutation survived the whole
+        # class. What the step PRINTS is the only thing that proves it prints.
+        parsed["_stdout"] = proc.stdout
         return parsed
 
 
@@ -4335,6 +4372,25 @@ class TestWorkflowConfiguration(unittest.TestCase):
         action, model, `--effort max` and `--max-turns 150`, and across **52 successful
         runs** its median is 455s and its **maximum 1244s — 20.7 minutes**. Any job cap
         at or below 21 kills that tail.
+
+        🔴 **THIS repository's own distribution, added BESIDE the inherited one rather
+        than replacing it** -- two measurements from two repositories are two labelled
+        facts, and a recorded measurement is never edited to keep a document tidy.
+        Measured per ATTEMPT, since a re-run adds an attempt to the same run id and a
+        per-run reading undercounts: across **49 successful attempts**, median 543s,
+        p90 818s, **maximum success 868s -- 14m28s**.
+
+        ⚠️ **And here is why that second measurement had to be taken: every figure
+        above was compared against a cap the runner never honoured.** This job ran on
+        `ubuntu-slim`, whose platform ceiling is 15 minutes and cannot be raised from
+        configuration, so "a job cap that clears the measurement" was a true statement
+        about a number nothing read. Five attempts were killed at 15m0s. The job moved
+        to `ubuntu-latest`.
+
+        **This case checks the cap clears the WORKLOAD;
+        :class:`DeclaredJobCapIsEnforceableTests` checks the RUNNER will allow it.
+        Neither implies the other -- this one passed throughout the outage -- which is
+        why both exist.**
         """
 
         job = re.findall(r"^    timeout-minutes: (\d+)", self.workflow, re.M)
@@ -11224,6 +11280,33 @@ class DeclaredJobCapIsEnforceableTests(unittest.TestCase):
                     "it against its runner's ceiling",
                 )
 
+    def test_a_caller_job_really_declares_neither_key(self):
+        """The exemption must be earned, not merely claimed.
+
+        🔴 A 4-space `uses:` switches BOTH checks off for a job. GitHub would
+        reject a job declaring `uses:` beside `runs-on:`, so it is not reachable
+        in a valid workflow -- but this guard cannot tell, and the comment
+        beside the exemption claims it is granted "BY NAME rather than by
+        falling through a condition". This case is what makes that sentence
+        true: a job claiming the exemption is held to the shape justifying it.
+
+        ⚠️ Vacuous today -- this repository has no caller job. §1.3 of the
+        implementation plan commits `ci.yml` to becoming callers, and this is
+        here so the exemption is checked from the first one rather than
+        retrofitted after somebody notices.
+        """
+
+        for job in self._jobs():
+            if not job["caller"]:
+                continue
+            with self.subTest(file=job["file"], job=job["job"]):
+                self.assertIsNone(
+                    job["runner"],
+                    "declares `uses:` AND `runs-on:`; GitHub rejects such a job, "
+                    "and here it silently buys exemption from both checks",
+                )
+                self.assertIsNone(job["timeout"], "declares `uses:` and a cap")
+
     def test_no_job_declares_a_cap_its_runner_will_not_honour(self):
         """The claim this class is for.
 
@@ -11234,6 +11317,11 @@ class DeclaredJobCapIsEnforceableTests(unittest.TestCase):
         that looks correct and buys nothing.
         """
 
+        # ⚠️ The two `continue`s below are NOT the skipping this class's docstring
+        # forbids: a missing cap and an unrecorded runner each already fail in
+        # their own case above, and re-reporting them here would turn one defect
+        # into three failures. Nothing reaches a `continue` without having
+        # already failed something.
         for job in self._jobs():
             if job["caller"] or job["timeout"] is None:
                 continue
@@ -11252,6 +11340,108 @@ class DeclaredJobCapIsEnforceableTests(unittest.TestCase):
                     "does not declare anywhere",
                 )
 
+
+class WorkflowJobParserTests(unittest.TestCase):
+    """The parser behind the ceiling guard, on spellings this tree does not use.
+
+    🔴 **Every case here is a way the guard could have gone hollow while staying
+    green**, so they are driven against written files rather than left to the
+    mutation battery: a mutation proves a check fires today, a committed case
+    keeps proving it.
+
+    ⚠️ The parser reads block-style YAML with a regex, because this suite runs on
+    a bare interpreter with no dependency install. That is a real limit, and the
+    rule that makes it safe is **refuse what you cannot resolve** -- never skip.
+    """
+
+    def _write(self, body):
+        """Write a throwaway workflow and parse it.
+
+        Args:
+            body: The file's whole text.
+
+        Returns:
+            The parsed job dicts.
+        """
+
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        path = Path(tmp.name) / "throwaway.yml"
+        path.write_text(body, encoding="utf-8")
+        return _declared_jobs(path)
+
+    HEAD = "name: T\non:\n  workflow_dispatch:\njobs:\n"
+
+    def test_a_trailing_comment_is_not_part_of_the_runner_label(self):
+        """`runs-on: ubuntu-slim  # cheap` is legal and names a known runner.
+
+        Without the strip it reads as the label ``'ubuntu-slim  # cheap'`` and
+        the guard tells the author to add a comment string to the ceiling
+        table -- a failure, but for a reason that sends them the wrong way.
+        """
+
+        jobs = self._write(
+            self.HEAD + "  a:\n    runs-on: ubuntu-slim  # cheap\n    timeout-minutes: 5\n"
+        )
+        self.assertEqual(jobs[0]["runner"], "ubuntu-slim")
+
+    def test_a_flow_mapping_job_is_refused_rather_than_skipped(self):
+        """🔴 The escape that made every check pass on a 99-minute cap.
+
+        `a: {runs-on: ubuntu-slim, timeout-minutes: 99}` is legal YAML that
+        GitHub accepts. The job-mark pattern is end-anchored, so it matched
+        nothing and the job vanished from the sweep -- leaving the recorded job
+        set intact and the whole class green with an unenforceable cap declared
+        on a capped runner. Measured before the fix.
+        """
+
+        with self.assertRaises(AssertionError) as caught:
+            self._write(self.HEAD + "  a: {runs-on: ubuntu-slim, timeout-minutes: 99}\n")
+        self.assertIn("cannot resolve", str(caught.exception))
+
+    def test_a_quoted_job_key_is_refused_rather_than_skipped(self):
+        """It used to fail only by accident, which is not the same as being caught.
+
+        A quoted key did not match the mark pattern either, so its body lines
+        were attributed to the PREVIOUS job -- which happened to trip a
+        different check. Depending on that is depending on the order of the
+        jobs in the file.
+        """
+
+        with self.assertRaises(AssertionError):
+            self._write(
+                self.HEAD + '  "a":\n    runs-on: ubuntu-slim\n    timeout-minutes: 5\n'
+            )
+
+    def test_a_step_level_timeout_is_not_read_as_a_job_cap(self):
+        """Eight spaces, not four. Reading one as the other invents a cap."""
+
+        jobs = self._write(
+            self.HEAD
+            + "  a:\n    runs-on: ubuntu-latest\n    steps:\n"
+            + "      - run: true\n        timeout-minutes: 3\n"
+        )
+        self.assertIsNone(jobs[0]["timeout"])
+
+    def test_a_caller_job_is_recognised_as_one(self):
+        """The exemption exists for this shape and no other."""
+
+        jobs = self._write(self.HEAD + "  a:\n    uses: ./.github/workflows/x.yml\n")
+        self.assertTrue(jobs[0]["caller"])
+        self.assertIsNone(jobs[0]["runner"])
+
+    def test_top_level_keys_are_not_mistaken_for_jobs(self):
+        """`on:`, `env:`, `permissions:` and `concurrency:` all have 2-space children.
+
+        The sweep is bounded to the `jobs:` block for exactly this reason; an
+        unbounded one reads `workflow_dispatch:` as a job with no runner.
+        """
+
+        jobs = self._write(
+            "name: T\non:\n  workflow_dispatch:\nenv:\n  X: '1'\n"
+            "jobs:\n  a:\n    runs-on: ubuntu-latest\n    timeout-minutes: 5\n"
+        )
+        self.assertEqual([job["job"] for job in jobs], ["a"])
 
 class NoDocumentMisdescribesTheSlimRunnerTests(unittest.TestCase):
     """`ubuntu-slim` is one of GitHub's standard public labels. Four files said otherwise.
@@ -11294,8 +11484,60 @@ class NoDocumentMisdescribesTheSlimRunnerTests(unittest.TestCase):
     #: leak guard does.
     MARKER = "noqa: runner-claim"
 
+    def _root(self):
+        """Return the directory both the sweep and its control walk.
+
+        🔴 **One expression, used by both, deliberately.** The control below
+        exists to prove the sweep reached real files; when each computed its own
+        root, moving the sweep's left the control green and the survivor was
+        measured. A control that cannot see the thing it controls is not one.
+
+        Returns:
+            The `.github/` directory this suite lives under.
+        """
+
+        return Path(__file__).resolve().parents[2]
+
+    def test_the_rule_recognises_the_claim_it_forbids(self):
+        """🔴 The control the sweep cannot give itself.
+
+        The check below asserts an EMPTY list. A mistyped pattern, or a move
+        that leaves `parents[2]` pointing somewhere other than `.github`, passes
+        it for ever on a walk that saw nothing. The leak guard this class models
+        itself on carries two such controls; the first version of this one
+        carried none.
+        """
+
+        # These three lines state the shapes the rule forbids, so the sweep reads
+        # them as offences unless suppressed -- the same self-match the leak
+        # guard handles the same way. Marked per line, so editing this case
+        # cannot silently disable the sweep.
+        self.assertRegex("an organisation-configured runner", self.CLAIM)  # noqa: runner-claim
+        self.assertRegex("an organization-configured runner", self.CLAIM)  # noqa: runner-claim
+        self.assertNotRegex("a GitHub-hosted standard label", self.CLAIM)
+
+    def test_the_marker_suppresses_a_deliberate_match(self):
+        """The escape hatch is exercised, or it is only a comment.
+
+        Nothing in the tree needs it today, so without this the marker could
+        stop working and the first person to need it finds out the hard way.
+        """
+
+        line = "an organisation-configured one  # noqa: runner-claim"
+        self.assertRegex(line, self.CLAIM)
+        self.assertIn(self.MARKER, line)
+
+    def test_the_sweep_actually_reaches_the_files_it_claims_to(self):
+        """A walk that found nothing satisfies an empty-offences assertion."""
+
+        root = self._root()
+        seen = {path.name for path in root.rglob("*") if path.is_file()}
+        for expected in ("claude-code-review.yml", "ci.md", "README.md"):
+            with self.subTest(file=expected):
+                self.assertIn(expected, seen)
+
     def test_no_file_under_dot_github_misdescribes_the_label(self):
-        root = Path(__file__).resolve().parents[2]
+        root = self._root()
         offences = []
         for path in sorted(root.rglob("*")):
             if not path.is_file() or "__pycache__" in path.parts:
@@ -11511,12 +11753,21 @@ class ResolveSurvivesCancellationTests(unittest.TestCase):
         Which of `success`/`failure`/`cancelled` a cap kill presents is a fact
         about GitHub that this repository can only learn by observing one. The
         log line is how the next occurrence answers it without anyone
-        re-deriving the question.
+        re-deriving the question, so it is a criterion rather than a courtesy.
+
+        🔴 **Asserted against the step's EXECUTED stdout, not its source.** The
+        first version of this case read the `run:` block and looked for the
+        strings -- but the block carries a comment explaining the echo, so
+        deleting the echo itself left the case green. Measured: that mutation
+        survived. It is the same trap
+        :class:`OutcomeChainCancellationWiringTests` documents for the `if:`
+        reader, missed one class over for the `run:` reader.
         """
 
-        script = _workflow_step_script("Resolve outcome")
-        self.assertIn("JOB_STATUS", script)
-        self.assertIn("job_status=", script)
+        self.assertIn(
+            "job_status=cancelled", resolve_outcome(job_status="cancelled")["_stdout"]
+        )
+        self.assertIn("job_status=<unset>", resolve_outcome(status="ok")["_stdout"])
 
 
 class OutcomeChainCancellationWiringTests(unittest.TestCase):
@@ -11555,6 +11806,13 @@ class OutcomeChainCancellationWiringTests(unittest.TestCase):
         therefore still has no pull-request-visible surface. It has none today
         either. What changed is that the run summary stopped telling the reader
         to go and find a configuration bug that does not exist.
+
+        ⚠️ **`cancelled()` is forbidden here too, not only `always()`.** The
+        requirement is about behaviour -- may this step begin running on a
+        cancellation -- and `if: cancelled()`, or `failure() || cancelled()`,
+        starts on exactly the supersede this guard exists to keep quiet while
+        satisfying an `always()`-only assertion. Forbidding one spelling of a
+        behaviour is not forbidding the behaviour.
         """
 
         for name in (
@@ -11563,7 +11821,12 @@ class OutcomeChainCancellationWiringTests(unittest.TestCase):
             "Fail when no review was produced",
         ):
             with self.subTest(step=name):
-                self.assertNotIn("always()", _step_condition(name))
+                self.assertNotRegex(
+                    _step_condition(name),
+                    r"always\(\)|cancelled\(\)",
+                    "this step would begin running on a cancellation, so a "
+                    "superseded push comments or annotates once per push",
+                )
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/.github/review/tests/test_review_scripts.py
+++ b/.github/review/tests/test_review_scripts.py
@@ -56,6 +56,150 @@ import post_review  # noqa: E402
 import select_rules  # noqa: E402
 
 WORKFLOW = Path(__file__).resolve().parents[2] / "workflows" / "claude-code-review.yml"
+WORKFLOW_DIR = Path(__file__).resolve().parents[2] / "workflows"
+
+#: Platform job ceiling, in minutes, for every runner label this repository is
+#: prepared to name. **These are GitHub's numbers, not this repository's**, which
+#: is why they sit in one table with a source rather than beside each job.
+#:
+#: 🔴 `ubuntu-slim` is a SINGLE-CPU runner, and GitHub's runner reference states
+#: the constraint in one sentence: *"The job timeout for single-CPU runners is 15
+#: minutes. If a job reaches this limit, the job is terminated and fails."* It is
+#: a property of the platform and **cannot be overridden from configuration**, so
+#: a `timeout-minutes:` above it is not a longer budget -- it is a fiction that
+#: nothing reports until a job is killed mid-run.
+#:
+#: 🔴 **That is not hypothetical; it is why this table exists.** The review job
+#: declared `timeout-minutes: 60` on `ubuntu-slim`. Five attempts were killed at
+#: 15m0s over three days on five different pull requests -- job ids 99916228958,
+#: 100274991357, 100287032371, 100714288570 and 100725754347 -- each annotated
+#: *"The job has exceeded the maximum execution time of 15m0s"*, on a
+#: merge-gating check, while every offline check in this file stayed green.
+#: Nothing anywhere paired the two lines, and
+#: `test_the_review_has_no_step_cap_and_a_job_cap_that_clears_the_measurement`
+#: actively required a cap the named runner could never honour.
+#:
+#: 360 is the ordinary GitHub-hosted ceiling (6 hours). 7200 is the self-hosted
+#: one (5 days); the self-hosted labels are kept so a move back does not have to
+#: fight this table, exactly as `KNOWN_RUNNERS` kept them.
+RUNNER_JOB_CEILING_MINUTES = {
+    "ubuntu-slim": 15,
+    "ubuntu-latest": 360,
+    "ubuntu-24.04": 360,
+    "ubuntu-22.04": 360,
+    "[self-hosted, cap-main, noble]": 7200,
+    "[self-hosted, cap-light, noble]": 7200,
+    "[self-hosted, cap-nano, noble]": 7200,
+    "[self-hosted, cap-pico, noble]": 7200,
+}
+
+#: Every job this repository runs, as ``(workflow file name, job id)``.
+#:
+#: 🔴 **Pinned as a SET, not merely swept.** A sweep that finds nothing passes,
+#: and a sweep that silently stops seeing a job passes too -- so a per-job
+#: comparison cannot tell a green run from a hollow one. The set is what notices
+#: a job added without a cap, a job deleted, and a file whose jobs stopped
+#: parsing.
+EXPECTED_JOBS = {
+    ("ci.yml", "review-scripts"),
+    ("ci.yml", "review_replies"),
+    ("claude-code-review.yml", "review"),
+}
+
+#: The workflow files themselves, pinned for the same reason one level up: the
+#: sweep globs rather than enumerates, so a file added later is checked -- and
+#: this set is what fails if one is added, renamed or deleted without a thought.
+EXPECTED_WORKFLOW_FILES = {"ci.yml", "claude-code-review.yml"}
+
+
+def _workflow_files():
+    """Return every workflow file, by glob rather than by enumeration.
+
+    Both extensions, because GitHub accepts either and a `.yaml` file added
+    later must not slip past a `.yml`-only sweep.
+
+    Returns:
+        The paths, sorted by name.
+    """
+
+    found = list(WORKFLOW_DIR.glob("*.yml")) + list(WORKFLOW_DIR.glob("*.yaml"))
+    return sorted(found, key=lambda p: p.name)
+
+
+def _jobs_section(text: str) -> str:
+    """Return the body of the top-level ``jobs:`` mapping.
+
+    🔴 **Bounded rather than swept whole, and that bound is the point.**
+    ``on:``, ``env:``, ``permissions:`` and ``concurrency:`` are all top-level
+    keys with two-space children, so an unbounded sweep for ``^  <name>:`` reads
+    ``pull_request:`` as a job and then reports it has no runner.
+
+    Args:
+        text: The whole workflow file.
+
+    Returns:
+        Everything after ``jobs:`` up to the next top-level key.
+
+    Raises:
+        AssertionError: The file declares no ``jobs:`` block at all.
+    """
+
+    opening = re.search(r"^jobs:[ \t]*$", text, re.M)
+    assert opening is not None, "workflow declares no `jobs:` block"
+    tail = text[opening.end() :]
+    following = re.search(r"^[A-Za-z]", tail, re.M)
+    return tail[: following.start()] if following else tail
+
+
+def _declared_jobs(path):
+    """Parse one workflow file's jobs into what the ceiling check needs.
+
+    Matched with a regex rather than parsed with PyYAML, for the reason the rest
+    of this file gives: the suite runs on a bare interpreter with no dependency
+    install, and importing a third-party module here would make these the only
+    tests that cannot run in their own CI job.
+
+    ⚠️ **Both keys are anchored at exactly four spaces.** A step-level
+    ``timeout-minutes`` sits at eight and must never be read as a job cap, and a
+    ``runs-on:`` inside a comment must never be read at all.
+
+    Args:
+        path: The workflow file.
+
+    Returns:
+        One dict per job with ``file``, ``job``, ``runner``, ``timeout`` and
+        ``caller``. ``runner`` and ``timeout`` are ``None`` when the key is
+        absent *or* spelled in a form this parser does not resolve -- the caller
+        fails on ``None`` rather than skipping, so an unresolvable shape is
+        loud.
+    """
+
+    section = _jobs_section(path.read_text(encoding="utf-8"))
+    marks = [
+        (m.group(1), m.start())
+        for m in re.finditer(r"^  ([A-Za-z_][A-Za-z0-9_-]*):[ \t]*$", section, re.M)
+    ]
+
+    jobs = []
+    for index, (name, start) in enumerate(marks):
+        end = marks[index + 1][1] if index + 1 < len(marks) else len(section)
+        body = section[start:end]
+        runner = re.findall(r"^ {4}runs-on:[ \t]*(\S.*?)[ \t]*$", body, re.M)
+        timeout = re.findall(r"^ {4}timeout-minutes:[ \t]*(\d+)[ \t]*$", body, re.M)
+        jobs.append(
+            {
+                "file": path.name,
+                "job": name,
+                "runner": runner[0] if len(runner) == 1 else None,
+                "timeout": int(timeout[0]) if len(timeout) == 1 else None,
+                # A reusable-workflow call legally declares neither key, so it is
+                # exempted BY NAME rather than by falling through a condition --
+                # the difference between an exemption and a hole.
+                "caller": bool(re.search(r"^ {4}uses:[ \t]*\S", body, re.M)),
+            }
+        )
+    return jobs
+
 REVIEW_DIR = Path(__file__).resolve().parents[1]
 PROMPT = REVIEW_DIR / "REVIEW_PROMPT.md"
 GUIDE = REVIEW_DIR / "REVIEW_GUIDE.md"
@@ -3372,7 +3516,9 @@ def _find_bash() -> str | None:
 BASH = _find_bash()
 
 
-def resolve_outcome(*, status="", available="true", first_status=None, retry_status=""):
+def resolve_outcome(
+    *, status="", available="true", first_status=None, retry_status="", job_status=""
+):
     """Execute the real `Resolve outcome` step and return its outputs.
 
     Module-level rather than a method, because two test classes need it: the
@@ -3385,6 +3531,10 @@ def resolve_outcome(*, status="", available="true", first_status=None, retry_sta
         first_status: Attempt 1's own status. Defaults to ``status``, which is
             what a single-attempt run looks like.
         retry_status: Attempt 2's status, empty when no retry ran.
+        job_status: The `job.status` the step is handed. Defaults to empty,
+            which is what every call written before the cancellation ladder
+            existed passes -- the step reads `${JOB_STATUS:-}` under
+            `set -euo pipefail` precisely so those calls keep working.
 
     Returns:
         The parsed ``$GITHUB_OUTPUT`` as a dict.
@@ -3407,6 +3557,14 @@ def resolve_outcome(*, status="", available="true", first_status=None, retry_sta
             RETRY_STATUS=retry_status,
             GITHUB_OUTPUT=out.as_posix(),
         )
+        # 🔴 **Set only when given, never as an empty default.** An earlier draft
+        # passed `JOB_STATUS=""` always, which left the variable SET on every
+        # call -- so `set -u` had nothing to fire on and the mutation replacing
+        # `${JOB_STATUS:-}` with a bare `$JOB_STATUS` survived the whole
+        # battery. Omitting it is what makes the unset path a real case rather
+        # than a name.
+        if job_status:
+            env["JOB_STATUS"] = job_status
         proc = subprocess.run(
             [BASH, "-c", script], env=env, capture_output=True, text=True
         )
@@ -4081,25 +4239,32 @@ class TestWorkflowConfiguration(unittest.TestCase):
             len(set(budgets)), 1, f"budgets disagree: {sorted(set(budgets))}"
         )
 
-    #: Runner labels this repository is prepared to name. Two families, both
-    #: deliberate:
+    #: Runner labels this repository is prepared to name, **derived from
+    #: :data:`RUNNER_JOB_CEILING_MINUTES` rather than listed again here**.
     #:
-    #: * the GitHub-hosted labels it uses today -- `ubuntu-slim` is the
-    #:   organisation-configured one, the rest are GitHub's own always-available
-    #:   labels and are the fallback when an org label is not offered;
-    #: * the self-hosted capability form the upstream repository uses, kept so a
-    #:   move back does not have to fight this test.
+    #: 🔴 **It was listed twice, and the two records disagreed about what the
+    #: labels mean.** This tuple's comment said `ubuntu-slim` was the one the
+    #: organisation configures and the rest were GitHub's own always-available
+    #: labels. All of them are GitHub's own; `ubuntu-slim` appears in the same
+    #: *"Standard GitHub-hosted runners for public repositories"* table as
+    #: `ubuntu-latest`, and what actually distinguishes it is a 15-minute
+    #: platform job ceiling that no setting can raise. Deriving from the ceiling
+    #: table makes a label unnameable until somebody has recorded what limit it
+    #: carries, which is the fact that mattered and was missing.
+    #:
+    #: ⚠️ **No set-equality assertion accompanies this, deliberately.** Derived
+    #: sets are equal by construction, and a test asserting that would pass
+    #: whatever either side said. The single source is the mechanism; an
+    #: assertion about it would be decoration.
     #:
     #: 🔴 **Spelled out rather than written as `\S+`, and that is the whole point of
     #: the test.** An unknown runner label does not fail loudly on GitHub: the job
     #: QUEUES FOR EVER, with no error, no annotation and no timeout. A pattern
     #: accepting any word would pass a typo straight through into that silence.
-    KNOWN_RUNNERS = (
-        r"ubuntu-slim",
-        r"ubuntu-latest",
-        r"ubuntu-24\.04",
-        r"ubuntu-22\.04",
-        r"\[self-hosted, cap-(?:main|light|nano|pico), noble\]",
+    #: The self-hosted capability labels stay in the ceiling table so a move back
+    #: does not have to fight this test.
+    KNOWN_RUNNERS = tuple(
+        re.escape(label) for label in sorted(RUNNER_JOB_CEILING_MINUTES)
     )
 
     def test_the_review_job_names_a_known_runner_as_a_literal(self):
@@ -4120,9 +4285,19 @@ class TestWorkflowConfiguration(unittest.TestCase):
 
         ⚠️ **What this test CANNOT check, said plainly so a green run is not
         over-read:** whether the label it accepts is actually offered to this
-        repository. `ubuntu-slim` is organisation-configured, so its availability is a
-        property of the org, invisible from inside the repository. This test proves the
-        label is one somebody wrote down on purpose — never that a machine will answer.
+        repository. This test proves the label is one somebody wrote down on purpose —
+        never that a machine will answer.
+
+        🔴 **An earlier version of this paragraph gave the wrong reason**, and the
+        wrong reason is what cost the time. It said `ubuntu-slim` was configured by
+        the organisation, so its availability was a property of the org and invisible
+        from here. It is a standard GitHub-hosted public label, listed in the same
+        table as `ubuntu-latest`. The caveat above survives the correction — no
+        offline check can promise a runner answers — but the *reason* was an invented
+        one, and it sent a documented 15-minute platform ceiling to be hunted for in
+        organisation settings. What separates these labels is their job ceiling, which
+        `DeclaredJobCapIsEnforceableTests` now checks against the cap each job
+        declares.
 
         ⚠️ Matched with a regex rather than parsed, deliberately: this suite runs on a
         bare interpreter with **no dependency install**, so importing PyYAML here would
@@ -5854,10 +6029,14 @@ class ReviewRepliesWiringTests(unittest.TestCase):
     # and post nothing to the pull request: a worse outcome than the wasted spend
     # it was meant to prevent.
     #
-    # Doing it properly needs a third run outcome that `Resolve outcome` produces
-    # and `build_run_summary.py` renders, which is its own change. The `ci.yml`
-    # gate already makes the state unmergeable, which is the requirement that
-    # matters; this was the cost optimisation.
+    # 🔴 **That third run outcome now EXISTS, and this note is corrected rather
+    # than left standing.** The job-cap fix gave `Resolve outcome` an `always()`
+    # and a `job.status` ladder, and `build_run_summary.py` renders a `cancelled`
+    # verdict -- so the mechanism this paragraph said would be "its own change"
+    # has been built, for a different reason. What is still missing is only the
+    # new outcome VALUE for this case and the decision to spend a run on it. The
+    # `ci.yml` gate already makes the state unmergeable, which is the requirement
+    # that matters; this was the cost optimisation.
 
     def test_the_complete_copy_is_written_and_kept(self):
         """🔴 AC16a — `.gitignore` and the artifact upload both name
@@ -10937,6 +11116,454 @@ class NoticeInvocationsAreAcceptedByTheScriptTests(unittest.TestCase):
 
             self.assertIn("Automatic code review failed", out.read_text("utf-8"))
 
+
+class DeclaredJobCapIsEnforceableTests(unittest.TestCase):
+    """A `timeout-minutes:` its runner will not honour is a fiction, not a budget.
+
+    🔴 **This class exists because the repository shipped exactly that for three
+    days, with every check green.** The review job declared 60 minutes on
+    `ubuntu-slim`, whose platform ceiling is 15 and cannot be raised from
+    configuration. Five attempts were killed mid-run on a merge-gating check --
+    see :data:`RUNNER_JOB_CEILING_MINUTES` for the job ids and the annotation
+    they all carry. Two lines four hundred apart in one file contradicted each
+    other and **nothing in this suite paired them**, because every existing check
+    read one line or the other and never both.
+
+    ⚠️ **The failure mode is what makes it worth a guard rather than a comment.**
+    Nothing warns when a workflow declares an unreachable cap: it validates, it
+    runs, and it is killed at a number the file does not mention, with an
+    annotation naming a limit no file in the repository declares. An operator
+    reading the workflow finds 60 and looks anywhere but at the runner.
+
+    ⚠️ **Every check here fails rather than skips on a shape it cannot resolve.**
+    A guard that skips what it does not understand is a guard that quietly stops
+    checking, and this one is being written precisely because a check went hollow
+    without saying so.
+    """
+
+    def _jobs(self):
+        """Return every job in every workflow file, parsed."""
+
+        return [job for path in _workflow_files() for job in _declared_jobs(path)]
+
+    def test_the_workflow_files_are_the_ones_recorded(self):
+        """Globbed, not enumerated -- and then compared against the record.
+
+        The sweep must find files nobody listed, or a workflow added later lands
+        unguarded. The record is what makes a sweep that found *nothing* fail
+        instead of passing with an empty loop.
+        """
+
+        self.assertEqual(
+            {path.name for path in _workflow_files()},
+            EXPECTED_WORKFLOW_FILES,
+            "the set of workflow files moved; every job in a new file needs a "
+            "runner ceiling recorded before it can be checked",
+        )
+
+    def test_the_jobs_are_the_ones_recorded(self):
+        """Pin the SET, not only each member.
+
+        A per-job assertion answers "does this pair agree?" and none of them
+        notices a job that stopped parsing, a job deleted, or a fourth job
+        nobody guarded. Those three are indistinguishable from success without
+        this.
+        """
+
+        self.assertEqual(
+            {(job["file"], job["job"]) for job in self._jobs()},
+            EXPECTED_JOBS,
+            "the set of jobs moved; a job whose `runs-on:` stopped parsing "
+            "disappears from this set rather than failing a check below",
+        )
+
+    def test_every_job_names_a_runner_whose_ceiling_is_recorded(self):
+        """An unrecorded label cannot be checked, so it is refused.
+
+        ⚠️ **This is the clause the CI epic will hit first, deliberately.** A
+        matrix job spells its runner `${{ matrix.os }}`, which resolves to no
+        entry here and fails with the message below rather than being waved
+        through. The ceiling for a matrix runner is a decision worth making when
+        the matrix is written; discovering later that the check went hollow is
+        the expensive order.
+        """
+
+        for job in self._jobs():
+            if job["caller"]:
+                continue
+            with self.subTest(file=job["file"], job=job["job"]):
+                self.assertIsNotNone(
+                    job["runner"],
+                    "declares no `runs-on:` this parser can resolve -- a block "
+                    "sequence, a flow list or a matrix expression reaches here "
+                    "as unresolved, and is refused rather than skipped",
+                )
+                self.assertIn(
+                    job["runner"],
+                    RUNNER_JOB_CEILING_MINUTES,
+                    f"names runner {job['runner']!r}, whose platform job "
+                    "ceiling is not recorded; add it to "
+                    "RUNNER_JOB_CEILING_MINUTES with its documented limit",
+                )
+
+    def test_every_job_declares_a_cap(self):
+        """A job with no cap escapes the ceiling check entirely.
+
+        Not a style rule: an uncapped job is checked against nothing, so
+        omitting the key is the one edit that makes the check below vacuous
+        while leaving it green.
+        """
+
+        for job in self._jobs():
+            if job["caller"]:
+                continue
+            with self.subTest(file=job["file"], job=job["job"]):
+                self.assertIsNotNone(
+                    job["timeout"],
+                    "declares no job-level `timeout-minutes:`, so nothing pairs "
+                    "it against its runner's ceiling",
+                )
+
+    def test_no_job_declares_a_cap_its_runner_will_not_honour(self):
+        """The claim this class is for.
+
+        🔴 **Strictly below the ceiling, not at or below.** A cap equal to the
+        ceiling means the file and the platform kill the job at the same
+        instant, so the declared number could never produce a diagnosis of its
+        own -- which is the whole reason to declare one. Equality is the shape
+        that looks correct and buys nothing.
+        """
+
+        for job in self._jobs():
+            if job["caller"] or job["timeout"] is None:
+                continue
+            ceiling = RUNNER_JOB_CEILING_MINUTES.get(job["runner"])
+            if ceiling is None:
+                continue
+            with self.subTest(file=job["file"], job=job["job"]):
+                self.assertLess(
+                    job["timeout"],
+                    ceiling,
+                    f"declares timeout-minutes: {job['timeout']} on runner "
+                    f"{job['runner']!r}, whose platform ceiling is {ceiling} "
+                    "minutes and cannot be raised from configuration; the "
+                    "declared number is a fiction and the job dies at the "
+                    "ceiling with an annotation naming a limit this repository "
+                    "does not declare anywhere",
+                )
+
+
+class NoDocumentMisdescribesTheSlimRunnerTests(unittest.TestCase):
+    """`ubuntu-slim` is one of GitHub's standard public labels. Four files said otherwise.
+
+    🔴 **Believing the label was granted by the organisation is why a platform
+    limit was attributed to an org setting and never looked up.** The workflow's
+    own comment denied that the label is one of GitHub's standard public ones and
+    called it something the org configures, whose availability could not be
+    checked from inside the file; the same sentence appeared twice in this suite
+    and once in the review README. All four are false. The label is listed in
+    GitHub's *"Standard GitHub-hosted runners for public repositories"* table,
+    every job on it reports `runner_group_name: "GitHub Actions"`, and its
+    15-minute job ceiling is a documented platform limit rather than a setting
+    anyone here can raise.
+
+    ⚠️ **The claim is PARAPHRASED above and never quoted**, following the
+    convention this repository already uses for retired phrasings: this guard
+    reads every file under `.github/` line by line, so quoting the sentence would
+    reintroduce it as far as the check can tell. The pattern below is the only
+    literal, and it does not match its own source.
+
+    ⚠️ **A guard rather than the grep that found them, because this file already
+    records the partial-fix regression.** The identical sentence about
+    self-hosted runners was corrected in `rules/ci.md` and survived in the
+    parallel block in the workflow; the automated review caught it on the next
+    round. A one-time grep is an act, not an invariant.
+
+    Walked rather than enumerated, for the same reason the leak guard walks: an
+    enumerated list guards the files somebody thought of, and the next document
+    added lands unguarded while the guard still passes.
+    """
+
+    #: Both spellings, since the tree writes British English and the next author
+    #: may not. Nothing else in this repository is described this way, so the
+    #: phrase alone is the offence -- no proximity window is needed, and a
+    #: window is what made an earlier draft of this guard report its own source.
+    CLAIM = re.compile(r"organi[sz]ation-configured")
+
+    #: Suppress a deliberate match with this marker on the line, exactly as the
+    #: leak guard does.
+    MARKER = "noqa: runner-claim"
+
+    def test_no_file_under_dot_github_misdescribes_the_label(self):
+        root = Path(__file__).resolve().parents[2]
+        offences = []
+        for path in sorted(root.rglob("*")):
+            if not path.is_file() or "__pycache__" in path.parts:
+                continue
+            try:
+                text = path.read_text(encoding="utf-8")
+            except (UnicodeDecodeError, OSError):
+                # A binary file cannot carry a reviewable claim, and failing on
+                # one would make this guard about file types.
+                continue
+            for lineno, line in enumerate(text.splitlines(), 1):
+                if self.MARKER in line:
+                    continue
+                if self.CLAIM.search(line):
+                    offences.append(
+                        f"{path.relative_to(root.parent).as_posix()}:{lineno}: "
+                        f"{line.strip()[:100]}"
+                    )
+
+        self.assertFalse(
+            offences,
+            "`ubuntu-slim` is a STANDARD GitHub-hosted public label, and its "
+            "15-minute job ceiling is a platform limit rather than anything the "
+            "organisation sets. Rewrite each of these rather than deleting the "
+            "sentence, so the reasoning survives:\n  " + "\n  ".join(offences),
+        )
+
+class CancelledRunIsNotAMisconfigurationTests(unittest.TestCase):
+    """A run that was cut short must not be reported as a broken workflow.
+
+    🔴 **This is the surface a killed run actually presented, measured.** On job
+    100714288570 the job cap fired, `Resolve outcome` was skipped -- it carried
+    no `if:`, so GitHub applied the implicit `success()` -- and `Write run
+    summary`, which does carry `always()`, fell back to its
+    `--result "${RESULT:-fatal}"` default. The log line reads
+    `run summary written: result=fatal, tiers=1`, and the reader was told:
+    *"Review failed -- the workflow needs fixing ... The failure is in the
+    workflow configuration, not in the change under review."*
+
+    **That is a wrong instruction, not merely a wrong verdict.** The correct
+    action after a cap kill is precisely to re-run, and the summary sent the
+    reader to look for a configuration bug that did not exist. Two agents were
+    sent to debug a healthy workflow by the sibling version of this message.
+
+    ⚠️ **The vocabulary is closed here, not merely extended.** `--result` had no
+    `choices` and `_headline` ended in a bare fall-through, so *every*
+    unrecognised value rendered the misdirection -- adding one branch would have
+    left the class of defect live and fixed one instance of it. The sibling
+    module made exactly this fix and recorded why; this follows it.
+    """
+
+    def test_a_cancelled_run_is_reported_as_unfinished(self):
+        body = build_run_summary.build("cancelled", "", [])
+        self.assertIn("did not finish", body.lower())
+
+    def test_a_cancelled_run_tells_the_reader_to_rerun(self):
+        """The one sentence the killed runs needed and did not get."""
+
+        body = build_run_summary.build("cancelled", "", [])
+        self.assertIn("re-run", body.lower())
+
+    def test_a_cancelled_run_does_not_blame_the_workflow(self):
+        """Asserted by the exact strings an operator acted on.
+
+        Not a paraphrase: these two are what sent somebody looking for a
+        configuration fault, so they are what must be absent.
+        """
+
+        body = build_run_summary.build("cancelled", "", [])
+        self.assertNotIn("the workflow needs fixing", body)
+        self.assertNotIn("workflow configuration", body)
+
+    def test_an_unrecognised_result_raises_rather_than_blaming_the_workflow(self):
+        """The class, not the instance.
+
+        A bare fall-through means any future outcome -- or a typo -- renders
+        "the workflow needs fixing" about a run nobody classified. Refusing is
+        louder than a plausible wrong answer.
+        """
+
+        with self.assertRaises(ValueError):
+            build_run_summary.build("timed-out", "", [])
+
+    def test_the_cli_keeps_the_result_vocabulary_closed(self):
+        """`--result` is fed Resolve's alphabet; a value outside it is a defect.
+
+        ⚠️ `--out` points into a temporary directory even though nothing should
+        reach it: an assertion about a refusal must not depend on the refusal
+        working in order to stay clean.
+        """
+
+        stderr = io.StringIO()
+        with tempfile.TemporaryDirectory() as tmp:
+            out = str(Path(tmp) / "unreached.md")
+            argv = sys.argv
+            sys.argv = [
+                "build_run_summary.py",
+                "--result",
+                "timed-out",
+                "--out",
+                out,
+            ]
+            try:
+                with contextlib.redirect_stderr(stderr), self.assertRaises(SystemExit):
+                    build_run_summary.main()
+            finally:
+                sys.argv = argv
+            self.assertFalse(Path(out).exists(), "a refused render wrote a file")
+        self.assertIn("invalid choice", stderr.getvalue())
+
+    def test_the_settled_outcomes_render_unchanged(self):
+        """The negative control: closing the vocabulary must move nothing else."""
+
+        self.assertIn("Review posted", build_run_summary.build("ok", "Kitty", []))
+        self.assertIn(
+            "provider was unavailable", build_run_summary.build("exhausted", "", [])
+        )
+        self.assertIn(
+            "the workflow needs fixing", build_run_summary.build("fatal", "", [])
+        )
+
+@unittest.skipIf(BASH is None, "bash is required to run workflow steps")
+class ResolveSurvivesCancellationTests(unittest.TestCase):
+    """`Resolve outcome` must answer for every job status, not only a healthy one.
+
+    🔴 **It used to answer for one.** The step carried no `if:` at all, so GitHub
+    applied the implicit `success()` and a cancelled job skipped it entirely --
+    leaving `Write run summary`, which does carry `always()`, to fall back to
+    `${RESULT:-fatal}` and announce a broken workflow about a run that was merely
+    killed at a cap. Measured on five jobs; see
+    :class:`CancelledRunIsNotAMisconfigurationTests` for the log line.
+
+    🔴 **Moving to `always()` is what makes the FAILURE case matter, and the
+    first draft of this change missed it.** `job.status` has three values. With a
+    bare `always()` and only a cancellation branch, a run whose `Interpret
+    result` reported `ok` and whose next step then failed hard would resolve
+    `ok`, and the summary would render *"Review posted -- the pull request was
+    reviewed"* beside a red required check, with `Post review` -- implicit
+    `success()` -- never having run. Today's defect is a wrong instruction; that
+    draft would have replaced it with a **false success**, which this suite
+    already names as the worst outcome it guards against. Hence a case per value.
+
+    ⚠️ **`failure` resolves `fatal` deliberately, because that is what happens
+    today.** Whether a cap kill presents to an `always()` step as `cancelled` or
+    as `failure` is a runtime detail of GitHub's, and this repository's evidence
+    could not settle it before the change: on the killed job the step was
+    skipped, which is equally consistent with either. Sending `failure` to the
+    value the `${RESULT:-fatal}` default already produces means a wrong guess can
+    only leave today's behaviour standing -- never invent a success.
+    """
+
+    def test_a_cancelled_job_resolves_as_cancelled(self):
+        outputs = resolve_outcome(status="", job_status="cancelled")
+        self.assertEqual(outputs["result"], "cancelled")
+
+    def test_a_cancellation_outranks_an_attempt_that_reported_ok(self):
+        """The precedence, and the reason it goes this way.
+
+        🔴 `Resolve outcome` runs BEFORE `Build review payload` and `Post
+        review`, so `STATUS=ok` means "an attempt produced a review", never "a
+        review was posted" -- and under cancellation those two steps are
+        skipped. Resolving `ok` here would claim something that demonstrably did
+        not happen.
+
+        ⚠️ Design review proposed the opposite precedence, on the grounds that a
+        `cancelled` verdict would stop `Supersede any stale failure notice` from
+        retracting a stale banner. It cannot: that step carries an implicit
+        `success()`, which is false on ANY cancelled job whatever this output
+        holds. The cost of this direction is one wasted re-run when a cancel
+        lands after a review was already posted, on a check that is red either
+        way.
+        """
+
+        outputs = resolve_outcome(status="ok", job_status="cancelled")
+        self.assertEqual(outputs["result"], "cancelled")
+
+    def test_a_failed_job_resolves_as_fatal(self):
+        """Unchanged behaviour, asserted so the `always()` cannot quietly change it."""
+
+        outputs = resolve_outcome(status="ok", job_status="failure")
+        self.assertEqual(outputs["result"], "fatal")
+
+    def test_a_healthy_job_is_untouched(self):
+        """The negative control: the new ladder must not hijack the good path."""
+
+        outputs = resolve_outcome(status="ok", job_status="success")
+        self.assertEqual(outputs["result"], "ok")
+        self.assertEqual(outputs["provider"], "Kitty Bridge")
+
+    def test_an_unset_job_status_is_untouched(self):
+        """The step runs under `set -euo pipefail`, so the read must be guarded.
+
+        🔴 **This case is only real because the harness OMITS the variable
+        rather than setting it empty.** With `JOB_STATUS=""` always exported,
+        `set -u` has nothing to fire on and a bare `$JOB_STATUS` passes
+        everything -- which is exactly what happened to the first version of
+        this battery: the mutation survived, and the guard the code carries was
+        justified by nothing.
+
+        ⚠️ In production the variable is always present, because `job.status`
+        yields a string into the step's `env:` block. What this pins is the
+        weaker but load-bearing claim: the step is readable by a caller that
+        knows nothing about the ladder, which is every existing call in this
+        file.
+        """
+
+        outputs = resolve_outcome(status="exhausted")
+        self.assertEqual(outputs["result"], "exhausted")
+
+    def test_the_step_reports_the_job_status_it_saw(self):
+        """Echoed so a future cancellation records the value.
+
+        Which of `success`/`failure`/`cancelled` a cap kill presents is a fact
+        about GitHub that this repository can only learn by observing one. The
+        log line is how the next occurrence answers it without anyone
+        re-deriving the question.
+        """
+
+        script = _workflow_step_script("Resolve outcome")
+        self.assertIn("JOB_STATUS", script)
+        self.assertIn("job_status=", script)
+
+
+class OutcomeChainCancellationWiringTests(unittest.TestCase):
+    """Which steps may begin running on a cancellation, and which may not.
+
+    🔴 **Asserted on each step's parsed `if:` expression, never on its body.**
+    The step reader in this file returns the surrounding comments too, so a
+    comment saying a step deliberately carries no `always()` would satisfy an
+    assertion about the body -- and a comment written above a step's `- name:`
+    is attributed by that parser to the PREVIOUS step. Both are ways to pass
+    while checking nothing.
+    """
+
+    def test_resolve_outcome_runs_when_the_job_is_cancelled(self):
+        """Without this the whole repair is unreachable.
+
+        ⚠️ A **bare** `always()` is safe here, against the precedent elsewhere in
+        this file that a bare `always()` also fires when the job died before the
+        checkout: this step reads no repository file and shells out to nothing.
+        It computes from step outputs, which are empty rather than missing.
+        """
+
+        self.assertIn("always()", _step_condition("Resolve outcome"))
+
+    def test_no_step_that_speaks_to_the_pull_request_runs_on_a_cancellation(self):
+        """🔴 The workflow cancels an in-flight review on every new push.
+
+        `concurrency.cancel-in-progress: true` makes a superseded cancellation
+        routine -- one per rapid push sequence. Giving these steps `always()`
+        would post a failure notice, and emit an `::error::` annotation, on every
+        one of those. That is the noise the concurrency group exists to prevent,
+        so the repair stops at the two surfaces that are per-run and silent: the
+        job summary and the check's own conclusion.
+
+        ⚠️ **Accepted residual, recorded rather than implied:** a cap kill
+        therefore still has no pull-request-visible surface. It has none today
+        either. What changed is that the run summary stopped telling the reader
+        to go and find a configuration bug that does not exist.
+        """
+
+        for name in (
+            "Build failure notice",
+            "Post failure notice",
+            "Fail when no review was produced",
+        ):
+            with self.subTest(step=name):
+                self.assertNotIn("always()", _step_condition(name))
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/.github/review/tests/test_review_scripts.py
+++ b/.github/review/tests/test_review_scripts.py
@@ -210,7 +210,15 @@ def _declared_jobs(path):
         runner = re.findall(
             r"^ {4}runs-on:[ \t]*(\S.*?)[ \t]*(?:#.*)?$", body, re.M
         )
-        timeout = re.findall(r"^ {4}timeout-minutes:[ \t]*(\d+)[ \t]*$", body, re.M)
+        # Same trailing-comment tolerance as `runs-on` above, and for a sharper
+        # reason: an unstripped `timeout-minutes: 10  # reason` matches nothing,
+        # so the cap reads as ABSENT and the failure says "declares no
+        # job-level `timeout-minutes:`" about a line that is right there. The
+        # two patterns must agree, or the parser is lenient about the runner and
+        # strict about the cap for no stated reason.
+        timeout = re.findall(
+            r"^ {4}timeout-minutes:[ \t]*(\d+)[ \t]*(?:#.*)?$", body, re.M
+        )
         jobs.append(
             {
                 "file": path.name,
@@ -11384,6 +11392,22 @@ class WorkflowJobParserTests(unittest.TestCase):
             self.HEAD + "  a:\n    runs-on: ubuntu-slim  # cheap\n    timeout-minutes: 5\n"
         )
         self.assertEqual(jobs[0]["runner"], "ubuntu-slim")
+
+    def test_a_trailing_comment_is_not_part_of_the_cap(self):
+        """The same tolerance as `runs-on`, and a worse failure without it.
+
+        An unstripped `timeout-minutes: 10  # reason` matches nothing, so the
+        cap reads as ABSENT -- and the guard reports "declares no job-level
+        `timeout-minutes:`" about a line the author is looking straight at.
+        The two patterns were inconsistent in the first draft: lenient about the
+        runner, strict about the cap, with no reason for the difference.
+        """
+
+        jobs = self._write(
+            self.HEAD
+            + "  a:\n    runs-on: ubuntu-slim\n    timeout-minutes: 10  # measured\n"
+        )
+        self.assertEqual(jobs[0]["timeout"], 10)
 
     def test_a_flow_mapping_job_is_refused_rather_than_skipped(self):
         """🔴 The escape that made every check pass on a 99-minute cap.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,15 @@ name: CI
 # minutes with no error, no annotation and no timeout. **An unreachable runner label
 # is completely silent** -- if either job here is queued and never starts, suspect
 # the label first; `ubuntu-latest` is the always-available fallback.
+#
+# 🔴 **`ubuntu-slim` IS a standard GitHub-hosted public label, and it carries a hard
+# 15-minute job ceiling.** GitHub's runner reference: *"The job timeout for single-CPU
+# runners is 15 minutes. If a job reaches this limit, the job is terminated and
+# fails."* It cannot be raised from configuration, so any `timeout-minutes` at or above
+# 15 on this label is a fiction. Both jobs below declared 20 and nobody ever saw it,
+# because they finish in well under a minute -- but the review workflow declared 60 on
+# the same label and was killed mid-run five times on a merge-gating check before
+# anyone paired the two lines. `DeclaredJobCapIsEnforceableTests` pairs them now.
 
 on:
   pull_request:
@@ -38,18 +47,31 @@ on:
 
 jobs:
   review-scripts:
-    # The Claude review system's own tests -- 482 of them, covering the rule
+    # The Claude review system's own tests -- 502 of them, covering the rule
     # selector, the result classifier, the failure notices, the prompt redactor,
     # the findings schema and the workflow's own wiring.
     #
     # Pure Python and subprocesses, no service container, no pip install at all --
     # the suite runs in about a second.
     #
-    # Same runner as the review workflow, so both of this repository's workflows
-    # depend on exactly ONE label being available. Two jobs that queue for different
-    # reasons is the shape that wastes an afternoon.
+    # 🔴 **No longer the same runner as the review workflow, and that is a real cost
+    # paid deliberately.** These two jobs and that one used to depend on exactly ONE
+    # label being available, which is a genuinely good property: two jobs that queue
+    # for different reasons is the shape that wastes an afternoon. The review job had
+    # to leave, because its median run is nine minutes against this label's 15-minute
+    # ceiling and it was being killed. It kept the label that always exists
+    # (`ubuntu-latest`), so the pair is now "always available" and "always available",
+    # not one of each.
+    #
+    # These jobs stay because they are exactly what `ubuntu-slim` is documented for --
+    # lightweight, short-running automation. Measured over 40 successful runs: min 22s,
+    # median 35s, **max 207s**.
     runs-on: ubuntu-slim
-    timeout-minutes: 20
+    # 20 was never enforceable on this label; the platform ceiling is 15. 10 is under
+    # the ceiling -- so the declared cap can actually fire, and produce a diagnosis of
+    # its own instead of the platform killing the job at the same instant -- and still
+    # ~2.9x the measured maximum above.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -96,10 +118,13 @@ jobs:
     # there is no pull request to ask about, and a gate that failed when it could
     # not check would turn a manual run into a red check for no reason.
     if: github.event_name == 'pull_request'
-    # One Python script and one `gh` call. Same runner as the job above, for the
-    # same one-label reason.
+    # One Python script and one `gh` call. Same runner as the job above, and the
+    # one-label reasoning there now applies to this pair rather than to all three
+    # jobs in the repository. Measured over 40 successful runs: min 19s, median 29s,
+    # **max 184s**.
     runs-on: ubuntu-slim
-    timeout-minutes: 20
+    # Under the label's 15-minute platform ceiling, for the reason given above.
+    timeout-minutes: 10
     # 🔴 Declared, not inherited. This file has no workflow-level `permissions:`,
     # so a job inherits the organisation default -- and a **read** default grants
     # `contents` and `packages` while leaving `pull-requests` at `none`. Without

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ on:
 
 jobs:
   review-scripts:
-    # The Claude review system's own tests -- 502 of them, covering the rule
+    # The Claude review system's own tests -- 512 of them, covering the rule
     # selector, the result classifier, the failure notices, the prompt redactor,
     # the findings schema and the workflow's own wiring.
     #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ on:
 
 jobs:
   review-scripts:
-    # The Claude review system's own tests -- 512 of them, covering the rule
+    # The Claude review system's own tests -- 513 of them, covering the rule
     # selector, the result classifier, the failure notices, the prompt redactor,
     # the findings schema and the workflow's own wiring.
     #

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -150,6 +150,14 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  # ⚠️ **This number does not move, but the sentence justifying it was written
+  # against a cap that was never enforced.** "Well below `timeout-minutes`" meant well
+  # below 60; the runner actually killed at 15, so 8 minutes was over half of the real
+  # budget and two attempts could never have fitted inside it at all. The runner move
+  # below is what makes the comparison true rather than aspirational. 480000 is
+  # unchanged, and `test_the_api_timeout_is_bounded_well_below_the_job_cap` checks the
+  # ratio against a cap that now exists.
+  #
   # Reserved for the CLI's own read-timeout budget -- the only call a runner
   # makes that is bounded by this number is the Claude CLI itself. Kitty owns
   # its own timeouts in `egress.json`; the Configure step has no budget worth
@@ -246,21 +254,55 @@ jobs:
     # runner in every group a repository can see -- was never claimed either. Nothing
     # claimed it, so that set was empty.
     #
-    # ⚠️ **AN UNREACHABLE LABEL IS SILENT, AND THAT IS THE THING TO REMEMBER HERE.** It
-    # is true of this runner too: if `ubuntu-slim` is not a label this organisation
-    # actually offers, this job queues for ever exactly as the self-hosted one did, and
-    # nothing anywhere says so. `ubuntu-slim` is NOT one of GitHub's standard public
-    # labels (`ubuntu-latest`, `ubuntu-24.04`, `ubuntu-22.04`) -- it is an
-    # organisation-configured runner, so its availability is a property of the org and
-    # cannot be checked from inside this file.
+    # ⚠️ **AN UNREACHABLE LABEL IS SILENT, AND THAT IS STILL THE THING TO REMEMBER
+    # HERE.** A job asking for a label nothing offers queues for ever exactly as the
+    # self-hosted one did, and nothing anywhere says so. `ubuntu-latest` is one of
+    # GitHub's standard public labels and is always available, which is the one property
+    # that cannot be taken away by a settings change somewhere else.
     #
-    # **If this job is queued and never starts, the label is the first thing to
-    # suspect, and `ubuntu-latest` is the one-word fallback that is always available.**
+    # 🔴 **`ubuntu-slim` -> `ubuntu-latest`, and the reason is a HARD PLATFORM CEILING
+    # rather than a preference.** This job ran on `ubuntu-slim` and declared
+    # `timeout-minutes: 60` below. Those two lines were contradictory and nothing said
+    # so. `ubuntu-slim` is a SINGLE-CPU runner, and GitHub's runner reference states the
+    # limit in one sentence: *"The job timeout for single-CPU runners is 15 minutes. If a
+    # job reaches this limit, the job is terminated and fails."* It is a property of the
+    # platform and **cannot be raised from configuration**, so the 60 below was a fiction
+    # for as long as it sat here.
     #
-    # ⚠️ A slim image is also the one most likely to be missing `unzip`, which the
-    # action shells out to. That is what the preflight step below exists for, and it is
-    # now load-bearing rather than defensive -- see its own comment.
-    runs-on: ubuntu-slim
+    # ⚠️ **An earlier version of this comment said the opposite, and that error is what
+    # cost the time.** It claimed `ubuntu-slim` is NOT one of GitHub's standard public
+    # labels and that the org configures it, so its availability could not be checked
+    # from inside this file. Both halves are wrong: the label appears in GitHub's
+    # *"Standard GitHub-hosted runners for public repositories"* table, free and
+    # unlimited on public repositories, and every job on it reported
+    # `runner_group_name: "GitHub Actions"`. Believing the org owned it is why a
+    # documented platform limit was hunted for in organisation settings.
+    #
+    # 🔴 **Measured on this repository before the move, per ATTEMPT rather than per run,
+    # since a re-run adds an attempt to the same run id.** Across 49 successful attempts:
+    # median 543s (9m03s), p90 818s, **maximum success 868s -- 14m28s, thirty-two seconds
+    # inside the ceiling**, with 11 of 49 past twelve minutes. **Five attempts were
+    # killed at 15m0s** over three days on five different pull requests, each annotated
+    # *"The job has exceeded the maximum execution time of 15m0s"*, on a merge-gating
+    # check. This job's normal distribution ran into the ceiling; it was not an unlucky
+    # tail.
+    #
+    # ⚠️ **Declaring an honest 15 would have fixed nothing**, which is worth saying
+    # because it is the cheaper-looking option. The platform already kills at that
+    # instant, so an honest 15 buys a truthful file and no working review -- and the
+    # two-attempt retry this job is built around cannot fit under a 15-minute ceiling at
+    # ANY cap when one median attempt alone is nine minutes.
+    #
+    # `ubuntu-latest` carries 4 CPUs against slim's 1 and the ordinary 6-hour ceiling, so
+    # the cap below becomes enforceable for the first time and the distribution should
+    # shorten as well. `ci.yml` deliberately KEEPS `ubuntu-slim`: two jobs whose slowest
+    # observed run is 207s are exactly the lightweight workload that label is for. The
+    # two workflows therefore no longer share one label, which is a real cost -- see
+    # `ci.yml`, where it is recorded on both jobs.
+    #
+    # ⚠️ The pairing of this label with the cap below is now checked by
+    # `DeclaredJobCapIsEnforceableTests`, so neither line can move without the other.
+    runs-on: ubuntu-latest
     # 🔴 **22 -> 25, and the STEP cap below is deleted (upstream).** This review died at
     # exactly 20m12s against a 20-minute step cap. a sibling repository runs the same
     # model at the same `--effort max` and, at the time, the same turn budget -- 150,
@@ -318,6 +360,17 @@ jobs:
     # that is too TIGHT is the `fatal` misdirection described above -- a wrong
     # instruction, not merely a wrong verdict. So this stays generous until there is a
     # measured distribution from this repository to replace it with.
+    #
+    # 🔴 **60 DID NOT MOVE, and that is the point of the runner change above.** Every
+    # figure in this block was derived against a cap that the runner never honoured: the
+    # enforced ceiling was 15 the whole time, so the 20 -> 22 -> 25 -> 45 -> 60 sequence
+    # was arithmetic about a number nothing read. The arithmetic was right and is kept;
+    # what was wrong was the machine it was written for. On `ubuntu-latest` the platform
+    # ceiling is 6 hours, so this is the first version of this line that means anything.
+    #
+    # ⚠️ Do not "tidy" this back down to fit a slim runner. The pairing is checked --
+    # `DeclaredJobCapIsEnforceableTests` fails if this number reaches a runner's ceiling
+    # -- so a change to either line must state what it did with the other.
     timeout-minutes: 60
     # 🔴 **Same-repository, non-draft pull requests only, and on a PUBLIC repository
     # that is a SECURITY CONTROL rather than a convenience.** In the reference
@@ -846,11 +899,21 @@ jobs:
         # invariant -- a future job that needs a tool and forgets to probe for it fails only
         # when placement is unlucky, and the re-run passes.
         #
-        # 🔴 **MORE load-bearing on `ubuntu-slim`, not less.** The measurement above is from a
-        # heterogeneous self-hosted fleet, where the package was present on one machine and
-        # absent on another. A SLIM image is a different and more predictable version of the
-        # same risk: being slim is precisely a claim that it carries fewer packages than the
-        # full `ubuntu-latest`, and `unzip` is exactly the sort of thing trimmed from one.
+        # 🔴 **The slim-image justification that stood here is FALSIFIED and is corrected
+        # rather than deleted.** It read that the step was more load-bearing on
+        # `ubuntu-slim`, not less, because a slim image carries fewer packages and `unzip`
+        # is the sort of thing trimmed from one. That was true while this job ran there; it
+        # no longer does, and this job is the preflight's only caller. `ubuntu-latest`
+        # carries `unzip` -- the measurement two paragraphs up says so in as many words --
+        # so the step is a no-op here today.
+        #
+        # ⚠️ **It is kept, and the reason it is kept is the one that never depended on the
+        # image.** `unzip` is invoked inside a third-party action two levels down and is
+        # named nowhere in this repository, so no scan of `run:` blocks can find it; the
+        # only thing that catches it is probing for the capabilities this job's ACTIONS
+        # need. That was always the real argument. The slim claim was a second, weaker one
+        # that has now expired, and removing the step because the weaker argument expired
+        # would delete the stronger one with it.
         #
         # ⚠️ It should self-heal here rather than fail: a GitHub-hosted runner gives the job
         # passwordless sudo, so the script installs the package and emits a WARNING. Read
@@ -1272,8 +1335,27 @@ jobs:
 
       - name: Resolve outcome
         id: outcome
+        # 🔴 **`always()`, because without it a cancelled job skips this step and the
+        # run reports the opposite of the truth.** With the implicit `success()` this
+        # step used to carry, a job cap kill left `Write run summary` -- which does
+        # carry `always()` -- to fall back to `${RESULT:-fatal}` and announce that the
+        # workflow was misconfigured and re-running would not help. Measured on five
+        # killed jobs. The correct action after a cap kill is precisely to re-run, so
+        # that was a wrong INSTRUCTION rather than merely a wrong verdict.
+        #
+        # ⚠️ A **bare** `always()` is safe here, though elsewhere in this file it is
+        # deliberately avoided: a bare `always()` also fires when the job died before
+        # the checkout. This step reads no repository file and shells out to nothing --
+        # it computes from step outputs, which are empty rather than missing.
+        if: always()
         shell: bash
         env:
+          # 🔴 **`job.status`, not `cancelled()`.** GitHub's expression reference states
+          # that status check functions are usable "as expressions in `if` conditionals",
+          # and that "outside `if` conditionals, you can use `job.status` to access the
+          # job status". A `cancelled()` here is outside an `if:` and is not supported.
+          # Its three values are `success`, `failure` and `cancelled`.
+          JOB_STATUS: ${{ job.status }}
           # The second attempt's verdict when one ran, the first's otherwise.
           # `||` in a GitHub expression yields the right-hand side when the left
           # is an empty string, and a step that was skipped has empty outputs --
@@ -1318,7 +1400,30 @@ jobs:
 
           PROVIDER=""
 
-          if [ "${STATUS:-}" = "ok" ]; then
+          # The job's own status is read FIRST, because it outranks anything an
+          # attempt reported. `${JOB_STATUS:-}`, not a bare read: this block runs
+          # under `set -euo pipefail`, and the variable is absent on every call the
+          # test harness made before this ladder existed.
+          if [ "${JOB_STATUS:-}" = "cancelled" ]; then
+            # 🔴 A cancellation outranks an `ok` status, and the ordering is the
+            # whole point. This step runs BEFORE `Build review payload` and `Post
+            # review`, so `STATUS=ok` means "an attempt produced a review", never
+            # "a review was posted" -- and under cancellation those two steps are
+            # skipped. Resolving `ok` here would report a review that demonstrably
+            # never reached the pull request.
+            #
+            # Two causes share this branch because both want the same response:
+            # the job cap fired, or a newer push superseded the run.
+            RESULT=cancelled
+          elif [ "${JOB_STATUS:-}" = "failure" ]; then
+            # ⚠️ Unchanged behaviour, stated rather than left to fall through. A
+            # step failed outright, which is what `${RESULT:-fatal}` already
+            # produced when this step was skipped. Deliberate: whether a cap kill
+            # presents here as `cancelled` or as `failure` is a runtime detail of
+            # GitHub's, so routing `failure` to today's answer means a wrong guess
+            # can only leave current behaviour standing, never invent a success.
+            RESULT=fatal
+          elif [ "${STATUS:-}" = "ok" ]; then
             RESULT=ok
             PROVIDER="${NAME}"
           elif [ "${STATUS:-}" = "fatal" ]; then
@@ -1351,7 +1456,9 @@ jobs:
           echo "result=${RESULT}" >> "$GITHUB_OUTPUT"
           echo "provider=${PROVIDER}" >> "$GITHUB_OUTPUT"
           echo "attempts=${ATTEMPTS}" >> "$GITHUB_OUTPUT"
-          echo "Resolved: ${RESULT} after ${ATTEMPTS} attempt(s) (attempted: ${TIERS:-none})${PROVIDER:+, produced by ${PROVIDER}}"
+          # `job_status=` is echoed so the next cancellation RECORDS which value
+          # GitHub presented, instead of leaving the question to be re-derived.
+          echo "Resolved: ${RESULT} after ${ATTEMPTS} attempt(s) (attempted: ${TIERS:-none})${PROVIDER:+, produced by ${PROVIDER}}, job_status=${JOB_STATUS:-<unset>}"
 
       - name: Build review payload
         if: steps.outcome.outputs.result == 'ok'
@@ -1564,6 +1671,26 @@ jobs:
       # Both failure paths say so on the pull request. Nobody should have to open
       # the Actions tab to find out that no review happened.
 
+      # 🔴 **These three keep their implicit `success()` DELIBERATELY, and the reason
+      # is the concurrency group at the top of this file.** `cancel-in-progress: true`
+      # cancels an in-flight review on every new push, so a superseded cancellation is
+      # routine -- one per rapid push sequence. Giving these `always()` would post a
+      # failure comment and emit an `::error::` annotation on every one of them, which
+      # is exactly the noise that concurrency group exists to prevent. `Resolve
+      # outcome` above got `always()`; these did not, and that asymmetry IS the
+      # decision rather than an oversight.
+      #
+      # ⚠️ **Accepted residual:** a job cap kill therefore has no pull-request-visible
+      # surface. It had none before this change either -- all three were skipped. What
+      # changed is that the run summary stopped telling the reader the workflow was
+      # broken and re-running would not help.
+      #
+      # ⚠️ **A coupling that is easy to miss.** `Resolve outcome` can now emit
+      # `cancelled`, and `build_failure_notice.py` keeps a closed `exhausted | fatal`
+      # vocabulary that would reject it with argparse exit 2. That is unreachable only
+      # while these steps stay on `success()`. `OutcomeChainCancellationWiringTests` is
+      # what keeps it unreachable; do not add `always()` here without extending that
+      # script's vocabulary first.
       - name: Build failure notice
         if: steps.outcome.outputs.result != 'ok'
         shell: bash

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1355,6 +1355,24 @@ jobs:
           # and that "outside `if` conditionals, you can use `job.status` to access the
           # job status". A `cancelled()` here is outside an `if:` and is not supported.
           # Its three values are `success`, `failure` and `cancelled`.
+          #
+          # 🔴 **MEASURED, because reading could not settle it and the whole repair
+          # turns on the answer.** GitHub's own wording is split: the timeout
+          # documentation says a job exceeding its cap is *cancelled*, while the
+          # single-CPU runner reference says such a job "is terminated and fails". A
+          # concurrency supersede is NOT a substitute for the measurement -- it is a
+          # different cancellation path, so observing one answers nothing about the
+          # other. So a throwaway workflow was run with `timeout-minutes: 1` and a
+          # 120-second step, on `ubuntu-latest`, and an `always()` step echoed the
+          # value. Run 33901140237 on 2026-09-04, annotated *"The job has exceeded the
+          # maximum execution time of 1m0s"* -- the same wording as the five production
+          # kills -- printed:
+          #
+          #     MEASURED job_status=cancelled
+          #
+          # So a cap kill takes the `cancelled` branch below, and the `always()` step
+          # ran after the kill. The `failure` branch is the fail-safe, not the
+          # expected path.
           JOB_STATUS: ${{ job.status }}
           # The second attempt's verdict when one ran, the first's otherwise.
           # `||` in a GitHub expression yields the right-hand side when the left

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -1798,6 +1798,43 @@ on:
 
 Add `ready_for_review` if draft PRs are filtered out.
 
+**A declared `timeout-minutes` is only real if the runner will honour it.**
+Added 2026-09-04, after the `review` job in `.github/workflows/claude-code-review.yml`
+declared `timeout-minutes: 60` on `ubuntu-slim` and was killed mid-run five times
+on a merge-gating check. `ubuntu-slim` is a **single-CPU** GitHub-hosted runner,
+and GitHub's runner reference states the constraint in one sentence: *"The job
+timeout for single-CPU runners is 15 minutes. If a job reaches this limit, the
+job is terminated and fails."* It is a platform property and **cannot be raised
+from configuration**, so a larger number is not a larger budget — it is a fiction
+that nothing reports until a job dies at a limit no file in the repository
+mentions. Ordinary GitHub-hosted labels are 6 hours; self-hosted runners are
+5 days.
+
+Two consequences for the jobs in this table:
+
+1. **Every job declares a `timeout-minutes` strictly below its runner's ceiling.**
+   Strictly, not at-or-below: a cap equal to the ceiling means the file and the
+   platform kill at the same instant, so the declared number could never produce a
+   diagnosis of its own. This is checked by
+   `DeclaredJobCapIsEnforceableTests` in `.github/review/tests/test_review_scripts.py`,
+   which pairs each job's `runs-on` against a table of platform ceilings and fails
+   on a cap at or above one, an unrecorded label, a missing cap, or a `runs-on`
+   it cannot resolve. That guard fails rather than skips on a shape it does not
+   understand, which is deliberate: a guard that skips what it does not
+   understand is a guard that quietly stops checking.
+2. **A matrix runner must carry a recorded ceiling before it can be named.**
+   `fast` and `subsystem` above run on Windows + Linux, whose canonical spelling
+   is `runs-on: ${{ matrix.os }}`. That resolves to no entry in the ceiling table
+   and will fail the guard on E4-1's first commit, by design — the ceiling for a
+   matrix runner is a decision worth making when the matrix is written rather
+   than discovered later, when the check has gone hollow. E4-1 extends the table;
+   the failure message names it.
+
+A **caller job** — one that only declares `uses:` to call a reusable workflow, as
+§1.3 of the implementation plan requires `ci.yml`'s jobs to become — legally
+declares neither `runs-on` nor `timeout-minutes` and is exempt from both, by name
+in the guard rather than by falling through a condition.
+
 **One stable required check.** Requiring every matrix-generated check by name is
 brittle: adding a Python or `mcp` axis renames the checks and silently drops the
 old names from branch protection. `ci-required` runs no tests, declares `needs`
@@ -1817,6 +1854,8 @@ ci-required:
   if: ${{ always() }}          # without this the job is skipped, not failed
   needs: [fast, fast-extras, subsystem, chromium, package, types, coverage]
   runs-on: ubuntu-latest
+  timeout-minutes: 10          # every job declares one, strictly below its
+                               # runner's ceiling -- see the paragraph above
   steps:
     - name: Fail unless every dependency succeeded
       if: >-

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -747,7 +747,8 @@ typo'd selector fails the job.
   `timeout-minutes: 60` on `ubuntu-slim`, whose ceiling is 15 and cannot be
   raised from configuration, and was killed mid-run five times on a merge-gating
   check while every offline check stayed green. §10.3 carries the rule.
-  §10.3's complete trigger list; one job selecting
+
+  The step itself: §10.3's complete trigger list; one job selecting
   `--ignore=tests/package -m "not live and not chromium and not package"` on both
   platforms — deliberately **including** `subsystem`, per TEST_SUITE §8B; and
   `ci-required` with `if: always()` asserting every dependency is `success`.

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -735,7 +735,19 @@ from that selection**; a job whose selector silently stops matching is otherwise
 green while running nothing. Each job's acceptance includes: a deliberately
 typo'd selector fails the job.
 
-- **E4-1.** §10.3's complete trigger list; one job selecting
+- **E4-1.** **Extend the runner-ceiling table before this lands, or the branch is
+  red.** A CI defect fixed on 2026-09-04 added `DeclaredJobCapIsEnforceableTests`
+  to `.github/review/tests/test_review_scripts.py`: it pairs every job's
+  `runs-on` against a table of platform job ceilings and fails on a cap at or
+  above one, an unrecorded label, a missing `timeout-minutes`, or a `runs-on` it
+  cannot resolve. This step's matrix job spells its runner `${{ matrix.os }}`,
+  which resolves to no entry and therefore fails — deliberately, so the ceiling
+  for a matrix runner is decided when the matrix is written. The guard's message
+  names the table. The provoking defect: the `review` job declared
+  `timeout-minutes: 60` on `ubuntu-slim`, whose ceiling is 15 and cannot be
+  raised from configuration, and was killed mid-run five times on a merge-gating
+  check while every offline check stayed green. §10.3 carries the rule.
+  §10.3's complete trigger list; one job selecting
   `--ignore=tests/package -m "not live and not chromium and not package"` on both
   platforms — deliberately **including** `subsystem`, per TEST_SUITE §8B; and
   `ci-required` with `if: always()` asserting every dependency is `success`.


### PR DESCRIPTION
## Context for the Product Owner

The automatic code review is a **merge-gating check** — a pull request cannot land until it passes. It has been failing at random, on healthy code, and telling whoever read the failure to go and fix a configuration bug that does not exist.

The cause turned out to be a mismatch nobody could see. The review job asked for a **60-minute budget**, but it was running on a small, cheap machine type that GitHub caps at **15 minutes no matter what you ask for**. There is no warning for this: the file validates, the job starts, and it is killed at a limit that appears nowhere in the repository. Measured over the last three days, **five review runs were killed this way, on five different pull requests**, and the longest run that *did* finish came in 32 seconds under the wire — so this was going to keep happening.

Three things change:

1. **The review job moves to a bigger machine.** Four CPUs instead of one, a six-hour cap instead of fifteen minutes — and still free, because this repository is public. The 60-minute budget the team reasoned its way to becomes real for the first time. Reviews should also get faster.
2. **The two small CI jobs stay where they are**, because they finish in about half a minute and that machine type is exactly right for them. Only their own fictional 20-minute number becomes an honest 10.
3. **A killed run now says the right thing.** It used to report *"the workflow needs fixing"* — the opposite of the truth, since the correct response is simply to re-run. It now says the run did not finish and what to do about it.

And a test now checks the pairing, so no future change can quietly declare a budget the machine will not honour.

**Cost:** none. Both machine types are free on public repositories.

---

## The defect

`.github/workflows/claude-code-review.yml` declared, on one job:

```yaml
runs-on: ubuntu-slim
timeout-minutes: 60
```

Those two lines are contradictory. `ubuntu-slim` is a **single-CPU** GitHub-hosted runner, and GitHub's runner reference states the constraint in one sentence:

> The job timeout for single-CPU runners is 15 minutes. If a job reaches this limit, the job is terminated and fails.

It is a property of the platform and **cannot be raised from configuration**.

### The leading hypothesis was wrong, and the wrong belief is why

The ticket named an organisation-configured runner with an org-level cap as the leading candidate, and asked that it be confirmed before any change was made. It is confirmed **false**:

- `ubuntu-slim` appears in GitHub's **"Standard GitHub-hosted runners for public repositories"** table, alongside `ubuntu-latest`.
- Every job on it — killed and passing alike — reports `runner_group_name: "GitHub Actions"` with a runner named `GitHub Actions <n>`.

Four files in this tree asserted the opposite. The workflow's own comment read that `ubuntu-slim` is *"NOT one of GitHub's standard public labels … it is an organisation-configured runner, so its availability is a property of the org and cannot be checked from inside this file."* **That belief is the whole reason a documented platform limit was hunted for in organisation settings instead of being looked up.** All four sites are corrected, and `NoDocumentMisdescribesTheSlimRunnerTests` walks `.github/` and fails if the claim returns — a guard rather than the one-time grep that found them, because this file already records a case where the identical sentence was fixed in one place and survived in its parallel block.

### Measured

Per **attempt**, not per run: `gh run rerun` adds an attempt to the same run id, so a per-run reading undercounts.

| Figure | Value |
|---|---|
| Successful attempts | 49 |
| Median | 543 s (9m03s) |
| p90 | 818 s (13m38s) |
| **Longest success** | **868 s (14m28s)** — 32 s inside the ceiling |
| Over 12 minutes | 11 of 49 |

**Five attempts killed at 15m0s**, each carrying `The job has exceeded the maximum execution time of 15m0s`:

| Job id | Started | Duration |
|---|---|---|
| 99916228958 | 2026-09-01T15:27:09Z | 901 s |
| 100274991357 | 2026-09-02T13:52:31Z | 920 s |
| 100287032371 | 2026-09-02T14:25:46Z | 918 s |
| 100714288570 | 2026-09-03T15:50:13Z | 930 s |
| 100725754347 | 2026-09-03T16:24:30Z | 927 s |

Two longer cancellations in the history (1621 s, 38018 s) are **excluded**: both ran on the retired self-hosted labels and are the never-claimed-runner phenomenon the file's comments already describe.

### Why the runner and not the number

Declaring an honest 15 would change *which runs die* not at all — the platform already kills at that instant. The real reason is structural: the **two-attempt retry this job is built around cannot fit under a 15-minute ceiling at any cap**, when one median attempt alone is nine minutes. `timeout-minutes: 60` is unchanged; every figure in the comment block above it was derived against a cap the runner never read.

## The second defect: a killed run gave the wrong instruction

`Resolve outcome` carried no `if:`, so GitHub applied the implicit `success()` and a cancellation skipped it — leaving `Write run summary`, which does carry `always()`, to fall back to `--result "${RESULT:-fatal}"`. Read verbatim from killed job 100714288570's log:

```
env:
  RESULT:
...
run summary written: result=fatal, tiers=1
```

which renders *"Review failed — the workflow needs fixing … The failure is in the workflow configuration, not in the change under review."* **A wrong instruction, not merely a wrong verdict.**

`Resolve outcome` now carries `always()` and a `job.status` ladder. Two decisions worth reading:

- **`cancelled` outranks an `ok` status.** This step runs *before* `Build review payload` and `Post review`, so `STATUS=ok` means "an attempt produced a review", never "a review was posted" — and under cancellation those steps are skipped. Resolving `ok` would render *"Review posted"* beside a red required check: a **false success**, worse than the wrong instruction being fixed. Design review proposed the opposite precedence on the grounds that `cancelled` would block `Supersede any stale failure notice`; it cannot — that step's implicit `success()` is false on any cancelled job whatever this output holds.
- **`failure` resolves `fatal`, which is today's behaviour, deliberately.** Whether a cap kill presents as `cancelled` or `failure` is a runtime detail I could not settle before the change: on the killed job the step was *skipped*, equally consistent with either. Routing `failure` to what `${RESULT:-fatal}` already produced means a wrong guess can only leave current behaviour standing, never invent a success. The step echoes `job_status=` so the next cancellation records the answer.

**`job.status`, not `cancelled()`:** GitHub's expression reference says status functions work "as expressions in `if` conditionals", and that "outside `if` conditionals, you can use `job.status`". A `cancelled()` in a step's `env:` is unsupported.

### What deliberately did *not* get `always()`

`Build failure notice`, `Post failure notice` and `Fail when no review was produced` keep their implicit `success()`. `concurrency.cancel-in-progress: true` makes superseded cancellations routine — one per rapid push — so `always()` there would comment and annotate on every push, which is the noise that concurrency group exists to prevent.

**Accepted residual, stated rather than implied:** a cap kill therefore still has no pull-request-visible surface. It had none before either. What changed is that the run summary stopped lying.

## Tests

`.github/review/tests/test_review_scripts.py`: **482 → 502**, run by `ci.yml` on every pull request. Regex-based rather than PyYAML because that suite runs on a bare interpreter with no dependency install — I cross-checked the parser against a real YAML parser out-of-band and it agrees on all three jobs.

| New class | Claim |
|---|---|
| `DeclaredJobCapIsEnforceableTests` | every job's cap is **strictly below** its runner's ceiling; the runner is recorded; a cap exists; the job and file sets are pinned |
| `CancelledRunIsNotAMisconfigurationTests` | the `cancelled` verdict renders, and the vocabulary is **closed** |
| `ResolveSurvivesCancellationTests` | the real step under bash, one case per `job.status` value |
| `OutcomeChainCancellationWiringTests` | `Resolve outcome` carries `always()`; the three PR-facing steps do not |

Three design points worth flagging:

- **Strictly below, not at-or-below.** A cap equal to the ceiling means the file and the platform kill at the same instant, so the declared number could never produce a diagnosis of its own.
- **The guard fails rather than skips** on a `runs-on` it cannot resolve. **This will red the CI epic's first matrix job on purpose** — `${{ matrix.os }}` resolves to no ceiling, and that decision is cheapest when the matrix is written rather than discovered later when the check has gone hollow. Noted in `TEST_SUITE.md` §10.3 and against that step in the plan.
- **`KNOWN_RUNNERS` is now derived** from the ceiling table's keys. It was a second, disagreeing record of the same set — its comment is what called `ubuntu-slim` organisation-configured.

### Mutation battery

**19 mutations applied and run**, each observed to fail a named case — not asserted. Including: both caps raised above and *to* the ceiling; the runner reverted; a deleted `timeout-minutes`; an unknown label; `runs-on` as a block sequence; a fourth job; an extra `.yaml` file; `always()` removed from `Resolve outcome` and added to `Build failure notice`; the `cancelled` branch deleted; the `choices` removed; the ladder demoted below `STATUS`; and the claim reintroduced in two files.

Two results worth reporting rather than burying:

- **One survivor, diagnosed and converted into a kill.** Replacing `${JOB_STATUS:-}` with a bare `$JOB_STATUS` survived — because the test harness exported `JOB_STATUS=""` on every call, so `set -u` had nothing to fire on and the guard the code carries was justified by nothing. The harness now *omits* the variable, the mutation kills 9 cases, and the test is renamed to match what it actually pins.
- **One broken mutation discarded, not counted.** My first attempt at reintroducing the runner claim patched text that did not exist. Re-done against the real line; it dies.

### Regression

- Review suite: **502 passed**.
- Project suite: **573 passed, 2 skipped, 16 subtests** — identical to the branch point.
- `ruff`: this repository is deliberately not clean (`ruff check` reports ~300 pre-existing errors and there is no `[tool.ruff]` config). This diff adds no new lint *class* — 6 × `FURB167` (`re.M`) and 2 × `ISC004` in files that already carry 7 and 4 of the same, matching the surrounding style.

## Measured: what a cap kill actually presents

The repair fires only if a job-cap kill presents `job.status == 'cancelled'`, and GitHub's own wording is split — the timeout documentation says such a job is *cancelled*, the single-CPU runner reference says it "is terminated and fails".

**The plan first stated here — double-push for a supersede cancel — was wrong**, and both reviewers said so: a supersede is a *different cancellation path*, so observing one answers nothing about the other. Corrected rather than quietly satisfied.

Settled by **constructing a cap kill**: a throwaway push-triggered workflow on a temporary branch, `ubuntu-latest`, `timeout-minutes: 1` against a 120-second step, with an `always()` step echoing the value. Run `33901140237`, annotated *"The job has exceeded the maximum execution time of 1m0s"* — the same wording as all five production kills — printed:

```
MEASURED job_status=cancelled
```

The `always()` step ran after the kill. So the `cancelled` branch is the live path and `failure → fatal` is the fail-safe it was designed to be. Branch deleted; the measurement and its run id are recorded beside `JOB_STATUS` in the workflow.

## Observed on the new runner

Three review runs on this branch, all on `ubuntu-latest`: **581 s, 560 s, 237 s**. Against the pre-move distribution (median 543 s, p90 818 s, max success 868 s) the tail is gone and every run finished well inside a cap that is now real. Three runs is not a distribution and is not claimed as one — the point is only that nothing was killed and the ceiling is no longer in reach.

## Second review round

Two reviews, one blocker each. The two that would have shipped a defect:

- **A test asserted a comment.** `test_the_step_reports_the_job_status_it_saw` read the step's `run:` source for `job_status=`, but the block reader returns the surrounding comments — and this step's comments explain the echo. Deleting the echo left the case green; the review verified the mutation surviving. It now asserts the step's **executed stdout**.
- **A job could escape the sweep.** `sneaky: {runs-on: ubuntu-slim, timeout-minutes: 99}` is legal YAML that GitHub accepts, and the end-anchored job-mark pattern made it vanish — recorded job set still equal, every check green, a 99-minute cap on a 15-minute runner. The parser now **refuses what it cannot resolve**, with six committed cases covering that, a quoted key, a trailing comment on `runs-on`, a step-level cap at eight spaces, and the caller shape.

Also taken: `ci_preflight.sh` still asserted the slim-image reason the workflow had just retired (two files contradicting each other about the same step); the claim guard had **no non-vacuity control** and now has three, sharing one root expression with the sweep — when each computed its own, mutating the sweep's left the control green; the caller exemption is held to the shape justifying it; the cancellation guard now forbids `cancelled()` as well as `always()`; an ambient `JOB_STATUS` is popped so the unset case is hermetic; and the cap guard's docstring gains this repository's distribution beside the inherited one.

Suite: **482 → 512**. Project suite unchanged at 573 passed, 2 skipped, 16 subtests. Mutation battery re-run after the hardening: **25 mutations, all killed** — including two that previously survived and are now dead, both of which were found by review rather than by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)