### PR TITLE
Prove no URL is claimed by two parsers, and repair the rule that was false (plan step E5-1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,10 @@ __pycache__/
 /coverage.json
 /coverage.xml
 /htmlcov/
+
+# Hypothesis's example database. The property test in
+# `tests/test_url_parser_exclusivity.py` is the repository's first Hypothesis
+# user, so this directory starts appearing with it. It is a local cache of
+# failing examples to replay -- valuable on the machine that found them,
+# meaningless anywhere else, and it must never be what makes a suite green.
+/.hypothesis/

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -468,6 +468,237 @@ can state. The per-parser properties are instead:
   a bare `Exception`, and rejection does not depend on trailing slashes, case in
   the scheme, or query-string order.
 
+**E5-1 shipped a production fix, following E5-8's precedent above.** A test
+step changing production code is the exception, not the rule, and the reason is
+the same one E5-8 gives: the defect *is* the thing the step set out to pin, so
+filing it separately would have meant merging a property that documents its own
+falsity. What changed in behaviour: `.com` hosts outside the Stack Exchange
+network — `github.com` and `www.github.com` above all, and any `meta.<x>.com` —
+no longer route to the StackExchange handler and are now claimed by whichever
+handler actually owns them. **For the class this fix exists for that is the
+GitHub handlers, not the HTML loader**: a `github.com` issue or discussion URL
+is claimed at stage 2 or 3 and served over the GitHub GraphQL API, with
+`load_url_as_markdown` reached only if that retrieval itself fails — no token,
+or a rate limit. The HTML loader is the destination only for the remaining
+hosts, which no specialized parser claims. An earlier draft of this sentence
+said everything falls through to the HTML loader, which told a reader with
+`GITHUB_TOKEN` configured that the fix demotes GitHub content to the browser
+path when it does the opposite. §9's risk row moves to covered on the strength of that fix, not merely
+of the new test.
+
+**The property was false on arrival.** The step was written expecting to pin a
+property that already held. It did not:
+`tests/test_url_parser_exclusivity.py` was red the moment it existed.
+StackExchange is tried first, so it won, and the resolver's StackExchange branch
+returns a canned failure note instead of falling through — the caller got no
+content and no indication of a mis-route.
+
+**Two families, and the second is the one that matters.** The first sweep found
+only family A and the requirements originally described only it; review found
+family B and it is far wider:
+
+| Family | Shape | Example |
+|---|---|---|
+| A | owner ∈ {`a`,`q`,`questions`}, all-digit repo | `github.com/a/2048/issues/7` |
+| B | **any** owner, **any** repo, marker in a trailing segment | `github.com/microsoft/vscode/issues/5/x/q/999` |
+
+Family B exists because `_ISSUE_RE` is a `match` anchored only at the start, so
+trailing segments are permitted, while `_QUESTION_RE` and `_ANSWER_RE` `search`
+the whole path. Any GitHub issue URL carrying `/q/<digits>`, `/a/<digits>` or
+`/questions/<digits>` after the issue number was claimed. Both are pinned as
+`@example`s, because family B is generable but rare — measured at ~0.06% per
+example against family A's ~3%.
+
+The cause was in `_derive_site_parameter`, not in the path patterns: it ended
+with `if host.endswith(".com")`, so **every** `.com` host was a StackExchange
+community and `github.com` derived the nonexistent site slug `github`. GitHub
+owners may legitimately be spelled `a`, `q` or `questions`, which is what the
+path patterns look for.
+
+**The obvious fix was tried first and is wrong; it is recorded so it is not
+re-proposed.** Anchoring `_QUESTION_RE` and `_ANSWER_RE` to the start of the
+path (`.search` → `^…`) leaves **family A** untouched, because in all eighteen
+overlaps the first generator found — which were family A only, family B not yet
+being known — the marker is *already* the first path segment. Measured, not
+reasoned.
+
+**The scoping matters, and an earlier draft of this paragraph omitted it.**
+Anchoring *would* close family B, whose marker is by definition a trailing
+segment. So anchoring is not inert; it is inert against exactly the family that
+would survive it. A future reader contemplating a narrower owner-based fix —
+excluding `a`, `q` and `questions` as owners, which is the change that would
+leave family B alone — must not read this paragraph as saying anchoring is
+useless in general. It says a fix validated against one family looks like it
+works, which is the reason both families are pinned as `@example`s.
+
+What landed is a membership gate ahead of every derivation branch:
+`_STACKEXCHANGE_NETWORK_DOMAINS`, the seven domains StackExchange itself
+publishes, with a host qualifying when it equals one or is a subdomain of one.
+**An allowlist rather than a denylist of the hosts other parsers own**, because a
+denylist makes this one property pass while leaving the same defect live
+wherever no second parser competes — `example.com/q/12345` would still be sent
+to a site that does not exist. §3.2 puts these parsers in the mutation scope, and
+a property that holds by coincidence survives mutation for the wrong reason.
+
+**The gate precedes all four branches rather than replacing the last one**,
+because the `meta.` branch is a second catch-all: it accepted `meta.example.com`
+and derived `meta.example`. Gating first is also the smaller diff — one guard
+added, four branches untouched.
+
+**`mathoverflow.net` is on the list and still rejected.** Every derivation branch
+requires `.com`, so MathOverflow resolves to `None` exactly as before. Removing
+it from the list was therefore an **equivalent mutant** when first written — and
+that is precisely why it did not stay one. A test now asserts both halves of the
+intent (`_is_stackexchange_network_host("mathoverflow.net")` is true, *and*
+`parse_stackexchange_url` still raises), which **converts it into a killed
+mutant**; it is the row recorded as killed in the matrix below. That conversion
+is the point: an allowlist entry no test can observe is a survivor somebody must
+triage, and this section exists to spare E12-1 exactly that. The entry stays
+because a constant named for the network must not lie about membership;
+restoring MathOverflow is a separate change.
+
+**One survivor was found by hand and killed.** With the separating dot deleted —
+`endswith(domain)` rather than `endswith("." + domain)` — every test in the
+module still passed, while `notstackoverflow.com` became StackExchange community
+`notstackoverflow`. The exclusivity property is structurally blind to it, since
+no second parser claims that host, so two explicit rejection rows own the
+suffix-versus-subdomain distinction instead.
+
+**The verification record, kept here because this is the durable document.**
+E5-1's mutation matrix and its control live in the step's task-local
+requirements folder, which `.gitignore` excludes from the repository — so the
+summary belongs here, where a reader of the tree can actually reach it:
+
+| Mutation | Outcome |
+|---|---|
+| Each of the five parsers' host guards, deleted in turn | killed (the property) |
+| Allowlist widened with `github.com` | killed (property + the GitHub rejection rows) |
+| Allowlist narrowed by dropping `superuser.com` | killed (exactly the two Super User rows) |
+| `endswith("." + domain)` weakened to `endswith(domain)` | killed (the two suffix rows) |
+| `mathoverflow.net` dropped from the allowlist | killed (the MathOverflow intent test) |
+
+**Nine mutants tried, nine killed.** Separately, a *control*: with the gate
+reverted **and** both pinned `@example`s deleted, the property still failed on
+five of five trials from a cleared `.hypothesis/examples`, shrinking to
+`https://github.com/a/1/issues/1` — so generation finds the defect unaided and
+the pins are belt-and-braces rather than load-bearing. A 200,000-example soak
+against the fixed code found no overlap. Every figure was measured locally, and
+that is not a preference — **the CI that exists runs no part of this suite.**
+`.github/workflows/ci.yml` carries the banner itself: *"This file is
+deliberately NOT this repository's test suite. It does not run `pytest`, `ruff`,
+or anything under `tests/`."* Its two jobs are `review-scripts`, which runs the
+review system's own tests, and `review_replies`, a merge gate over answered
+review threads that runs no tests at all. Neither touches `tests/`, and neither
+does any job in `claude-code-review.yml` or the CodeQL workflow.
+
+The citation here used to be §10.3, which was exactly backwards: §10.3 is this
+document's CI **design** and defines seven jobs — `fast`, `fast-extras`,
+`subsystem`, `chromium`, `package`, `types`, `coverage` — every one of which
+runs a pytest selection. A reader following that pointer found seven jobs where
+the sentence promised none. This document describes the *"To Be"* state
+throughout, so a claim about what runs **today** must cite the workflow file,
+never a section of this one.
+
+**Which parser pairs can collide depends entirely on which model you are
+counting under, and an earlier draft of this paragraph gave a number without
+saying.** Three models, three answers:
+
+- **Before the fix.** StackExchange's host language was every `.com` host, which
+  contains GitHub's `{github.com, www.github.com}`. Wikipedia needs
+  `.wikipedia.org` and arXiv an `arxiv.org` suffix, neither of which is `.com`,
+  so they were untouchable. Two pairs could collide — StackExchange ×
+  GitHub-issue and StackExchange × GitHub-discussion — and both did.
+- **After the fix.** All five host languages are pairwise disjoint, so **no**
+  pair can collide. That is what the property asserts and the soak confirms.
+- **Under single-guard deletion**, which is the model the mutation matrix
+  exercises: deleting any one non-StackExchange host guard lets that parser
+  accept a StackExchange host, so **four** pairs become reachable — the two
+  above plus StackExchange × arXiv and StackExchange × Wikipedia, whose
+  counterexamples are quoted below.
+
+GitHub-issue × GitHub-discussion is in none of the three: their host sets are
+identical, but the third path segment is literally `issues` or `discussions`, so
+they are separated structurally rather than by host and no host mutation can
+bring them together. **So apart from that one structurally-separated pair, the
+host predicates are what keeps every pair apart**, and that is what the property
+guards — *in one direction only*, which is the part worth stating precisely.
+Deleting a host guard, or widening it into space another parser
+claims, is killed. Widening one into **unclaimed** space is invisible: measured,
+`notarxiv.org`, `notwikipedia.org` and `notgithub.com` all pass the entire fast
+suite, because nothing then accepts a URL twice and a mutual-exclusivity
+property has nothing to see.
+
+*An earlier draft closed the sentence above with "the other seven pairs".
+Seven reconciles with none of the three models — they leave eight, ten and six
+pairs apart respectively — and was a leftover from a fourth, unstated one. The
+claim never needed a count: one pair is separated structurally and the host
+predicates separate the rest, which holds under all three.* That second direction is a per-parser *rejection*
+claim and is handed to E5-2, whose Verify clause names it. It is also why E5-1's first generator was
+insufficient: it crossed each parser's *path prefix* against every host, which
+found the GitHub overlap but left the arXiv and Wikipedia host guards as
+surviving mutants. What has to be crossed is each parser's **identifier
+vocabulary** — a legacy arXiv id is `<category>/<7 digits>` with the category
+unconstrained, so `q/1234567` is simultaneously a valid arXiv id and a
+StackExchange question marker, and `_WIKI_PATH_RE`'s capture is unconstrained in
+the same way. `https://stackoverflow.com/abs/q/1234567` and
+`https://stackoverflow.com/wiki/q/12345` are the two counterexamples that now
+fail those mutants.
+
+**A second equivalent mutant lives in the same function, and it predates this
+step.** Deleting the `meta.<community>.com` branch leaves the suite green:
+after the gate it and the fall-through `.com` branch agree on every allowlisted
+host **the network actually uses** — `meta.stackoverflow.com` →
+`meta.stackoverflow`, `meta.superuser.com` → `meta.superuser`, with
+`meta.stackexchange.com` caught by the special case above both. The scope is
+load-bearing and an earlier draft omitted it: `meta.<x>.stackexchange.com` *is*
+allowlisted, being a subdomain of `stackexchange.com`, and it is exactly where
+the two branches disagree — `meta.<x>.stackexchange` with the branch present,
+`meta` without it. What makes the deletion survive is not that no allowlisted
+host distinguishes them but that no host the network *operates* does: real
+second-level metas are `<x>.meta.stackexchange.com`, not `meta.<x>.…`.
+Kept because deleting a pre-existing branch is a behaviour change E5-1 was not
+asked for; recorded because the mutation step will otherwise surface it as a
+survivor with nothing to consult.
+
+**Adjacent widenings are recorded, not fixed.** `parse_arxiv_url` matches
+`endswith("arxiv.org")` with **no leading dot**, so `notarxiv.org` is accepted —
+the same defect class as the one E5-1 fixed in StackExchange, but it produces no
+overlap today and so is outside a step whose claim is exclusivity. And the
+`*.stackexchange.com` branch takes only the first label, so
+`math.meta.stackexchange.com` derives `math` where the API's
+`api_site_parameter` is `math.meta`; a characterisation test pins today's wrong
+answer so a future correction is visible rather than silent. And all four non-StackExchange parsers admit unclaimed host space without any
+test noticing, in two distinct conditions that an earlier draft collapsed into
+one count:
+
+- **arXiv needs no mutation at all.** `endswith("arxiv.org")` is *already* a
+  bare suffix test, so `notarxiv.org` is accepted on `main` today. A live
+  defect, not a survivable mutation.
+- **Three admit a widening mutation** that no test kills: `wikipedia.py`'s
+  `endswith(".wikipedia.org")` weakened to a bare suffix, and both GitHub
+  parsers' `host not in {"github.com", "www.github.com"}` weakened to a suffix
+  test.
+
+That is the arithmetic behind "three widenings" and "four parsers" — the two
+numbers count different things and the sentence used to give one of them without
+saying which. All four are the defect class E5-1 fixed on the StackExchange side
+and pinned with the `notstackoverflow.com` rows; all four belong to E5-2's
+stable-rejection claim. All are named here so the next reader
+does not re-derive them, and so a mutation report has an answer to point at.
+
+**`_QUESTION_RE` and `_ANSWER_RE` stay unanchored, and the honest reason is
+narrower than the one first written here.** An earlier version of this paragraph
+claimed the markers "do appear mid-path on real URLs" — that assertion had no
+citation, no test, and no URL anyone could produce on an allowlisted host; the
+closest candidate, the Teams `/c/<team>/questions/<id>/…` form, lives on
+`stackoverflowteams.com`, which this allowlist rejects, so it argues against the
+claim rather than for it. The real reason is simply that after the host fix,
+anchoring buys nothing, and narrowing acceptance is a behaviour change E5-1 was
+not asked to make. Nothing currently guards it: `search`→`match` on either
+pattern passes the whole suite, as does dropping the `q` alternative that real
+short links like `https://es.stackoverflow.com/q/12345` depend on. Those cases
+are handed to E5-2.
+
 **Environment resolvers.** The `_resolve_*` families in `server.py`,
 `chromium_pool.py` and `nodriver_worker.py`, plus `_parse_port_range`,
 `_resolve_transport_security` and `_cors_origin_regex`. Table-driven over unset,
@@ -2055,7 +2286,7 @@ The **Today** column describes *test coverage*, not implementation status.
 | `pdf-advanced` extras present *and* absent | gap | L2 | `fast` (both installs) | |
 | Resolver routing and per-handler fallback | partial | L1 | `fast` | |
 | Markdown transforms | partial | L1 + corpus | `fast` | |
-| URL parser mutual exclusivity | gap | L1 property | `fast` | |
+| URL parser mutual exclusivity | covered (E5-1) — the property was red on arrival; §3.1 records the defect and the fix | L1 property | `fast` | |
 | Env resolvers across all three modules | partial | L1 | `fast` | |
 | Diagnostics redaction at the emit boundary | gap (§7.1) | L1 + L2 | `fast` | |
 | Outbound URL policy | gap, undefined (§7.2) | L1 + L3 | `fast` + `subsystem` | |

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -911,11 +911,67 @@ duplicating tests or touching the same files.
 
 - **E5-1.** Hypothesis over generated URLs. *Verify:* fails if any parser's
   matching is widened to overlap another; the shrunk counterexample is readable.
+
+  **Landed.** `tests/test_url_parser_exclusivity.py` — the repository's first
+  Hypothesis module — with the property, two pinned `@example`s, and rows for
+  the claims the property is structurally blind to. **The property was false on
+  arrival**, so this step also shipped a production fix, on E5-8's precedent:
+  `_derive_site_parameter` ended with a catch-all making every `.com` host a
+  StackExchange community, so `github.com` derived the slug `github` and GitHub
+  issue URLs were answered with a StackExchange failure note. §3.1 of
+  `TEST_SUITE.md` carries the defect, the two exposure families, the allowlist,
+  and the falsified anchoring alternative that was tried first.
+
+  **Nine mutants tried, nine killed, one further mutation recorded as an
+  equivalent** — the five host guards, the allowlist widened and narrowed, the
+  separating dot, and the `mathoverflow.net` entry converted from an equivalent
+  mutant into a killed one. Stated as three numbers because E12-1 consults this
+  record and "no survivors" alone cannot be reconciled with the equivalents named
+  below: the equivalent is the `meta.<x>.com` branch, which is *not* counted
+  among the nine, and three further mutations survive **by construction** —
+  widening the non-StackExchange host guards into unclaimed space, which this
+  property cannot see and E5-2 now owns. Three findings came from hunting
+  survivors rather than from this bullet: the dot (`notstackoverflow.com` became
+  a community and every test passed), the generator crossing path prefixes
+  instead of identifier vocabularies (which left the arXiv and Wikipedia guards
+  surviving), and family B of the exposure (any owner, any repo).
+
+  **What this step does not own, stated because two reviews had to establish
+  it.** The property kills a host guard widened into space another parser
+  claims. It is blind to one widened into *unclaimed* space, because nothing
+  then accepts a URL twice — so `notarxiv.org` and `notwikipedia.org` pass. That
+  is a rejection claim, and it is handed to E5-2 below. **One** equivalent mutant
+  is recorded rather than removed: the `meta.<x>.com` branch, pre-existing and
+  dead weight once the gate is in place. `math.meta.stackexchange.com` is *not* a
+  second one — a characterisation test asserts its wrong slug, so the behaviour
+  is observable by definition; it is a recorded defect, filed in §3.1 under the
+  widenings left unfixed. An earlier draft called them two, contradicting this
+  bullet's own singular count three sentences above.
 - **E5-2.** For each of the five parsers: a generated URL built from known
   identifiers returns exactly those identifiers; a rejected URL raises that
   parser's own error type; rejection is stable across trailing slashes, scheme
   case and query order. *Verify:* each property fails if its parser's group
   extraction is off by one, and if the parser raises bare `Exception`.
+
+  **Also owns, handed over by E5-1: suffix-is-not-subdomain rejection for the
+  four non-StackExchange parsers.** *Verify additionally:* each parser rejects a
+  host that merely *ends with* the domain it accepts without being that domain
+  or a subdomain of it. The three guards are written three different ways and
+  only one is a subdomain test, so the clause is phrased against the behaviour
+  rather than the mutation: `wikipedia.py` guards with
+  `endswith(".wikipedia.org")` (a subdomain test, widenable), both GitHub
+  parsers with `host not in {"github.com", "www.github.com"}` (a set-membership
+  test, widenable to a suffix test), and `arxiv.py` with a bare
+  `endswith("arxiv.org")` that needs no mutation because it is already wrong.
+  Concretely `notarxiv.org` (`arxiv.py` matches `endswith("arxiv.org")` with no
+  leading dot **today**, so this one is a live defect rather than a mutant),
+  `notwikipedia.org`, and `notgithub.com` for both GitHub parsers. E5-1 fixed
+  and pinned this exact class on the StackExchange side and cannot reach the
+  others: its property is mutual exclusivity, and a widening into host space no
+  second parser claims produces no overlap for it to detect. Also unguarded and
+  belonging here: `_QUESTION_RE`/`_ANSWER_RE` survive `search`→`match`, and
+  `_QUESTION_RE` survives losing its `q` alternative, which real short links
+  such as `https://es.stackoverflow.com/q/12345` depend on.
 - **E5-3.** Owns `server.py`'s `_resolve_transport`, `_resolve_host_port`,
   `_resolve_tool_total_timeout_seconds`, `_resolve_web_search_max_concurrency`,
   `_resolve_transport_security`, `_cors_origin_regex`, `_get_int_env`,

--- a/src/kindly_web_search_mcp_server/content/stackexchange.py
+++ b/src/kindly_web_search_mcp_server/content/stackexchange.py
@@ -30,8 +30,73 @@ class StackExchangeError(RuntimeError):
     pass
 
 
+#: The domains the Stack Exchange network publishes, per Stack Exchange's own
+#: community-wiki list (meta.stackexchange.com question 81379, "Can we have a
+#: list of all the Stack Exchange domains somewhere, for firewall purposes?").
+#: Subdomains of each are network hosts too, which covers the `meta.` and
+#: language communities (`meta.superuser.com`, `pt.stackoverflow.com`) as well as
+#: `*.stackexchange.com` and `*.*.stackexchange.com`.
+#:
+#: `mathoverflow.net` is listed because it is genuinely a network domain and a
+#: constant named for the network must not lie about its membership. It does not
+#: change behaviour: every derivation branch below requires `.com`, so
+#: MathOverflow resolves to `None` here exactly as it did before this gate
+#: existed. Restoring it is a separate change.
+_STACKEXCHANGE_NETWORK_DOMAINS = frozenset(
+    {
+        "askubuntu.com",
+        "mathoverflow.net",
+        "serverfault.com",
+        "stackapps.com",
+        "stackexchange.com",
+        "stackoverflow.com",
+        "superuser.com",
+    }
+)
+
+
+def _is_stackexchange_network_host(host: str) -> bool:
+    """Report whether a hostname belongs to the Stack Exchange network.
+
+    A host qualifies when it is one of :data:`_STACKEXCHANGE_NETWORK_DOMAINS` or
+    a subdomain of one.
+
+    Args:
+        host: A lowercased hostname, without port or userinfo.
+
+    Returns:
+        ``True`` when ``host`` is a Stack Exchange network host.
+    """
+    return any(
+        host == domain or host.endswith(f".{domain}")
+        for domain in _STACKEXCHANGE_NETWORK_DOMAINS
+    )
+
+
 def _derive_site_parameter(host: str) -> str | None:
+    """Derive the Stack Exchange API ``site`` slug for a hostname.
+
+    Args:
+        host: The hostname from the URL being parsed.
+
+    Returns:
+        The ``site`` slug to send to the Stack Exchange API, or ``None`` when no
+        slug can be derived for the host. ``None`` does **not** mean "not on the
+        network": `mathoverflow.net` is a network domain and is listed in
+        :data:`_STACKEXCHANGE_NETWORK_DOMAINS`, yet every branch below requires
+        ``.com`` and so it derives ``None`` too. The two conditions are
+        deliberately distinct — :func:`_is_stackexchange_network_host` answers
+        membership, this function answers derivability.
+    """
     host = host.lower()
+
+    # Gate first: the branches below derive a slug from the hostname itself, so
+    # without this every `.com` host produced one -- `github.com` became site
+    # `github`, and because the resolver tries this parser first, GitHub issue
+    # URLs whose owner is spelled `a`, `q` or `questions` were silently routed
+    # here instead of to the GitHub handler.
+    if not _is_stackexchange_network_host(host):
+        return None
 
     # Meta exception: meta.stackexchange.com -> site=meta (per provided docs)
     if host == "meta.stackexchange.com":
@@ -45,7 +110,9 @@ def _derive_site_parameter(host: str) -> str | None:
     if host.endswith(".stackexchange.com"):
         return host[: -len(".stackexchange.com")].split(".")[0]
 
-    # Common communities: stackoverflow.com, superuser.com, serverfault.com, askubuntu.com, etc.
+    # Common communities on their own apex domain, and their subdomains:
+    # stackoverflow.com, superuser.com, serverfault.com, askubuntu.com,
+    # stackapps.com. The gate above has already established network membership.
     if host.endswith(".com"):
         return host.removesuffix(".com")
 

--- a/tests/test_url_parser_exclusivity.py
+++ b/tests/test_url_parser_exclusivity.py
@@ -1,0 +1,498 @@
+"""Assert that no URL is claimed by two of the five specialized parsers.
+
+:func:`~kindly_web_search_mcp_server.content.resolver.resolve_page_content_markdown`
+routes a URL by trying the five parsers **in a fixed order** and taking the
+first that does not raise. First acceptance wins, so two parsers accepting the
+same URL is not a conflict anyone sees — it is a silent mis-route. The later
+handler never runs, no error is raised, and the caller receives content
+retrieved by the wrong integration, or a canned failure note from it.
+
+That makes mutual exclusivity the load-bearing property of this whole family:
+
+    No URL may be accepted by more than one parser.
+
+Hypothesis states it over a generated space; examples do not, because the
+interesting inputs are precisely the ones no author thinks to write down. The
+defect this module was written against is the case in point — a GitHub issue
+URL whose owner is spelled ``a`` and whose repository name is all digits was
+claimed by the **StackExchange** parser, because
+``_derive_site_parameter`` ended with a catch-all accepting every ``.com`` host
+and a GitHub owner may legitimately be spelled ``a``, ``q`` or ``questions``.
+
+**The generator is deliberately narrow, and that is a trade with a control.**
+Free-form text would essentially never produce a URL any parser accepts, so
+:func:`urls` composes hosts and paths from the vocabulary the five parsers
+match on. That bias is the author's model of the code, which is exactly the
+thing a property test is supposed to not depend on. The control, stated here
+rather than cited: with the host gate reverted **and** both pinned examples
+below deleted, this property still failed on five of five trials from a cleared
+example database, shrinking each time to ``https://github.com/a/1/issues/1``. So
+generation finds the defect unaided and the pins are belt-and-braces rather than
+the only thing holding the claim. ``TEST_SUITE.md`` §3.1 carries the full
+mutation record.
+
+An earlier version of this paragraph cited that control as "V3" in "this step's
+requirements". No reader of the repository could follow it: `.gitignore`
+excludes `.requirements/`, so the document it pointed at is not in the tree —
+the same defect as the fabricated citation described at the bottom of this
+module, arrived at a different way. A citation that cannot be resolved from a
+clean checkout is worth less than the sentence it replaced.
+
+**Acceptance here means "returned at all", which matches the resolver's routing
+decision exactly; it is the *rejection* side that is broader.** The resolver
+routes to a parser precisely when that parser returns, so the two acceptance
+sets are identical. They part company on failure: the resolver catches only each
+parser's *own* error type, so a parser raising, say, a ``ValueError`` does not
+fall through — it escapes ``resolve_page_content_markdown`` altogether. This
+module counts that as a non-acceptance, which is the broader reading, and the
+right one for the claim it owns: that two parsers never both succeed. Whether a
+rejection uses the correct type is a separate claim, owned by the per-parser
+identifier-preservation and rejection step. Both claims are needed and neither implies the other.
+
+The parsers are pure functions of a string, so no case here reads the clock,
+the network or the environment, and none needs a seam. The one filesystem touch
+is ``Path(__file__).resolve()`` in the ``sys.path`` line every test module in
+this repository opens with, which runs at import and feeds nothing any assertion
+depends on.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from hypothesis import example, given, settings
+from hypothesis import strategies as st
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from kindly_web_search_mcp_server.content import resolver
+from kindly_web_search_mcp_server.content.arxiv import parse_arxiv_url
+from kindly_web_search_mcp_server.content.github_discussions import (
+    parse_github_discussion_url,
+)
+from kindly_web_search_mcp_server.content.github_issues import parse_github_issue_url
+from kindly_web_search_mcp_server.content.stackexchange import (
+    StackExchangeError,
+    parse_stackexchange_url,
+)
+from kindly_web_search_mcp_server.content.wikipedia import parse_wikipedia_url
+
+#: The five parsers, in the order ``resolve_page_content_markdown`` tries them.
+#: Order is not what this module asserts — mutual exclusivity makes order
+#: irrelevant, which is the point of proving it — but it is the order a reader
+#: needs to interpret a counterexample, since the earlier parser is the one that
+#: actually wins.
+PARSERS: tuple[tuple[str, Callable[[str], object]], ...] = (
+    ("stackexchange", parse_stackexchange_url),
+    ("github_issue", parse_github_issue_url),
+    ("github_discussion", parse_github_discussion_url),
+    ("wikipedia", parse_wikipedia_url),
+    ("arxiv", parse_arxiv_url),
+)
+
+#: A GitHub issue URL that the StackExchange parser also claimed before the
+#: allowlist landed. Pinned with ``@example`` so the regression is exercised on
+#: every run rather than only when the generator happens to produce it.
+KNOWN_GITHUB_OVERLAP = "https://github.com/a/2048/issues/7"
+
+#: The second overlap family, and the one that made the defect ordinary rather
+#: than exotic: **any** owner and **any** repository, because `_ISSUE_RE` permits
+#: trailing segments while the StackExchange patterns search the whole path.
+#:
+#: Pinned rather than left to generation. The trailing tail in :data:`PATHS`
+#: makes this family reachable, but only at about 0.06% per example against
+#: family A's 3% — roughly one run in four at the configured budget. Today both
+#: families die to the same host gate, so nothing rests on it; if someone later
+#: narrows the fix to exclude `a`, `q` and `questions` as owners, this is the
+#: family that would remain and generation alone would catch it a quarter of the
+#: time.
+KNOWN_GITHUB_TRAILING_OVERLAP = "https://github.com/microsoft/vscode/issues/5/x/q/999"
+
+#: Hosts every parser family claims, plus two no parser claims. Ordered simplest
+#: first: Hypothesis shrinks ``sampled_from`` toward earlier entries, so a
+#: counterexample reports ``github.com`` rather than ``en.m.wikipedia.org`` when
+#: either would do.
+HOSTS = st.sampled_from(
+    [
+        "github.com",
+        "stackoverflow.com",
+        "arxiv.org",
+        "en.wikipedia.org",
+        "superuser.com",
+        "example.com",
+        "www.github.com",
+        "math.stackexchange.com",
+        "meta.stackexchange.com",
+        "meta.stackoverflow.com",
+        "en.m.wikipedia.org",
+        "example.invalid",
+    ]
+)
+
+#: GitHub owner names. ``a``, ``q`` and ``questions`` are here because they are
+#: the three spellings the StackExchange path patterns look for; they are real,
+#: registrable GitHub owner names and not a contrivance.
+OWNERS = st.sampled_from(["a", "q", "questions", "owner", "microsoft"])
+
+#: Repository names. All-digit names are common on GitHub (``2048``) and are the
+#: half of the overlap the StackExchange patterns supply their id from.
+REPOS = st.sampled_from(["1", "2048", "12345", "repo"])
+
+#: Small identifiers. Kept short so a shrunk counterexample stays readable.
+NUMBERS = st.sampled_from(["1", "7", "123", "87654321"])
+
+#: Article titles, including one carrying the dot and underscore Wikipedia's
+#: canonical form uses.
+#:
+#: ``q/12345`` is a title only in the sense that ``_WIKI_PATH_RE`` is
+#: ``^/wiki/(.+)$`` — the capture is unconstrained, so a title may contain a
+#: slash and therefore a StackExchange marker. Same reasoning as
+#: :data:`ARXIV_IDS`: without it, widening Wikipedia's host guard produces a
+#: real overlap the generator can never see.
+TITLES = st.sampled_from(["Apple_Inc.", "Python", "Talk:Python", "q/12345"])
+
+#: arXiv identifiers in both the new (``2401.12345``) and legacy (``math/0309136``)
+#: shapes, plus one that matches neither.
+#:
+#: ``q/1234567`` and ``a/1234567`` are here because a legacy arXiv id is
+#: ``<category>/<7 digits>`` with **no constraint on the category**, so a
+#: category spelled ``q`` or ``a`` makes the same substring simultaneously a
+#: valid arXiv id and a StackExchange question or answer marker. Without these
+#: two entries the generator cannot reach the arXiv half of the space at all,
+#: and a widened arXiv host guard survives the property untouched — measured,
+#: and the reason this pool is not just three realistic ids.
+ARXIV_IDS = st.sampled_from(
+    [
+        "2401.12345",
+        "2401.12345v2",
+        "math/0309136",
+        "q/1234567",
+        "a/1234567",
+        "nope",
+    ]
+)
+
+#: Path vocabulary for the free-form shape, which exists so the generator is not
+#: confined to the four templates below. Every token either starts a parser's
+#: pattern or is ordinary filler.
+SEGMENTS = st.sampled_from(
+    [
+        "a",
+        "q",
+        "questions",
+        "issues",
+        "discussions",
+        "wiki",
+        "abs",
+        "pdf",
+        "w",
+        # `index.php` is here so Wikipedia's *second* acceptance shape is
+        # reachable at all: `parse_wikipedia_url` reads `?title=` only when the
+        # path is exactly `/w/index.php`. Without it, `w` in this list and
+        # `?title=Python` in QUERIES were both inert — measured, zero of 20,000
+        # generated URLs could reach that branch.
+        "index.php",
+        "1",
+        "x",
+    ]
+)
+
+#: Path shapes. The four templates mirror what each parser family matches, and
+#: the fifth draws free segments so a shape nobody anticipated can still appear.
+#: Crossing these against every host in :data:`HOSTS` — rather than pairing each
+#: template with its own host — is the whole point: an overlap lives exactly
+#: where one family's path arrives on another family's host.
+PATHS = st.one_of(
+    st.builds(
+        # The tail matters and is not decoration. ``_ISSUE_RE`` is a `match`
+        # anchored only at the start, so trailing segments are permitted, while
+        # the StackExchange patterns `search` the whole path. That combination
+        # made **any** owner and **any** repository overlap before the host fix
+        # — `/microsoft/vscode/issues/5/x/q/1` was claimed by both — and a
+        # template without a tail can only ever reach the far narrower family
+        # where the owner itself is spelled `a`, `q` or `questions`.
+        lambda owner, repo, kind, number, tail: (
+            f"/{owner}/{repo}/{kind}/{number}"
+            + ("/" + "/".join(tail) if tail else "")
+        ),
+        OWNERS,
+        REPOS,
+        st.sampled_from(["issues", "discussions"]),
+        NUMBERS,
+        st.lists(SEGMENTS, max_size=3),
+    ),
+    st.builds(
+        lambda marker, number: f"/{marker}/{number}",
+        st.sampled_from(["questions", "q", "a"]),
+        NUMBERS,
+    ),
+    st.builds(lambda title: f"/wiki/{title}", TITLES),
+    st.builds(
+        lambda prefix, identifier: f"/{prefix}/{identifier}",
+        st.sampled_from(["abs", "pdf"]),
+        ARXIV_IDS,
+    ),
+    st.builds(
+        lambda segments: "/" + "/".join(segments),
+        st.lists(SEGMENTS, max_size=4),
+    ),
+)
+
+#: Query strings, including the one ``parse_wikipedia_url`` reads a title out of.
+QUERIES = st.sampled_from(["", "?title=Python", "?ref=1", "?title="])
+
+#: Fragments, which every parser is supposed to ignore.
+FRAGMENTS = st.sampled_from(["", "#top"])
+
+
+@st.composite
+def urls(draw: st.DrawFn) -> str:
+    """Generate a URL from the vocabulary the five parsers match on.
+
+    Host and path are drawn independently so that any path shape can arrive on
+    any host. That cross product is where an overlap can exist at all — a
+    generator pairing each path template with only its own family's host could
+    never produce one.
+
+    Args:
+        draw: Hypothesis's draw function, supplied by ``@st.composite``.
+
+    Returns:
+        An absolute ``https`` URL as a string.
+    """
+    return f"https://{draw(HOSTS)}{draw(PATHS)}{draw(QUERIES)}{draw(FRAGMENTS)}"
+
+
+def _accepting_parsers(url: str) -> list[str]:
+    """Return the names of every parser that accepts ``url``.
+
+    Acceptance is "did not raise", which is the criterion
+    ``resolve_page_content_markdown`` itself applies when it routes.
+
+    Args:
+        url: The URL to offer to each of the five parsers.
+
+    Returns:
+        The names of the accepting parsers, in resolver order.
+    """
+    accepting: list[str] = []
+    # Deliberately broad: any exception at all is a non-acceptance for routing
+    # purposes. Which type a parser raises is another module's claim.
+    for name, parse in PARSERS:
+        try:
+            parse(url)
+        except Exception:
+            continue
+        accepting.append(name)
+    return accepting
+
+
+# 500 rather than the default 100, for margin rather than because 100 was ever
+# observed to be flaky. Measured on the unfixed code: family A overlaps at about
+# 2-3% per example, and at `max_examples=100` detection was 60/60 across sixty
+# cleared-database trials -- Hypothesis does not draw `sampled_from` i.i.d., it
+# deliberately diversifies, so the naive binomial estimate of "one miss in eight"
+# is simply wrong and an earlier version of this comment said so in error. 500 is
+# insurance against a future generator change diluting the space, not a fix for
+# an observed flake. Parsing is microseconds, so 500 costs
+# nothing. `deadline=None` for a measured reason rather than a feared one: with
+# the default 200 ms deadline restored the module still passes, so it is not
+# guarding against a spurious `DeadlineExceeded` — it is worth 3-5x wall clock
+# (2.6s against 8.7-13.2s measured), because the deadline is checked per example
+# and 500 of them pay the cost. Hypothesis's own `ci` profile already sets
+# `deadline=None`, so this only changes the local edit-test loop.
+# Marked `slow` because §10.5 defines that marker as "over a second" and 500
+# examples take about 2.6s. No job in §10.3 deselects `slow`, so this changes no
+# selection anywhere -- it keeps the marker table's own definition true of the
+# suite, which this repository machine-checks.
+@pytest.mark.slow
+@settings(max_examples=500, deadline=None)
+@given(url=urls())
+@example(url=KNOWN_GITHUB_OVERLAP)
+@example(url=KNOWN_GITHUB_TRAILING_OVERLAP)
+def test_no_url_is_accepted_by_more_than_one_parser(url: str) -> None:
+    """Assert at most one of the five parsers accepts any generated URL.
+
+    Args:
+        url: A generated URL.
+    """
+    accepting = _accepting_parsers(url)
+
+    assert len(accepting) <= 1, (
+        f"{url!r} was accepted by {len(accepting)} parsers: {', '.join(accepting)}.\n"
+        f"resolve_page_content_markdown takes the first acceptance, so "
+        f"{accepting[0]!r} wins and {', '.join(accepting[1:])} never runs. "
+        f"Nothing reports an error, so this is a silent mis-route."
+    )
+
+
+def test_every_parser_the_resolver_imports_is_covered_here() -> None:
+    """Assert this module covers exactly the parsers the resolver module holds.
+
+    Without this, adding a sixth parser would leave the exclusivity property
+    quietly covering five of six — passing, and no longer proving what its name
+    says. A property with a blind spot is worse than no property, because it
+    reports green over the gap.
+
+    **This measures what the resolver module *imports*, not what its body
+    actually calls**, and the name says so. The two can differ: a parser
+    imported and never dispatched would be demanded here, and — the direction
+    that would actually hurt — a parser dispatched through an alias this filter
+    does not match would not be. Proving real dispatch means parsing the
+    resolver's body, which is a different and more brittle claim; resolver
+    routing has its own owner in the risk matrix. Import is a deliberate proxy,
+    and it catches the realistic mistake, which is adding a sixth parser to the
+    chain and forgetting this module exists.
+    """
+    dispatched = {
+        name
+        for name in vars(resolver)
+        if name.startswith("parse_") and name.endswith("_url")
+    }
+
+    covered = {parse.__name__ for _, parse in PARSERS}
+
+    assert dispatched == covered, (
+        f"resolve_page_content_markdown dispatches {sorted(dispatched)} but this "
+        f"module covers {sorted(covered)}. Every parser the resolver tries must "
+        f"be in PARSERS, or the exclusivity property has a blind spot."
+    )
+
+
+@pytest.mark.parametrize(
+    ("url", "expected_site"),
+    [
+        ("https://stackoverflow.com/questions/123/x", "stackoverflow"),
+        ("https://superuser.com/questions/123/x", "superuser"),
+        ("https://serverfault.com/questions/123/x", "serverfault"),
+        ("https://askubuntu.com/questions/123/x", "askubuntu"),
+        ("https://stackapps.com/questions/123/x", "stackapps"),
+        ("https://math.stackexchange.com/questions/123/x", "math"),
+        ("https://meta.stackexchange.com/questions/123/x", "meta"),
+        ("https://meta.stackoverflow.com/questions/123/x", "meta.stackoverflow"),
+        ("https://meta.superuser.com/questions/123/x", "meta.superuser"),
+        ("https://pt.stackoverflow.com/questions/123/x", "pt.stackoverflow"),
+    ],
+)
+def test_accepts_every_stackexchange_com_network_host_shape(
+    url: str, expected_site: str
+) -> None:
+    """Assert the host allowlist did not narrow away a real ``.com`` network host.
+
+    Scoped to ``.com`` in the name on purpose: ``mathoverflow.net`` is also a
+    network host and is deliberately *rejected*, which a name promising "every
+    network host" would appear to contradict. That case has its own test.
+
+    The five apex domains, a ``*.stackexchange.com`` community, the
+    ``meta.stackexchange.com`` special case, two ``meta.`` subdomains and a
+    language subdomain. Every row asserts the derived ``site`` slug, not merely
+    that parsing succeeded: the slug is what reaches the Stack Exchange API, so
+    a gate that admits the host but derives the wrong slug is still broken.
+
+    Args:
+        url: A URL on a Stack Exchange network host.
+        expected_site: The ``site`` slug the API expects for that host.
+    """
+    assert parse_stackexchange_url(url).site == expected_site
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://github.com/a/2048/issues/7",
+        "https://www.github.com/a/2048/issues/7",
+        "https://example.com/q/12345",
+        "https://notstackoverflow.com/questions/1/x",
+        "https://xsuperuser.com/questions/1/x",
+        "https://meta.example.com/q/12345",
+    ],
+)
+def test_rejects_a_com_host_that_is_not_on_the_stackexchange_network(url: str) -> None:
+    """Assert a non-network ``.com`` host is refused, not given a made-up slug.
+
+    ``example.com`` is here alongside the two GitHub hosts on purpose. The
+    GitHub rows are the ones the exclusivity property also covers; the
+    ``example.com`` row is not, because no second parser claims that host. It is
+    the same defect — a site slug invented from a domain that has no Stack
+    Exchange community — and only this test can see it.
+
+    **The ``meta.example.com`` row pins the second catch-all.** Before the gate,
+    ``host.startswith("meta.") and host.endswith(".com")`` was a catch-all in its
+    own right and derived the slug ``meta.example``. It is not reachable by the
+    exclusivity property either — no other parser claims that host — so gating
+    ahead of every branch rather than replacing only the last one is a claim only
+    this row owns.
+
+    **The two suffix rows pin the separating dot**, and they were added because a
+    mutation deleted it and survived every other test in this module.
+    ``_is_stackexchange_network_host`` asks whether the host *is* a network
+    domain or ends with ``"." + domain``. Weaken that to a bare
+    ``endswith(domain)`` and ``notstackoverflow.com`` — registrable by anyone —
+    becomes Stack Exchange community ``notstackoverflow``. The exclusivity
+    property cannot see it, because no second parser claims those hosts either,
+    so nothing but a row here distinguishes a suffix from a subdomain.
+
+    Args:
+        url: A URL on a ``.com`` host outside the Stack Exchange network.
+    """
+    with pytest.raises(StackExchangeError):
+        parse_stackexchange_url(url)
+
+
+def test_mathoverflow_is_on_the_network_list_but_still_resolves_to_no_site() -> None:
+    """Pin both halves of the deliberately inert ``mathoverflow.net`` entry.
+
+    ``mathoverflow.net`` is a genuine Stack Exchange network domain, so it
+    belongs in a constant named for the network. It nonetheless changes no
+    behaviour, because every slug-derivation branch requires ``.com`` and
+    MathOverflow therefore still derives no site.
+
+    That combination makes deleting the entry an **equivalent mutant** — no
+    observable behaviour differs — which matters because §3.2 of the test-suite
+    design puts these parsers in the mutation-testing scope, and an entry no
+    test can observe is a survivor somebody has to triage. Asserting the private
+    predicate is the exception that proves the rule about testing through public
+    callers: here the public behaviour is identical either way, so the predicate
+    is the only place the intent is observable at all.
+
+    Restoring MathOverflow support is a separate change, and this test is what
+    will fail when someone makes it.
+    """
+    from kindly_web_search_mcp_server.content.stackexchange import (
+        _is_stackexchange_network_host,
+    )
+
+    assert _is_stackexchange_network_host("mathoverflow.net") is True
+
+    with pytest.raises(StackExchangeError):
+        parse_stackexchange_url("https://mathoverflow.net/questions/123/x")
+
+
+def test_second_level_meta_community_derives_the_wrong_slug_today() -> None:
+    """Characterise a known-wrong slug so a future fix is visible, not silent.
+
+    ``math.meta.stackexchange.com`` is a real site whose Stack Exchange API
+    ``api_site_parameter`` is ``math.meta``. The ``*.stackexchange.com`` branch
+    takes only the first label, so it derives ``math`` and a question on the
+    meta site is queried against the **main** site instead.
+
+    This is pre-existing, it is not what the mutual-exclusivity step set out to
+    fix, and widening the slug derivation is a behaviour change with its own
+    blast radius. It is pinned rather than left undescribed so the defect is
+    *characterised* instead of invisible: a test asserting today's wrong answer
+    states plainly which behaviour ships, and the day someone corrects the
+    derivation this test fails and points them at the decision rather than
+    letting the change land unnoticed.
+
+    An earlier version of this docstring justified the test by quoting the
+    surrounding design document as claiming these branches "derive correct
+    slugs". No document says that. The sentence was removed rather than
+    softened, because a fabricated citation is worse than no citation — it
+    invites the next reader to trust a source that was never checked.
+    """
+    assert parse_stackexchange_url(
+        "https://math.meta.stackexchange.com/questions/123/x"
+    ).site == "math"


### PR DESCRIPTION
## Context for the Product Owner

When a client asks this server for the contents of a web page, the server tries
to use a **specialist handler** for sites we support properly — Stack Exchange,
GitHub issues, GitHub discussions, Wikipedia and arXiv — and falls back to a
generic headless-browser reader for everything else. It picks the specialist by
offering the URL to each in a fixed order and taking the first one that says
"that's mine."

That scheme rests on exactly one rule: **no two handlers may claim the same
URL.** If two do, the first one silently wins, the correct one never runs, and
nothing anywhere reports a problem. This plan step exists to turn that rule into
an executable test.

**The rule was already broken, and this PR fixes it.** Stack Exchange was
claiming GitHub URLs, because it treated *any* `.com` address as a Stack
Exchange community — so `github.com` was read as a Stack Exchange site named
"github". A user asking for a GitHub issue got the message
`_Failed to retrieve StackExchange content_` instead of their issue. Not a
crash, not a log line anyone would notice — just the wrong answer.

Two shapes were affected. The narrow one needed a GitHub owner literally named
`a`, `q` or `questions`. The wide one needed nothing unusual at all: **any**
repository, whenever the URL carried an extra path segment such as
`github.com/microsoft/vscode/issues/5/x/q/999`.

**Product impact of the fix:** a `.com` URL that is not Stack Exchange now
reaches the handler that actually owns it. For the case this fix exists for —
GitHub issue and discussion URLs — that is the **GitHub API handler**, which
returns properly structured issue threads; the browser-based generic reader is
used only if that call fails (no `GITHUB_TOKEN`, or a rate limit). The generic
reader is the destination only for hosts no specialist claims. So the fix
*upgrades* those GitHub URLs from a canned failure note to real GitHub content.

*(An earlier version of this section said all such URLs "go to the generic
reader". That was wrong in the pessimistic direction and is corrected here — it
would have told a reader with a token configured that the fix demotes GitHub
content to browser scraping, when it does the opposite.)*

The one trade-off worth knowing is for the remaining hosts: the generic reader
needs a working headless browser where the Stack Exchange path needed only a
plain API call, so an over-narrow domain list degrades quality rather than
breaking anything. The list is Stack Exchange's own published set of seven
domains and has been stable since 2011.

---

## What changed

| File | Why |
|---|---|
| `tests/test_url_parser_exclusivity.py` | New. The property plus the rows it is structurally blind to. This is the repository's **first Hypothesis test**. |
| `content/stackexchange.py` | The fix: a network-membership gate ahead of the slug-derivation branches. |
| `.system_design/TEST_SUITE.md` | §3.1 records the defect and every decision; §9's risk row moves gap → covered. |
| `.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md` | E5-1's *Landed* block; E5-2's Verify clause amended to receive handed-off debt. |
| `.gitignore` | `/.hypothesis/`, which starts existing with this PR. |

The production diff is one constant, one helper, one guard and one docstring.
The four existing derivation branches are untouched.

## Why an allowlist, not a denylist

A denylist of hosts other parsers own would make the property pass while leaving
the same defect live wherever no second parser competes — `example.com/q/12345`
was being routed to a Stack Exchange site that does not exist, and a
mutual-exclusivity property can never see that. Valid Stack Exchange `site`
slugs are a closed registry, so rejecting a host outside the network is correct
by construction rather than by coincidence. That matters downstream: E12-1 runs
`mutmut` over these parsers, and a property that holds by coincidence survives
mutation for the wrong reason.

## The fix that was tried first and does not work

Anchoring `_QUESTION_RE`/`_ANSWER_RE` to the start of the path. Measured, not
reasoned: in the narrow family the marker is *already* the first path segment,
so anchoring changes nothing there. It would have closed only the wide family —
so a fix validated against that family alone would have looked like it worked.
Recorded in §3.1 so it is not re-proposed.

## Evidence

- **Full `fast` selection: 738 passed, 2 skipped.**
- **Nine mutants tried, nine killed**, on an isolated tree copy: all five
  parsers' host guards deleted; the allowlist widened *and* narrowed; the
  separating dot removed; the `mathoverflow.net` entry removed. Separately, one
  mutation is recorded as an **equivalent** (the `meta.<x>.com` branch, dead
  weight once the gate is in place) and is not counted among the nine; three
  more survive **by construction** and are handed to E5-2, below.
- **Control:** with the fix reverted and the pinned examples deleted, the
  property still fails 5/5 on a cleared example database, shrinking to
  `https://github.com/a/1/issues/1`.
- **Soak:** 200,000 generated examples against the fixed code, no overlap.

Three of those mutants were found by hunting for survivors rather than by
following the plan bullet:

1. **The separating dot.** With `endswith(domain)` instead of
   `endswith("." + domain)`, every test passed while `notstackoverflow.com` — a
   domain anyone can register — became Stack Exchange community
   `notstackoverflow`.
2. **The generator crossed the wrong thing.** Crossing each parser's *path
   prefix* against every host found the GitHub overlap and left arXiv's and
   Wikipedia's host guards as surviving mutants. What must be crossed is each
   parser's **identifier vocabulary**: a legacy arXiv id is
   `<category>/<7 digits>` with the category unconstrained, so `q/1234567` is at
   once a valid arXiv id and a Stack Exchange marker.
3. **`index.php` was documented but not present**, leaving Wikipedia's
   `?title=` acceptance branch unreachable by any of 20,000 generated URLs.

## What this step deliberately does not own

The property kills a host guard that is deleted, or widened into space **another
parser claims**. It is blind to one widened into *unclaimed* space —
`notarxiv.org` and `notwikipedia.org` pass the whole suite — because nothing
then accepts a URL twice. That is a per-parser *rejection* claim, so E5-2's
Verify clause has been amended to receive it, together with two other unguarded
behaviours found on the way (`search`→`match` on both Stack Exchange patterns,
and `_QUESTION_RE` losing its `q` alternative). `arxiv.py`'s dotless
`endswith("arxiv.org")` is a **live defect today**, not merely a mutant, and is
named there.

Two equivalent mutants are recorded rather than removed, both pre-existing: the
`meta.<x>.com` branch is dead weight once the gate is in place, and
`math.meta.stackexchange.com` derives the wrong slug (`math`, where the API
wants `math.meta`) and is now pinned by a characterisation test so a future
correction is visible rather than silent.

## Reviewer note on CI

**This repository's CI does not run `pytest`.** `ci.yml` says so in its own
banner — it runs only the review system's tests and CodeQL. So the checks on
this PR do not execute anything above; every figure here was measured locally.
The mutation record and the control are written into **`TEST_SUITE.md` §3.1**,
which is in the tree — the task-local requirements folder is `.gitignore`d, so
citing it would point a reader at a document they cannot open.

## Automated review findings — all three addressed

The `review` check passed with three findings, all on the written records rather
than the code, and all three were real:

1. *(warning)* The module docstring cited its control as "V3 in this step's
   requirements" — but `.gitignore` excludes `.requirements/`, so **no reader of
   the repository could resolve it**. The same defect as the fabricated citation
   the module itself documents removing, arrived at from a different direction.
   The control is now stated inline and the full record lives in `TEST_SUITE.md`
   §3.1, which is committed.
2. *(suggestion)* The plan's *Landed* block said "Eleven mutants, no survivors"
   while enumerating nine, and an equivalent mutant is by definition a survivor.
   Now stated as three reconciled numbers.
3. *(suggestion)* §3.1 said anchoring "changes nothing" without scoping it to
   family A. Anchoring *would* have closed family B — that is the whole reason
   the falsification had to be run. Now scoped.

## Review history

Three review passes: a design review that returned *not ready to merge* on three
blockers, a code review that returned *request changes*, and a second design
review that found three more — including a surviving mutant inside the very
function this PR edits, and an acceptance criterion that overclaimed what the
property can detect. All are resolved or explicitly reassigned above. Two
statements I had written and could not support — a fabricated citation to a
design document, and a probability argument that measurement contradicted 60/60
— were removed rather than softened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAcLX33N2yH29RWMSizntJ