### PR TITLE
Run this repository's own tests in CI, behind one required check (plan step E4-1)

### DIFF
--- a/.github/review/README.md
+++ b/.github/review/README.md
@@ -90,8 +90,9 @@ To enable the workflow on this repository:
 1. Grant this repository access to the three settings above (organisation
    settings → Secrets and variables → Actions → each item → repository access).
 2. Nothing to do for runners — the workflows use GitHub-hosted labels
-   (`ubuntu-latest` for the review, `ubuntu-slim` for the two CI jobs), so no
-   runner group has to be granted.
+   (`ubuntu-latest` for the review and for `ci-required`, `ubuntu-slim` for the
+   two review-system jobs, and `ubuntu-latest` + `windows-latest` for the broad
+   test job), so no runner group has to be granted.
 
    ⚠️ **Why not the self-hosted fleet, since the organisation has one:** a runner
    group carries an *"Allow public repositories"* setting that is **off by
@@ -110,9 +111,12 @@ To enable the workflow on this repository:
    GitHub's runner reference: *"The job timeout for single-CPU runners is 15
    minutes."* The review job used to run there with `timeout-minutes: 60` and was
    killed mid-run five times before anyone paired the two lines; it now runs on
-   `ubuntu-latest`, whose ceiling is six hours. The two CI jobs stay on
-   `ubuntu-slim`, which is what that label is for. A test fails if any job ever
-   declares a cap its runner will not honour.
+   `ubuntu-latest`, whose ceiling is six hours. The two review-system jobs stay
+   on `ubuntu-slim`, which is what that label is for, and the broad test job runs
+   on the ordinary six-hour labels because it is emphatically not lightweight
+   automation. A test fails if any job ever declares a cap its runner will not
+   honour — including a matrix job, which is held to the LOWEST ceiling among the
+   labels its matrix can produce.
 3. Open a pull request. The `review` check appears on it.
 4. Once it has run green once, make `review` a required status check on `main`.
 
@@ -158,8 +162,9 @@ step 2 above.
 ## Changing the review system
 
 `.github/workflows/ci.yml` runs `tests/test_review_scripts.py` on every pull
-request — 513 tests over the selector, the classifier, the notices, the redactor,
-the schema and the workflow's own wiring. Run them locally the same way:
+request — 543 tests over the selector, the classifier, the notices, the redactor,
+the schema and the workflow's own wiring, plus the workflow parser, the
+runner-ceiling table and the `ci-required` aggregation. Run them locally the same way:
 
 ```bash
 python .github/review/tests/test_review_scripts.py

--- a/.github/review/README.md
+++ b/.github/review/README.md
@@ -162,7 +162,7 @@ step 2 above.
 ## Changing the review system
 
 `.github/workflows/ci.yml` runs `tests/test_review_scripts.py` on every pull
-request — 543 tests over the selector, the classifier, the notices, the redactor,
+request — 551 tests over the selector, the classifier, the notices, the redactor,
 the schema and the workflow's own wiring, plus the workflow parser, the
 runner-ceiling table and the `ci-required` aggregation. Run them locally the same way:
 

--- a/.github/review/REVIEW_GUIDE.md
+++ b/.github/review/REVIEW_GUIDE.md
@@ -182,13 +182,17 @@ Explain the failure mode in one or two sentences and give a concrete fix.
   is not only allowed but expected; verify a count rather than assuming one.
 
   ⚠️ Note the difference from the upstream repository this contract came from:
-  **there, the justification was "the repository's own checks run them". This
-  repository has no CI test job at all** — `claude-code-review.yml` is its only
-  workflow. So the reason here is narrower and worth stating plainly: you have a
+  there, the justification was "the repository's own checks run them". This
+  repository **once ran none of its own tests in CI**, and now runs them —
+  `ci.yml` calls the hermetic and subsystem selection on both platforms. The reason here is
+  still narrower than upstream's and is worth stating plainly: you have a
   writable checkout, a network path and no isolation, and running a test suite or
-  a dependency install from a review job is a side effect nobody asked for. It is
-  **not** because something else has already run them. If a change looks untested,
-  say it is untested; do not assume a green suite exists somewhere.
+  a dependency install from a review job is a side effect nobody asked for.
+
+  ⚠️ **Do not read a green check as broad coverage.** The gate runs one
+  selection; the browser, packaging, type-check, coverage and live jobs are not
+  in it yet. If a change looks untested, say it is untested rather than assuming
+  a green suite covered it somewhere.
 - **Do not claim that tests, linters, or type checks pass or fail.** You have not
   run them and will not.
 - **Do not relitigate settled decisions.** These are deliberate and documented in

--- a/.github/review/REVIEW_GUIDE.md
+++ b/.github/review/REVIEW_GUIDE.md
@@ -27,8 +27,12 @@ Do not review the diff in isolation.
 > directory. It has one**, holding the test-suite design and its implementation
 > plan. What survives is the narrower rule: those documents are large and each
 > change touches a section of one, so they are not read whole on every pull
-> request — read the part the change actually touches, and do not report "there
-> is no design document" as a finding.
+> request — read the part the change actually touches, and do not report a
+> missing design document as a finding. <!-- The phrasing this sentence used to
+> quote is described rather than reproduced: the sweep guard in
+> `tests/test_review_scripts.py` reads every file here, so quoting a retired
+> claim reintroduces it as far as that guard can tell. Same convention as the
+> runner-claim guard. -->
 
 **Additionally, based on what the pull request touches:**
 

--- a/.github/review/REVIEW_GUIDE.md
+++ b/.github/review/REVIEW_GUIDE.md
@@ -11,11 +11,11 @@ Do not review the diff in isolation.
 
 **Always, in full:**
 
-- `README.md` — **this is the specification**, and the always-read one.
-  document in this repository. The README carries the tool contract, the
-  client-by-client setup for seven MCP clients, the transport and allowlist
-  behaviour, the proxy configuration, and the troubleshooting that tells a user
-  what a `403` or `421` means. It is ~38 KB; read it whole.
+- `README.md` — **this is the specification**, and the always-read one. It
+  carries the tool contract, the client-by-client setup for seven MCP clients,
+  the transport and allowlist behaviour, the proxy configuration, and the
+  troubleshooting that tells a user what a `403` or `421` means. It is ~38 KB;
+  read it whole.
 
 > This is a deliberate departure from the upstream repository this review system
 > was adopted from, which reads three `.system_design/` documents and navigates a

--- a/.github/review/REVIEW_GUIDE.md
+++ b/.github/review/REVIEW_GUIDE.md
@@ -11,7 +11,7 @@ Do not review the diff in isolation.
 
 **Always, in full:**
 
-- `README.md` — **this is the specification.** There is no separate design
+- `README.md` — **this is the specification**, and the always-read one.
   document in this repository. The README carries the tool contract, the
   client-by-client setup for seven MCP clients, the transport and allowlist
   behaviour, the proxy configuration, and the troubleshooting that tells a user
@@ -23,9 +23,10 @@ Do not review the diff in isolation.
 > small enough to read in full and carries the tool contract, the client setup
 > and the transport behaviour.
 >
-> ⚠️ **This paragraph used to say the repository had no `.system_design/`
-> directory. It has one**, holding the test-suite design and its implementation
-> plan. What survives is the narrower rule: those documents are large and each
+> ⚠️ **This paragraph used to deny that this repository keeps design documents
+> of its own. It keeps two**, under `.system_design/` -- the test-suite design
+> and its implementation plan. (Described rather than reproduced: the sweep
+> guard reads every file here.) What survives is the narrower rule: those documents are large and each
 > change touches a section of one, so they are not read whole on every pull
 > request — read the part the change actually touches, and do not report a
 > missing design document as a finding. <!-- The phrasing this sentence used to

--- a/.github/review/REVIEW_GUIDE.md
+++ b/.github/review/REVIEW_GUIDE.md
@@ -19,11 +19,16 @@ Do not review the diff in isolation.
 
 > This is a deliberate departure from the upstream repository this review system
 > was adopted from, which reads three `.system_design/` documents and navigates a
-> fourth by section. **This repository has no `.system_design/` directory.** The
-> README is what stands in its place, and it is small enough to read in full. Do
-> not treat its absence as a gap you should work around by inferring a design —
-> and do not report "there is no design document" as a finding on every pull
-> request. It is recorded here.
+> fourth by section. **The always-read document here is the README**, which is
+> small enough to read in full and carries the tool contract, the client setup
+> and the transport behaviour.
+>
+> ⚠️ **This paragraph used to say the repository had no `.system_design/`
+> directory. It has one**, holding the test-suite design and its implementation
+> plan. What survives is the narrower rule: those documents are large and each
+> change touches a section of one, so they are not read whole on every pull
+> request — read the part the change actually touches, and do not report "there
+> is no design document" as a finding.
 
 **Additionally, based on what the pull request touches:**
 

--- a/.github/review/REVIEW_GUIDE.md
+++ b/.github/review/REVIEW_GUIDE.md
@@ -24,9 +24,10 @@ Do not review the diff in isolation.
 > and the transport behaviour.
 >
 > ⚠️ **This paragraph used to deny that this repository keeps design documents
-> of its own. It keeps two**, under `.system_design/` -- the test-suite design
-> and its implementation plan. (Described rather than reproduced: the sweep
-> guard reads every file here.) What survives is the narrower rule: those documents are large and each
+> of its own. It keeps them**, under `.system_design/`. (Described rather than
+> reproduced: the sweep guard reads every file here. And deliberately not
+> counted -- a count in prose is a claim nothing checks, and the directory is
+> where a reader should look for what is in it.) What survives is the narrower rule: those documents are large and each
 > change touches a section of one, so they are not read whole on every pull
 > request — read the part the change actually touches, and do not report a
 > missing design document as a finding. <!-- The phrasing this sentence used to

--- a/.github/review/REVIEW_PROMPT.md
+++ b/.github/review/REVIEW_PROMPT.md
@@ -189,11 +189,18 @@ needs to check it.
 install dependencies.
 
 ⚠️ Be precise about why, because the upstream version of this instruction gave a
-reason that is false here: **this repository has no CI test job.**
-`claude-code-review.yml` is its only workflow, so nothing else has run the suite
-either. The reason is that you have a writable checkout, a network path and no
-isolation, and running a suite or an install from a review job is a side effect
-nobody asked for.
+reason this repository could not support and the correction has now moved twice.
+It once said this repository ran **none of its own tests in CI**; it now runs
+them. `ci.yml` calls the hermetic and subsystem selection on Linux and Windows
+and aggregates it into `ci-required`. So a green pull request does mean that selection passed.
+
+**It is still not the reason not to run anything here.** The reason is that you
+have a writable checkout, a network path and no isolation, and running a suite or
+an install from a review job is a side effect nobody asked for. And the gate is
+narrower than "the tests pass": it does not yet cover the browser tests, the
+packaging tests, the type-check job, the coverage controls or the live canaries.
+If a change looks untested, say so — do not infer from a green check that
+something has covered it.
 
 Your job is to read the change and reason about it. If a change needs a test
 that does not exist, that is a finding. If you cannot tell whether existing

--- a/.github/review/REVIEW_PROMPT.md
+++ b/.github/review/REVIEW_PROMPT.md
@@ -4,8 +4,8 @@ You are reviewing a pull request in this repository.
 
 **Start with the conversation, then the specification.** Read the pull request's
 discussion — included below, and described in the next section — before anything
-else. Then read `README.md` **in full**: this repository has no separate design
-document, and the README is the specification — the tool contract, the
+else. Then read `README.md` **in full**: it is the specification — the tool
+contract, the
 client-by-client setup, the transport and allowlist behaviour, and the
 troubleshooting that says what each error means. Do all of that **before** you
 look at the diff: every review here judges a change against its specification,

--- a/.github/review/rules/ci.md
+++ b/.github/review/rules/ci.md
@@ -1,9 +1,13 @@
 # Rule: CI and the review system (`.github/**`)
 
-This directory contains three workflows — `claude-code-review.yml`, the `ci.yml`
-that calls the test jobs and aggregates them into `ci-required`, and the reusable
-`tests-broad.yml` those jobs live in — plus the review system `claude-code-review.yml`
-drives. **The reviewer is reviewing itself here**, so the bar is higher, not
+This directory contains `claude-code-review.yml`, the `ci.yml` that calls the
+test jobs and aggregates them into `ci-required`, and the reusable
+`tests-broad.yml` those jobs live in — plus the review system
+`claude-code-review.yml` drives. (⚠️ The count that used to open this sentence is
+deliberately gone. It said "three" and would have been wrong the moment the next
+job landed, silently, in prose nothing checked — the same rot the test-count
+guard was written for. The files are **named** instead, and a guard holds this
+list to the recorded set.) **The reviewer is reviewing itself here**, so the bar is higher, not
 lower: a defect in this tree degrades or disables review across the repository
 without anything going red. The same is now true of the merge gate: an aggregate
 that stops failing is green, not red.

--- a/.github/review/rules/ci.md
+++ b/.github/review/rules/ci.md
@@ -1,9 +1,12 @@
 # Rule: CI and the review system (`.github/**`)
 
-This directory contains one workflow — `claude-code-review.yml` — and the review
-system it drives. **The reviewer is reviewing itself here**, so the bar is
-higher, not lower: a defect in this tree degrades or disables review across the
-repository without anything going red.
+This directory contains three workflows — `claude-code-review.yml`, the `ci.yml`
+that calls the test jobs and aggregates them into `ci-required`, and the reusable
+`tests-broad.yml` those jobs live in — plus the review system `claude-code-review.yml`
+drives. **The reviewer is reviewing itself here**, so the bar is higher, not
+lower: a defect in this tree degrades or disables review across the repository
+without anything going red. The same is now true of the merge gate: an aggregate
+that stops failing is green, not red.
 
 This review system was adopted from an internal repository where it is in
 production. The structure is kept deliberately close to that one's so fixes can
@@ -131,8 +134,10 @@ that overrides the child's endpoint and credentials.
 
 ## Runner and caps
 
-- `runs-on: ubuntu-latest` for the review job, `ubuntu-slim` for the two `ci.yml`
-  jobs — GitHub-hosted, **not** the self-hosted fleet the upstream repository
+- `runs-on: ubuntu-latest` for the review job and for `ci-required`,
+  `ubuntu-slim` for the two review-system jobs in `ci.yml`, and a
+  `${{ matrix.os }}` over `ubuntu-latest` and `windows-latest` for the broad test
+  job — all GitHub-hosted, **not** the self-hosted fleet the upstream repository
   uses. This repository is public, and a runner group's "Allow public
   repositories" setting is off by default, so it reaches no self-hosted group at
   all. A change that moves either back to `[self-hosted, ...]` needs to say what

--- a/.github/review/rules/docs.md
+++ b/.github/review/rules/docs.md
@@ -67,8 +67,15 @@ reference in the README still resolves.
 
 ## `.system_design/`
 
-**This repository has no `.system_design/` directory today.** The rule matches it
-so that the day one appears it is not reviewed with zero rules loaded.
+**This directory exists and is tracked.** It holds the test-suite design and its
+implementation plan, and it is where the reasoning behind the CI jobs, the
+coverage lanes and the marker scheme lives. The sentence that stood here said the
+repository had none; that was true when it was written and stopped being true
+without anyone editing it, which is why the claim is now guarded.
+
+⚠️ **It is deliberately NOT in the always-read set.** Those documents are large
+and each step touches a section of one, so reading them whole on every pull
+request would crowd out the diff. Read the part a change actually touches.
 
 If a pull request adds one, judge it on whether it records the **why** and not
 only the **what**: for each significant design choice, why it is done this way

--- a/.github/review/rules/docs.md
+++ b/.github/review/rules/docs.md
@@ -2,8 +2,8 @@
 
 ## README.md is the specification
 
-There is no separate design document in this repository. **`README.md` is the
-closest thing it has to one**, and it is what every user reads before installing:
+**`README.md` is the specification a change is judged against**, and it is what
+every user reads before installing:
 the tool contract, the client-by-client setup for seven MCP clients, the
 transport and allowlist behaviour, the proxy configuration, and the
 troubleshooting that tells someone what a `403` or `421` actually means.

--- a/.github/review/scripts/select_rules.py
+++ b/.github/review/scripts/select_rules.py
@@ -171,8 +171,11 @@ RULE_SPECS: tuple[RuleSpec, ...] = (
     # tells a user what a `403` means. A change to behaviour that does not move it
     # is drift. `SECURITY.md` is the same for the threat model.
     #
-    # `.system_design/` is matched although this repository has none today. The
-    # pattern costs nothing and covers the directory the day it appears; the
+    # `.system_design/` is matched because the directory exists and holds the
+    # test-suite design and its implementation plan. (⚠️ This comment used to say
+    # the repository had no such directory -- true when written, false since, and
+    # the third file found carrying that belief.) The pattern also covers any
+    # document added to it later; the
     # alternative is a design document landing with no rule file selected, which
     # is exactly the shape upstream recorded as a defect (`contracts/` matched
     # nothing for months while 397 files accumulated).

--- a/.github/review/tests/test_review_scripts.py
+++ b/.github/review/tests/test_review_scripts.py
@@ -763,10 +763,11 @@ class TestSelectRules(unittest.TestCase):
 
         The README is the always-read document: it carries the tool contract,
         the client-by-client setup for seven MCP clients, and the transport and
-        allowlist behaviour. (⚠️ This sentence used to open "there is no
-        `.system_design/` here". There is one, holding the test-suite design; it
-        is deliberately not in the always-read set because those documents are
-        large and each change touches a section of one.) A change to the README
+        allowlist behaviour. (⚠️ This sentence used to open by denying the
+        repository kept design documents of its own -- described rather than
+        reproduced, since the sweep guard reads this file. It keeps two, under
+        `.system_design/`; they are deliberately not in the always-read set
+        because they are large and each change touches a section of one.) A change to the README
         is a specification change and must
         load `docs.md`, which is what tells the reviewer to judge it as one.
 
@@ -12635,27 +12636,40 @@ class NoDocumentClaimsTheRepositoryHasNoTestGateTests(unittest.TestCase):
             re.compile(r"the two (?:CI|`ci\.yml`) jobs"),
             "`ci.yml` has more than two jobs",
         ),
-        # 🔴 A different claim class, added for the same reason and swept by the
-        # same walk: four files stated this repository has no `.system_design/`
-        # directory. It has one, holding the design these very CI jobs implement
-        # -- and one of the four told the automated reviewer not to report a
-        # missing design document, so the belief was degrading every review
-        # rather than merely sitting there. Not caused by the CI work; found
-        # while sweeping for the claims above, which is the argument for
-        # sweeping rather than editing the files somebody remembered.
+        # 🔴 **A different claim class, and the one that taught this guard what
+        # a pattern should be about.** Four files stated this repository has no  # noqa: ci-claim
+        # `.system_design/` directory. It has one, holding the design these CI
+        # jobs implement -- and one of the four told the automated reviewer not
+        # to report a missing design document, so the belief was degrading every
+        # review rather than sitting inert.
+        #
+        # 🔴 **The first two attempts matched PHRASINGS and both went stale  # noqa: ci-claim
+        # within a day.** A pattern for "no `.system_design/` directory" missed  # noqa: ci-claim
+        # "no design document"; adding that missed "no separate design document"  # noqa: ci-claim
+        # and "has none today". Each round the guard's own documentation claimed
+        # the tree was clean, and each round the automated review found more --
+        # three times. The lesson is not "add another spelling": it is that a
+        # pattern per phrasing makes the guard's reach a function of the author's
+        # imagination. These two match the **belief** instead, by proximity in
+        # both directions, and they were validated against the true sentences
+        # they sit beside before being adopted -- `test_no_rule_fires_on_the_
+        # true_sentences_it_sits_beside` is where those live.
+        #
+        # ⚠️ `no` and `none` but deliberately NOT `not`: "do not report a missing  # noqa: ci-claim
+        # design document as a finding" is a real instruction in the guide, and a
+        # guard that fires on it gets the instruction deleted rather than the
+        # pattern fixed.
         (
-            re.compile(r"(?:has no|is no|no) `?\.system_design/?`? ?(?:directory|here)"),  # noqa: ci-claim
+            re.compile(r"\b(?:no|none|neither|without|lacks)\b[^.\n]{0,80}(?:design document|\.system_design)"),  # noqa: ci-claim
             "`.system_design/` exists and holds the test-suite design",
         ),
-        # 🔴 The same belief in different words, and the automated review found
-        # it surviving in two files after the first pass swept only the
-        # `.system_design/` spelling. That is the argument for a pattern per
-        # PHRASING rather than per belief: a sweep is only as wide as its
-        # vocabulary, and this one's documentation claimed the belief was gone
-        # from the tree while the tree still carried it.
         (
-            re.compile(r"(?:has no|is no|no) design document"),  # noqa: ci-claim
-            "`.system_design/` exists; say which documents are always-read instead",
+            # ⚠️ `none` only, NOT `no`. Measured: "the alternative is a design
+            # document landing with no rule file selected" is a true sentence in
+            # two files, and a reverse pattern accepting `no` fires on it. A
+            # guard that cries wolf on correct prose gets the prose deleted.
+            re.compile(r"(?:design document|\.system_design)[^.\n]{0,80}\bnone\b"),  # noqa: ci-claim
+            "`.system_design/` exists and holds the test-suite design",
         ),
     )
 
@@ -12712,6 +12726,13 @@ class NoDocumentClaimsTheRepositoryHasNoTestGateTests(unittest.TestCase):
             "fourth by section. This repository has no `.system_design/` directory.",  # noqa: ci-claim
             "There is no `.system_design/` here; the README carries the contract",  # noqa: ci-claim
             "this comment is its only record, because this repository has no design document",  # noqa: ci-claim
+            # 🔴 The three the SECOND pattern round still missed, found by the
+            # automated review after this guard's docstring said the tree was
+            # clean. They are kept as specimens precisely because nobody
+            # predicted them.
+            "read `README.md` in full: this repository has no separate design document",  # noqa: ci-claim
+            "There is no separate design document in this repository.",  # noqa: ci-claim
+            "`.system_design/` is matched although this repository has none today.",  # noqa: ci-claim
         )
         for specimen in specimens:
             with self.subTest(specimen=specimen):
@@ -12737,6 +12758,8 @@ class NoDocumentClaimsTheRepositoryHasNoTestGateTests(unittest.TestCase):
             "`.system_design/` holds the test-suite design and its plan",
             "it is deliberately not in the always-read set",
             "do not report a missing design document as a finding",
+            "`.system_design/` exists and holds the test-suite design and its plan",
+            "this repository has a `.system_design/` of its own but does not always-read it",
         ):
             with self.subTest(sentence=sentence):
                 firing = [
@@ -12769,11 +12792,39 @@ class NoDocumentClaimsTheRepositoryHasNoTestGateTests(unittest.TestCase):
                 # A binary file cannot carry a reviewable sentence, and failing
                 # on one would make this guard about file types.
                 continue
-            for lineno, line in enumerate(text.splitlines(), 1):
+            lines = text.splitlines()
+            for lineno, line in enumerate(lines, 1):
                 if self.MARKER in line:
                     continue
+                # 🔴 **The line AND the line joined to its successor.** A claim
+                # wrapped across a line break is invisible to a line-oriented
+                # sweep, and that is not hypothetical: `REVIEW_PROMPT.md` split
+                # "no separate design / document" over two lines and survived a
+                # round of this guard for exactly that reason, while the same
+                # sentence in an unwrapped file was caught. Prose in this tree is
+                # hard-wrapped at 80 columns, so every claim longer than a few
+                # words is a candidate. The successor is joined with a space so
+                # the two halves read as one sentence, and its own marker is
+                # honoured so a marked line cannot be dragged in by its
+                # neighbour.
+                # ⚠️ **Joined only when the line looks like a CONTINUATION.**
+                # Measured while writing this: fusing every line with its
+                # successor made two adjacent entries of a list read as one
+                # sentence and fire a rule neither of them contains. Hard-wrapped
+                # prose breaks mid-sentence, so a line that already ends in
+                # sentence-final punctuation, a closing quote or a comma is not a
+                # wrapped half and must not be extended.
+                joined = line
+                stripped = line.rstrip()
+                if (
+                    lineno < len(lines)
+                    and stripped
+                    and stripped[-1] not in '.!?:,"\''
+                    and self.MARKER not in lines[lineno]
+                ):
+                    joined = line + " " + lines[lineno].lstrip("#> ").strip()
                 for rule, correction in self.CLAIMS:
-                    if rule.search(line):
+                    if rule.search(line) or rule.search(joined):
                         # 🔴 The correction travels WITH the pattern. One sweep
                         # now holds two unrelated claim classes, and a shared
                         # message would tell whoever reintroduced the

--- a/.github/review/tests/test_review_scripts.py
+++ b/.github/review/tests/test_review_scripts.py
@@ -258,6 +258,14 @@ def _matrix_values(block: str, key: str):
         or any of its values is a shape this parser cannot resolve.
     """
 
+    # 🔴 An `include:` or `exclude:` written INLINE is unreadable to a
+    # line-oriented scan, and stepping over it is not safe: `include:
+    # [{os: ubuntu-slim}]` names a runner the top-level list does not, so
+    # skipping it returns a label set missing its most constrained member and
+    # passes a cap that leg could never honour. Measured before this was added.
+    if re.search(r"^\s+(?:include|exclude):[ \t]*\S", block, re.M):
+        return None
+
     found = set()
     lines = block.splitlines()
     for index, line in enumerate(lines):
@@ -320,16 +328,36 @@ def _block_sequence(lines, key_indent: int):
 
     Returns:
         The labels, or ``None`` when the sequence is empty or carries a shape
-        this parser cannot read.
+        this parser cannot read. A line indented no further than the key ends
+        the sequence normally; an unreadable line **inside** it refuses the
+        whole job rather than truncating the list at that point.
     """
 
     labels = []
     for line in lines:
         if not line.strip():
             continue
-        item = re.match(r"^(\s+)-[ \t]+(\S.*?)[ \t]*(?:#.*)?$", line)
-        if item is None or len(item.group(1)) <= key_indent:
+        # 🔴 **A sequence ends at a DEDENT and at nothing else.** The first
+        # draft ended it at "the next line that is not an item", which made a
+        # comment BETWEEN two items look like the end of the list: the labels
+        # above it were returned and everything below was dropped. Measured --
+        # `ubuntu-latest`, a comment, `ubuntu-slim` resolved to just the first,
+        # so the lowest recorded ceiling came back 360 instead of 15 and a
+        # 60-minute cap passed. A confident wrong answer is the one outcome this
+        # module promises never to give, so the two conditions are now separate:
+        # a dedent ENDS the list, anything else unreadable REFUSES the job.
+        if len(line) - len(line.lstrip()) <= key_indent:
             break
+        # A whole-line comment is readable YAML that carries no datum, so it is
+        # stepped over rather than refused -- the same tolerance the item and
+        # scalar patterns already extend to a TRAILING comment. Refusing it
+        # would be safe but would make the guard dictate the comment style of
+        # the file it checks, which gets a guard edited into silence.
+        if line.lstrip().startswith("#"):
+            continue
+        item = re.match(r"^(\s+)-[ \t]+(\S.*?)[ \t]*(?:#.*)?$", line)
+        if item is None:
+            return None
         token = item.group(2).strip("'\"")
         if "${{" in token or not RUNNER_LABEL.match(token):
             return None
@@ -729,9 +757,13 @@ class TestSelectRules(unittest.TestCase):
     def test_the_specification_selects_the_docs_rule(self):
         """🔴 `README.md` is this repository's specification, not its blurb.
 
-        There is no `.system_design/` here; the README carries the tool contract,
+        The README is the always-read document: it carries the tool contract,
         the client-by-client setup for seven MCP clients, and the transport and
-        allowlist behaviour. A change to it is a specification change and must
+        allowlist behaviour. (⚠️ This sentence used to open "there is no
+        `.system_design/` here". There is one, holding the test-suite design; it
+        is deliberately not in the always-read set because those documents are
+        large and each change touches a section of one.) A change to the README
+        is a specification change and must
         load `docs.md`, which is what tells the reviewer to judge it as one.
 
         Upstream this path asserts the opposite -- `select(["README.md"]) == []`
@@ -11544,10 +11576,13 @@ class DeclaredJobCapIsEnforceableTests(unittest.TestCase):
         falling through a condition". This case is what makes that sentence
         true: a job claiming the exemption is held to the shape justifying it.
 
-        ⚠️ Vacuous today -- this repository has no caller job. §1.3 of the
-        implementation plan commits `ci.yml` to becoming callers, and this is
-        here so the exemption is checked from the first one rather than
-        retrofitted after somebody notices.
+        ⚠️ **No longer vacuous, and the sentence saying it was has been
+        corrected rather than left.** It was written before any caller job
+        existed, so that the exemption would be checked from the first one
+        rather than retrofitted after somebody noticed. `ci.yml`'s `broad` job
+        is that first one. It declares `uses:` and `permissions:` -- the latter
+        is legal on a caller and does not forfeit the exemption -- and neither
+        of the two keys this case forbids.
         """
 
         for job in self._jobs():
@@ -11714,6 +11749,120 @@ class WorkflowJobParserTests(unittest.TestCase):
         )
         self.assertEqual([job["job"] for job in jobs], ["a"])
 
+class BroadTestJobWiringTests(unittest.TestCase):
+    """The test job's own selection, held to the design rather than to a review.
+
+    🔴 **Every claim here was, until this class existed, checked only by a human
+    reading the diff.** Each of the four below could be deleted and the entire
+    suite -- and the CI run itself -- would stay green:
+
+    * drop `windows-latest` and the gate silently covers one platform;
+    * drop `--ignore=tests/package` and a file under that directory whose author
+      forgot its marker runs against the source checkout while claiming to have
+      tested an installed wheel;
+    * drop `--min-selected` and a selector that stops matching is green having
+      run almost nothing, which is the exact failure the floor exists for;
+    * install `.` instead of `.[dev]` and the cases that shell out to `mypy`
+      fail while the rest pass, which reads as a partial breakage.
+
+    ⚠️ **The CI run cannot substitute for these.** A green run proves the command
+    that ran was fine; it says nothing about the command being the one the design
+    asked for. `tests/package/` does not exist yet, so the path exclusion is
+    forward-looking and no run can exercise it at all.
+    """
+
+    WORKFLOW = (
+        Path(__file__).resolve().parents[2] / "workflows" / "tests-broad.yml"
+    )
+
+    def _text(self):
+        """Return the reusable test workflow.
+
+        Returns:
+            `tests-broad.yml` as text.
+        """
+
+        return self.WORKFLOW.read_text(encoding="utf-8")
+
+    def _selection_command(self):
+        """Return the pytest invocation, whitespace-normalised.
+
+        The command is written as a folded block scalar across several lines, so
+        it is collapsed to one before matching -- otherwise every assertion below
+        would silently depend on where the author wrapped it.
+
+        Returns:
+            The command as a single line.
+        """
+
+        text = self._text()
+        start = text.index("python -m pytest")
+        return " ".join(text[start:].split())
+
+    def test_the_selection_is_the_one_the_design_specifies(self):
+        """Both halves: the marker expression AND the path exclusion.
+
+        🔴 The path exclusion is **not** redundant with the marker. A marker
+        exclusion only helps when the marker is present, and a file under
+        `tests/package/` whose author forgot `@pytest.mark.package` is still
+        collected by the expression alone. Path and marker together; neither
+        alone.
+        """
+
+        command = self._selection_command()
+
+        self.assertIn("--ignore=tests/package", command)
+        self.assertIn(
+            '-m "not live and not chromium and not package"',
+            command,
+            "the marker expression is not the one the design specifies",
+        )
+
+    def test_the_selection_carries_a_collection_floor(self):
+        """A selector that stops matching is otherwise green having run nothing.
+
+        pytest fails by itself only when a selector matches *nothing* (exit 5).
+        The dangerous case is a selector matching a handful where it should match
+        hundreds: that exits 0. Only a declared floor catches it, so its presence
+        is asserted rather than assumed.
+        """
+
+        floor = re.search(r"--min-selected (\d+)", self._selection_command())
+
+        self.assertIsNotNone(floor, "the job declares no `--min-selected` floor")
+        self.assertGreater(
+            int(floor.group(1)),
+            0,
+            "a floor of zero is the option's inert default written out longhand",
+        )
+
+    def test_both_platforms_are_covered(self):
+        """A gate over one platform is half a gate, and looks exactly like one.
+
+        Named rather than counted: a matrix that swapped Windows for a second
+        Linux label would keep the leg count at two while covering one operating
+        system.
+        """
+
+        matrix = re.search(r"^        os: \[(.+)\]$", self._text(), re.M)
+
+        self.assertIsNotNone(matrix, "the job declares no flow-style `os` matrix")
+        labels = {item.strip() for item in matrix.group(1).split(",")}
+        self.assertEqual(labels, {"ubuntu-latest", "windows-latest"})
+
+    def test_the_install_carries_the_extra_the_selection_needs(self):
+        """`.[dev]`, not `.`, and the failure without it is asymmetric.
+
+        The selection includes `subsystem` cases that shell out to `mypy`, which
+        lives only in the `dev` extra. With it absent those cases fail while the
+        harness's configuration-reading cases still pass -- a partial breakage
+        rather than a missing tool, which is the reading that costs an
+        afternoon.
+        """
+
+        self.assertIn('pip install -e ".[dev]"', self._text())
+
+
 class CiRequiredAggregatorTests(unittest.TestCase):
     """The one required check, held to the shape that makes it one.
 
@@ -11739,6 +11888,25 @@ class CiRequiredAggregatorTests(unittest.TestCase):
         """
 
         return self.CI.read_text(encoding="utf-8")
+
+    def _job_block(self, name):
+        """Return one job's text from `ci.yml`, bounded to that job.
+
+        Args:
+            name: The job id.
+
+        Returns:
+            The job's text.
+        """
+
+        text = self._text()
+        start = text.index("\n  " + name + ":")
+        rest = text[start + 1 :]
+        end = re.search(r"\n  [A-Za-z_][\w-]*:\n", rest)
+        block = rest[: end.start()] if end else rest
+        self.assertIn(f"{name}:", block)
+        self.assertLess(len(block), len(text) // 2, "the job window did not close")
+        return block
 
     def _aggregate_block(self):
         """Return the aggregate job's own text, bounded to that job.
@@ -11867,21 +12035,61 @@ class CiRequiredAggregatorTests(unittest.TestCase):
             "because its own `if:` skips it on every other event",
         )
 
-    def test_the_conditional_clause_mirrors_that_jobs_own_condition(self):
-        """The exemption is only sound while the two conditions agree.
+    #: The exact condition `review_replies` must carry, as a WHOLE line. The
+    #: aggregate excuses that job on every event this expression excludes, so the
+    #: excuse is sound only while the expression is exactly this one.
+    REPLIES_CONDITION = "    if: github.event_name == 'pull_request'"
 
-        If `review_replies` stopped being `pull_request`-only, the clause above
-        would start excusing a job that was scheduled and skipped anyway. The
-        two lines live four hundred apart in one file, which is precisely the
-        arrangement that produced the runner-ceiling defect.
+    def test_the_conditional_clause_mirrors_that_jobs_own_condition(self):
+        """🔴 The excuse is only sound while the condition justifying it holds.
+
+        The aggregate does not require `review_replies` to succeed unless the
+        event is `pull_request`. That is safe **because that job does not run on
+        any other event**. If its own `if:` were widened, it would start running
+        on a push -- and a failure there would land in the gap the excuse opens:
+        the job runs, fails, and the aggregate does not count it. `ci-required`
+        then reports green over a failed merge gate.
+
+        🔴 **Pinned as a whole line, not as a substring, and this is the second
+        version of this check.** The first counted occurrences of the condition
+        and required exactly two. A count cannot see a WIDENED condition:
+        measured against that version, changing the job's `if:` to
+        `... == 'pull_request' || github.event_name == 'push'` left the string
+        present, the count at two, and **all 545 cases green** over exactly the
+        hole described above. Substring containment is the wrong relation for a
+        claim about what an expression EXCLUDES.
         """
 
-        text = self._text()
+        block = self._job_block("review_replies")
+        conditions = [
+            line for line in block.splitlines() if line.startswith("    if:")
+        ]
+
         self.assertEqual(
-            text.count("github.event_name == 'pull_request'"),
-            2,
-            "the aggregate's conditional clause and `review_replies`'s own "
-            "`if:` must both be present and must be the only two",
+            conditions,
+            [self.REPLIES_CONDITION],
+            "`review_replies` must carry exactly this condition and no other. "
+            "The aggregate excuses it on every event this expression excludes, "
+            "so widening it opens a gap in which the job runs, fails, and is "
+            "not counted -- change both together or neither",
+        )
+
+    def test_the_aggregates_excuse_names_the_same_event_the_job_is_limited_to(self):
+        """The other half of the mirror: the excuse must not outrun the limit.
+
+        Pinned separately from the case above so the two failures are
+        distinguishable. Widening the JOB is one defect; widening the EXCUSE to
+        an event the job does run on is a different one, and a single assertion
+        covering both would report the same message for either.
+        """
+
+        event = re.search(r"github\.event_name == ('[a-z_]+')", self.REPLIES_CONDITION)
+        self.assertIsNotNone(event, "the recorded condition no longer names an event")
+        self.assertIn(
+            f"github.event_name == {event.group(1)}",
+            self._aggregate_block(),
+            "the aggregate excuses `review_replies` on an event other than the "
+            "one its own condition limits it to",
         )
 
     def test_no_expression_reaches_a_shell(self):
@@ -12182,6 +12390,55 @@ class MatrixRunnerResolutionTests(unittest.TestCase):
         )
         self.assertEqual(jobs[0]["runners"], ("ubuntu-latest", "windows-latest"))
 
+    def test_a_comment_between_sequence_items_does_not_truncate_the_list(self):
+        """🔴 The silent under-resolution, measured before it was fixed.
+
+        A comment between two items is not an item. The first draft treated
+        "not an item" as "the sequence ended", so it returned the labels ABOVE
+        the comment and dropped everything below -- a confident wrong answer,
+        which is the one outcome :func:`_matrix_values` promises never to give.
+
+        Measured on that draft: a matrix of `ubuntu-latest`, a comment, then
+        `ubuntu-slim` resolved to `('ubuntu-latest',)`, whose lowest recorded
+        ceiling is 360, and a `timeout-minutes: 60` therefore PASSED the cap
+        check while one leg ran on a 15-minute runner. That is the original
+        defect this entire class was written after, reached through a different
+        door.
+        """
+
+        jobs = self._write(
+            self.HEAD
+            + "  a:\n    runs-on: ${{ matrix.os }}\n    timeout-minutes: 60\n"
+            + "    strategy:\n      matrix:\n        os:\n"
+            + "          - ubuntu-latest\n"
+            + "          # the cheap one\n"
+            + "          - ubuntu-slim\n"
+        )
+        self.assertEqual(jobs[0]["runners"], ("ubuntu-latest", "ubuntu-slim"))
+
+    def test_a_flow_style_include_is_refused_rather_than_stepped_over(self):
+        """🔴 The second door to the same wrong answer.
+
+        `include: [{os: ubuntu-slim}]` is legal YAML that GitHub accepts, and it
+        names a runner the top-level list does not. The line-oriented scan
+        cannot see inside it, and skipping it leaves the label invisible --
+        again resolving to a set that is missing its most constrained member,
+        again passing a cap that one leg could never honour.
+
+        Refused, not partially resolved: an `include:` this parser cannot read
+        may always be hiding a runner, so the honest answer about the whole job
+        is that it has none this file can settle.
+        """
+
+        jobs = self._write(
+            self.HEAD
+            + "  a:\n    runs-on: ${{ matrix.os }}\n    timeout-minutes: 60\n"
+            + "    strategy:\n      matrix:\n"
+            + "        os: [ubuntu-latest]\n"
+            + "        include: [{os: ubuntu-slim}]\n"
+        )
+        self.assertIsNone(jobs[0]["runners"])
+
     def test_a_key_whose_name_merely_starts_with_the_referenced_one_is_not_read(self):
         """`os-arch` is not `os`, and resolving against it would be confident and wrong.
 
@@ -12282,6 +12539,33 @@ class RecordedTestCountTests(unittest.TestCase):
                     "reader whether their local run was complete",
                 )
 
+    def test_the_ci_rule_names_every_workflow_file(self):
+        """🔴 Prose that lists files rots exactly like prose that counts them.
+
+        `rules/ci.md` opens by saying what this directory holds. It used to open
+        with a **count** -- "three workflows" -- which the next job to land would
+        have made wrong, silently, in a document nothing checked. The count is
+        gone and the files are named instead, and this is what keeps the naming
+        honest: it is derived from :data:`EXPECTED_WORKFLOW_FILES`, which is
+        itself pinned against the tree, so a workflow added without a mention
+        here fails rather than being quietly unmentioned to the reviewer that
+        reads this file.
+        """
+
+        rule = (
+            Path(__file__).resolve().parents[1] / "rules" / "ci.md"
+        ).read_text(encoding="utf-8")
+
+        for name in sorted(EXPECTED_WORKFLOW_FILES):
+            with self.subTest(workflow=name):
+                self.assertIn(
+                    name,
+                    rule,
+                    f"{name} is a workflow in this repository and the `ci` rule "
+                    "file does not mention it, so a pull request touching it is "
+                    "reviewed against a description of the tree that omits it",
+                )
+
     def test_the_count_is_derived_and_not_a_constant(self):
         """🔴 The control: a hard-coded total would pass the case above for ever.
 
@@ -12327,14 +12611,38 @@ class NoDocumentClaimsTheRepositoryHasNoTestGateTests(unittest.TestCase):
     #: which is a true sentence this repository needs to keep.
     CLAIMS = (
         # "this repository has no CI test job" / "no CI for its own code"  # noqa: ci-claim
-        re.compile(r"no CI (?:test job|for its own)"),
+        (
+            re.compile(r"no CI (?:test job|for its own)"),
+            "this repository DOES run its tests in CI",
+        ),
         # "`claude-code-review.yml` is its only workflow"  # noqa: ci-claim
-        re.compile(r"is its only workflow"),  # noqa: ci-claim
+        (
+            re.compile(r"is its only workflow"),  # noqa: ci-claim
+            "there is more than one workflow",
+        ),
         # "This directory contains one workflow"  # noqa: ci-claim
-        re.compile(r"contains one workflow"),  # noqa: ci-claim
+        (
+            re.compile(r"contains one workflow"),  # noqa: ci-claim
+            "there is more than one workflow",
+        ),
         # "the two CI jobs" / "the two `ci.yml` jobs" -- an undercount now that  # noqa: ci-claim
         # the caller, the aggregate and the broad job exist.
-        re.compile(r"the two (?:CI|`ci\.yml`) jobs"),
+        (
+            re.compile(r"the two (?:CI|`ci\.yml`) jobs"),
+            "`ci.yml` has more than two jobs",
+        ),
+        # 🔴 A different claim class, added for the same reason and swept by the
+        # same walk: four files stated this repository has no `.system_design/`
+        # directory. It has one, holding the design these very CI jobs implement
+        # -- and one of the four told the automated reviewer not to report a
+        # missing design document, so the belief was degrading every review
+        # rather than merely sitting there. Not caused by the CI work; found
+        # while sweeping for the claims above, which is the argument for
+        # sweeping rather than editing the files somebody remembered.
+        (
+            re.compile(r"(?:has no|is no|no) `?\.system_design/?`? ?(?:directory|here)"),  # noqa: ci-claim
+            "`.system_design/` exists and holds the test-suite design",
+        ),
     )
 
     #: Suppress a deliberate match with this marker on the line, exactly as the
@@ -12386,11 +12694,14 @@ class NoDocumentClaimsTheRepositoryHasNoTestGateTests(unittest.TestCase):
             "This directory contains one workflow and the review system",  # noqa: ci-claim
             "`ubuntu-slim` for the two CI jobs, so no runner group",  # noqa: ci-claim
             "`ubuntu-slim` for the two `ci.yml` jobs -- GitHub-hosted",  # noqa: ci-claim
+            "**This repository has no `.system_design/` directory today.**",  # noqa: ci-claim
+            "fourth by section. This repository has no `.system_design/` directory.",  # noqa: ci-claim
+            "There is no `.system_design/` here; the README carries the contract",  # noqa: ci-claim
         )
         for specimen in specimens:
             with self.subTest(specimen=specimen):
                 self.assertTrue(
-                    any(rule.search(specimen) for rule in self.CLAIMS),
+                    any(rule.search(specimen) for rule, _ in self.CLAIMS),
                     "no rule recognises a sentence this guard exists to forbid",
                 )
 
@@ -12408,9 +12719,13 @@ class NoDocumentClaimsTheRepositoryHasNoTestGateTests(unittest.TestCase):
             "the only workflow-level binding kitty reads",
             "the two review-system jobs stay on `ubuntu-slim`",
             "no CI runner group has to be granted",
+            "`.system_design/` holds the test-suite design and its plan",
+            "it is deliberately not in the always-read set",
         ):
             with self.subTest(sentence=sentence):
-                firing = [rule.pattern for rule in self.CLAIMS if rule.search(sentence)]
+                firing = [
+                    rule.pattern for rule, _ in self.CLAIMS if rule.search(sentence)
+                ]
                 self.assertFalse(firing, f"{sentence!r} -> {firing}")
 
     def test_the_sweep_reaches_the_files_it_claims_to(self):
@@ -12441,20 +12756,24 @@ class NoDocumentClaimsTheRepositoryHasNoTestGateTests(unittest.TestCase):
             for lineno, line in enumerate(text.splitlines(), 1):
                 if self.MARKER in line:
                     continue
-                for rule in self.CLAIMS:
+                for rule, correction in self.CLAIMS:
                     if rule.search(line):
+                        # 🔴 The correction travels WITH the pattern. One sweep
+                        # now holds two unrelated claim classes, and a shared
+                        # message would tell whoever reintroduced the
+                        # design-document claim that the repository runs its
+                        # tests in CI -- true, and no help at all.
                         offences.append(
                             f"{path.relative_to(root).as_posix()}:{lineno}: "
-                            f"{line.strip()[:100]}"
+                            f"{line.strip()[:100]}\n      -> {correction}"
                         )
 
         self.assertFalse(
             offences,
-            "this repository DOES run its tests in CI -- `ci.yml` calls the "
-            "broad selection on both platforms and aggregates it into "
-            "`ci-required`. Rewrite each of these to say what is true now "
-            "(which jobs the gate does and does not cover) rather than "
-            "deleting the sentence, so the reasoning survives:\n  "
+            "each of these asserts an absence that is no longer true. Rewrite "
+            "the sentence to say what IS true now -- the arrow on each line "
+            "says what -- rather than deleting it, so the reasoning "
+            "survives:\n  "
             + "\n  ".join(offences),
         )
 

--- a/.github/review/tests/test_review_scripts.py
+++ b/.github/review/tests/test_review_scripts.py
@@ -495,9 +495,10 @@ SCHEMA_PATH = REVIEW_DIR / "schemas" / "review_findings.schema.json"
 # repository has a `.system_design/` of its own but does not always-read it**,
 # and `README.md` is what the always-read set holds -- the tool contract, the
 # client setup, the transport and allowlist behaviour. ⚠️ This comment used to
-# say the repository had none of those documents. It has two, about the test
-# suite; they are large and each change touches a section of one, so they are
-# read where a change touches them rather than in full on every pull request.
+# say the repository had none of those documents. It has its own, under
+# `.system_design/`; they are large and each change touches a section of one, so
+# they are read where a change touches them rather than in full on every pull
+# request. (Not counted here: a count in prose is a claim nothing checks.)
 #
 # 🔴 The tuple survives with one entry rather than collapsing to a string,
 # because what it holds is not "the specification is README.md" but "whatever the
@@ -765,9 +766,10 @@ class TestSelectRules(unittest.TestCase):
         the client-by-client setup for seven MCP clients, and the transport and
         allowlist behaviour. (⚠️ This sentence used to open by denying the
         repository kept design documents of its own -- described rather than
-        reproduced, since the sweep guard reads this file. It keeps two, under
-        `.system_design/`; they are deliberately not in the always-read set
-        because they are large and each change touches a section of one.) A change to the README
+        reproduced, since the sweep guard reads this file. It keeps them under
+        `.system_design/`, uncounted for the reason the head of this file gives;
+        they are deliberately not in the always-read set because they are large
+        and each change touches a section of one.) A change to the README
         is a specification change and must
         load `docs.md`, which is what tells the reviewer to judge it as one.
 

--- a/.github/review/tests/test_review_scripts.py
+++ b/.github/review/tests/test_review_scripts.py
@@ -492,8 +492,12 @@ SCHEMA_PATH = REVIEW_DIR / "schemas" / "review_findings.schema.json"
 
 # Every reviewed pull request must be judged against this, not against the diff
 # alone. Upstream this is a tuple of three `.system_design/` documents; **this
-# repository has none of them**, and `README.md` is what stands in their place --
-# the tool contract, the client setup, the transport and allowlist behaviour.
+# repository has a `.system_design/` of its own but does not always-read it**,
+# and `README.md` is what the always-read set holds -- the tool contract, the
+# client setup, the transport and allowlist behaviour. ⚠️ This comment used to
+# say the repository had none of those documents. It has two, about the test
+# suite; they are large and each change touches a section of one, so they are
+# read where a change touches them rather than in full on every pull request.
 #
 # 🔴 The tuple survives with one entry rather than collapsing to a string,
 # because what it holds is not "the specification is README.md" but "whatever the
@@ -12643,6 +12647,16 @@ class NoDocumentClaimsTheRepositoryHasNoTestGateTests(unittest.TestCase):
             re.compile(r"(?:has no|is no|no) `?\.system_design/?`? ?(?:directory|here)"),  # noqa: ci-claim
             "`.system_design/` exists and holds the test-suite design",
         ),
+        # 🔴 The same belief in different words, and the automated review found
+        # it surviving in two files after the first pass swept only the
+        # `.system_design/` spelling. That is the argument for a pattern per
+        # PHRASING rather than per belief: a sweep is only as wide as its
+        # vocabulary, and this one's documentation claimed the belief was gone
+        # from the tree while the tree still carried it.
+        (
+            re.compile(r"(?:has no|is no|no) design document"),  # noqa: ci-claim
+            "`.system_design/` exists; say which documents are always-read instead",
+        ),
     )
 
     #: Suppress a deliberate match with this marker on the line, exactly as the
@@ -12697,6 +12711,7 @@ class NoDocumentClaimsTheRepositoryHasNoTestGateTests(unittest.TestCase):
             "**This repository has no `.system_design/` directory today.**",  # noqa: ci-claim
             "fourth by section. This repository has no `.system_design/` directory.",  # noqa: ci-claim
             "There is no `.system_design/` here; the README carries the contract",  # noqa: ci-claim
+            "this comment is its only record, because this repository has no design document",  # noqa: ci-claim
         )
         for specimen in specimens:
             with self.subTest(specimen=specimen):
@@ -12721,6 +12736,7 @@ class NoDocumentClaimsTheRepositoryHasNoTestGateTests(unittest.TestCase):
             "no CI runner group has to be granted",
             "`.system_design/` holds the test-suite design and its plan",
             "it is deliberately not in the always-read set",
+            "do not report a missing design document as a finding",
         ):
             with self.subTest(sentence=sentence):
                 firing = [

--- a/.github/review/tests/test_review_scripts.py
+++ b/.github/review/tests/test_review_scripts.py
@@ -85,6 +85,14 @@ WORKFLOW_DIR = Path(__file__).resolve().parents[2] / "workflows"
 RUNNER_JOB_CEILING_MINUTES = {
     "ubuntu-slim": 15,
     "ubuntu-latest": 360,
+    # Added with the first matrix job. An ordinary GitHub-hosted 4-CPU VM
+    # runner, so the 6-hour figure applies to it exactly as it does to the
+    # `ubuntu-*` labels; only the single-CPU tier is special. Re-confirmed
+    # against GitHub's Actions limits reference, which states the general rule
+    # in one sentence: *"Each job in a workflow can run for up to 6 hours of
+    # execution time. If a job reaches this limit, the job is terminated and
+    # fails."*
+    "windows-latest": 360,
     "ubuntu-24.04": 360,
     "ubuntu-22.04": 360,
     "[self-hosted, cap-main, noble]": 7200,
@@ -92,6 +100,38 @@ RUNNER_JOB_CEILING_MINUTES = {
     "[self-hosted, cap-nano, noble]": 7200,
     "[self-hosted, cap-pico, noble]": 7200,
 }
+
+def _lowest_ceiling(runners):
+    """Return the platform ceiling a job with these runners must clear.
+
+    🔴 **The minimum, because a matrix job is as constrained as its most
+    constrained leg.** Taking the highest -- or the first -- would call a
+    60-minute cap enforceable on a matrix that also runs on a 15-minute runner,
+    and that leg would then die at a limit no file in the repository mentions.
+    That is the original defect this whole mechanism was written after,
+    reproduced one level up.
+
+    ⚠️ **One unrecorded label makes the whole answer ``None``**, rather than a
+    minimum over the labels that happened to be recorded. The unrecorded label
+    already fails its own check; returning a number here as well would have the
+    cap check report a verdict it cannot support.
+
+    Args:
+        runners: The resolved runner labels, as :func:`_resolve_runners` returns
+            them.
+
+    Returns:
+        The lowest recorded ceiling in minutes, or ``None`` when any label has
+        none recorded.
+    """
+
+    ceilings = [
+        RUNNER_JOB_CEILING_MINUTES[label]
+        for label in runners
+        if label in RUNNER_JOB_CEILING_MINUTES
+    ]
+    return min(ceilings) if len(ceilings) == len(runners) else None
+
 
 #: Every job this repository runs, as ``(workflow file name, job id)``.
 #:
@@ -103,13 +143,19 @@ RUNNER_JOB_CEILING_MINUTES = {
 EXPECTED_JOBS = {
     ("ci.yml", "review-scripts"),
     ("ci.yml", "review_replies"),
+    # The caller job and the aggregate it feeds. `ci.yml/broad` declares only
+    # `uses:` and is the repository's first caller job, which is what stops
+    # `test_a_caller_job_really_declares_neither_key` being vacuous.
+    ("ci.yml", "broad"),
+    ("ci.yml", "ci-required"),
+    ("tests-broad.yml", "broad"),
     ("claude-code-review.yml", "review"),
 }
 
 #: The workflow files themselves, pinned for the same reason one level up: the
 #: sweep globs rather than enumerates, so a file added later is checked -- and
 #: this set is what fails if one is added, renamed or deleted without a thought.
-EXPECTED_WORKFLOW_FILES = {"ci.yml", "claude-code-review.yml"}
+EXPECTED_WORKFLOW_FILES = {"ci.yml", "claude-code-review.yml", "tests-broad.yml"}
 
 
 def _workflow_files():
@@ -151,6 +197,177 @@ def _jobs_section(text: str) -> str:
     return tail[: following.start()] if following else tail
 
 
+#: A `runs-on:` value that defers to a matrix, e.g. ``${{ matrix.os }}``. Only
+#: this one expression shape is resolvable from the file alone: `vars.` and
+#: `inputs.` name values decided outside it, and are refused.
+MATRIX_RUNNER = re.compile(r"^\$\{\{\s*matrix\.([A-Za-z_][A-Za-z0-9_-]*)\s*\}\}$")
+
+#: A concrete runner label, or one whole flow-list runner specification. The
+#: second alternative is why `runs-on: [self-hosted, cap-main, noble]` stays a
+#: single string: under `runs-on:` a flow list is ONE machine that must carry
+#: every label in it, and :data:`RUNNER_JOB_CEILING_MINUTES` records it spelled
+#: exactly that way. Under `strategy.matrix` the same punctuation means a list of
+#: alternatives, which is the collision :func:`_matrix_values` keeps apart.
+RUNNER_LABEL = re.compile(r"^(?:\[[A-Za-z0-9 ,._-]+\]|[A-Za-z0-9][A-Za-z0-9._-]*)$")
+
+
+def _strategy_block(body: str) -> str | None:
+    """Return one job's ``strategy:`` block, bounded to that job.
+
+    Bounded rather than swept, for the reason :func:`_jobs_section` gives one
+    level up: an unbounded scan reads the *next* job's matrix, and a job that
+    declares no strategy of its own then acquires a resolved runner it never
+    named.
+
+    Args:
+        body: One job's text, as sliced by :func:`_declared_jobs`.
+
+    Returns:
+        The block's text, or ``None`` when the job declares no ``strategy:``.
+    """
+
+    opening = re.search(r"^ {4}strategy:[ \t]*$", body, re.M)
+    if opening is None:
+        return None
+    tail = body[opening.end() :]
+    # The block ends at the next key at job depth -- four spaces and not deeper.
+    following = re.search(r"^ {4}\S", tail, re.M)
+    return tail[: following.start()] if following else tail
+
+
+def _matrix_values(block: str, key: str):
+    """Return every concrete value a matrix assigns to one key.
+
+    🔴 **`include:` entries are unioned in rather than skipped.** They may name a
+    runner the top-level list never does, and a label this function does not
+    return is a label the ceiling check never sees -- the guard going quietly
+    hollow, which is the failure it exists to prevent. `exclude:` is deliberately
+    NOT honoured: it only removes combinations, so ignoring it over-approximates,
+    which is the safe direction.
+
+    ⚠️ **Anything it cannot read makes the whole answer ``None``.** A partially
+    resolved label set is worse than an unresolved one, because it reports a
+    verdict on the labels it happened to understand.
+
+    Args:
+        block: The job's ``strategy:`` block.
+        key: The matrix key the `runs-on:` expression referenced.
+
+    Returns:
+        The values, sorted and de-duplicated, or ``None`` when the key is absent
+        or any of its values is a shape this parser cannot resolve.
+    """
+
+    found = set()
+    lines = block.splitlines()
+    for index, line in enumerate(lines):
+        # Both `os: ...` and an `include:` entry's `- os: ...` reach here.
+        # The same trailing-comment tolerance the `runs-on:` and
+        # `timeout-minutes:` patterns already carry, and for the reason stated
+        # there: a parser lenient about one key and strict about another, for no
+        # recorded reason, sends the author the wrong way. Measured before this
+        # was added -- `os: [ubuntu-latest, windows-latest]  # both platforms`
+        # resolved to None, so a legal and well-commented matrix was refused.
+        match = re.match(
+            rf"^(\s+)(?:-\s+)?{re.escape(key)}:[ \t]*(.*?)[ \t]*(?:#.*)?$", line
+        )
+        if match is None:
+            continue
+        indent, value = len(match.group(1)), match.group(2)
+        if value:
+            parsed = _scalar_or_flow_list(value)
+            if parsed is None:
+                return None
+            found.update(parsed)
+            continue
+        # An empty value means a block sequence follows, indented further.
+        items = _block_sequence(lines[index + 1 :], indent)
+        if items is None:
+            return None
+        found.update(items)
+
+    return tuple(sorted(found)) if found else None
+
+
+def _scalar_or_flow_list(value: str):
+    """Read a matrix value written inline, as a scalar or a flow list.
+
+    Args:
+        value: The text after the key's colon, already stripped.
+
+    Returns:
+        The labels it names, or ``None`` for a shape this parser cannot read --
+        an expression, or a token that is not a plain label.
+    """
+
+    inner = value[1:-1] if value.startswith("[") and value.endswith("]") else value
+    labels = []
+    for token in inner.split(","):
+        token = token.strip().strip("'\"")
+        # An expression has no answer in this file, so neither does the job.
+        if not token or "${{" in token or not RUNNER_LABEL.match(token):
+            return None
+        labels.append(token)
+    return labels
+
+
+def _block_sequence(lines, key_indent: int):
+    """Read a block-style YAML sequence following a key with an empty value.
+
+    Args:
+        lines: The lines after the key's own line.
+        key_indent: The key's indentation, in spaces. Items must be deeper.
+
+    Returns:
+        The labels, or ``None`` when the sequence is empty or carries a shape
+        this parser cannot read.
+    """
+
+    labels = []
+    for line in lines:
+        if not line.strip():
+            continue
+        item = re.match(r"^(\s+)-[ \t]+(\S.*?)[ \t]*(?:#.*)?$", line)
+        if item is None or len(item.group(1)) <= key_indent:
+            break
+        token = item.group(2).strip("'\"")
+        if "${{" in token or not RUNNER_LABEL.match(token):
+            return None
+        labels.append(token)
+    return labels or None
+
+
+def _resolve_runners(runner: str | None, body: str):
+    """Resolve a job's `runs-on:` to the concrete labels it can run on.
+
+    This is the field every ceiling verdict reads. ``runner`` survives beside it
+    only to carry the text a failure message quotes -- a job spelling
+    ``runs-on: ${{ inputs.os }}`` has a ``runner`` and no resolvable label at
+    all, so a check reading ``runner`` would wave it through.
+
+    Args:
+        runner: The `runs-on:` scalar exactly as written, or ``None``.
+        body: The whole job body, for its ``strategy:`` block.
+
+    Returns:
+        A tuple of one or more labels, or ``None`` when the job names no runner
+        this parser can resolve. ``None`` is refused by the caller, never
+        skipped.
+    """
+
+    if runner is None:
+        return None
+    if "${{" not in runner:
+        return (runner,) if RUNNER_LABEL.match(runner) else None
+    reference = MATRIX_RUNNER.match(runner)
+    if reference is None:
+        return None
+    block = _strategy_block(body)
+    if block is None:
+        return None
+    return _matrix_values(block, reference.group(1))
+
+
 def _declared_jobs(path):
     """Parse one workflow file's jobs into what the ceiling check needs.
 
@@ -167,11 +384,14 @@ def _declared_jobs(path):
         path: The workflow file.
 
     Returns:
-        One dict per job with ``file``, ``job``, ``runner``, ``timeout`` and
-        ``caller``. ``runner`` and ``timeout`` are ``None`` when the key is
-        absent *or* spelled in a form this parser does not resolve -- the caller
-        fails on ``None`` rather than skipping, so an unresolvable shape is
-        loud.
+        One dict per job with ``file``, ``job``, ``runner``, ``runners``,
+        ``timeout`` and ``caller``. ``runner`` and ``timeout`` are ``None`` when
+        the key is absent *or* spelled in a form this parser does not resolve --
+        the caller fails on ``None`` rather than skipping, so an unresolvable
+        shape is loud. ``runners`` is the resolved tuple of concrete labels and
+        is what every ceiling verdict reads; it is ``None`` for a `runs-on:`
+        naming no label this file can settle, including a matrix reference with
+        no matrix behind it.
     """
 
     section = _jobs_section(path.read_text(encoding="utf-8"))
@@ -219,11 +439,15 @@ def _declared_jobs(path):
         timeout = re.findall(
             r"^ {4}timeout-minutes:[ \t]*(\d+)[ \t]*(?:#.*)?$", body, re.M
         )
+        resolved = runner[0] if len(runner) == 1 else None
         jobs.append(
             {
                 "file": path.name,
                 "job": name,
-                "runner": runner[0] if len(runner) == 1 else None,
+                "runner": resolved,
+                # The field every ceiling verdict reads -- see
+                # :func:`_resolve_runners` for why `runner` is not it.
+                "runners": _resolve_runners(resolved, body),
                 "timeout": int(timeout[0]) if len(timeout) == 1 else None,
                 # A reusable-workflow call legally declares neither key, so it is
                 # exempted BY NAME rather than by falling through a condition --
@@ -6072,10 +6296,21 @@ class ReviewRepliesWiringTests(unittest.TestCase):
         self.assertIn("pull-requests: read", block)
 
     def test_the_ci_job_runs_only_on_pull_requests(self):
-        """🔴 AC14c — `ci.yml` also fires on `push: [main]`, a nightly
-        `schedule` and `workflow_dispatch`. There is no pull request on those,
-        and a gate that fails when it cannot check would turn that into a red
-        `main` and a red cron every morning."""
+        """🔴 AC14c — `ci.yml` also fires on `push: [main]` and
+        `workflow_dispatch`. There is no pull request on either, and a gate that
+        failed when it cannot check would turn every push to `main` red.
+
+        ⚠️ **Corrected when the test jobs landed.** This docstring was carried
+        across from the upstream repository and also claimed a nightly
+        `schedule`; there has never been one here. `push` was equally untrue
+        until the same change added it, so the sentence described a file that
+        did not exist in either direction.
+
+        🔴 **This condition is now mirrored by `ci-required`**, which excuses
+        this job from its strict `success` comparison on exactly the events
+        where this `if:` skips it. `test_the_conditional_clause_mirrors_that_jobs_own_condition`
+        holds the two together; loosening this line without that one is what
+        would turn the excuse into a hole."""
         block = self._job_block("review_replies")
 
         self.assertIn("github.event_name == 'pull_request'", block)
@@ -11244,31 +11479,42 @@ class DeclaredJobCapIsEnforceableTests(unittest.TestCase):
     def test_every_job_names_a_runner_whose_ceiling_is_recorded(self):
         """An unrecorded label cannot be checked, so it is refused.
 
-        ⚠️ **This is the clause the CI epic will hit first, deliberately.** A
-        matrix job spells its runner `${{ matrix.os }}`, which resolves to no
-        entry here and fails with the message below rather than being waved
-        through. The ceiling for a matrix runner is a decision worth making when
-        the matrix is written; discovering later that the check went hollow is
-        the expensive order.
+        🔴 **This is the clause the first matrix job hit, exactly as intended,
+        and the record of what happened next belongs here.** That job spells its
+        runner `${{ matrix.os }}`. Before the parser could resolve it, the label
+        reaching this check was the expression itself, it matched no entry, and
+        the job failed with the message below rather than being waved through --
+        which is what forced the ceiling for a matrix runner to be decided when
+        the matrix was written. The fix was to teach the parser to resolve the
+        expression against the job's own `strategy:` block and to record
+        `windows-latest`, NOT to relax this check. Weakening it to accept an
+        unresolved runner would have been the cheap way past, and it is the one
+        edit that makes this whole class hollow.
         """
 
         for job in self._jobs():
             if job["caller"]:
                 continue
             with self.subTest(file=job["file"], job=job["job"]):
+                # 🔴 `runners`, NOT `runner`. A job spelling
+                # `runs-on: ${{ inputs.os }}` has a `runner` and no resolvable
+                # label at all, so a check reading `runner` would find a
+                # non-empty string and wave it through.
                 self.assertIsNotNone(
-                    job["runner"],
-                    "declares no `runs-on:` this parser can resolve -- a block "
-                    "sequence, a flow list or a matrix expression reaches here "
-                    "as unresolved, and is refused rather than skipped",
+                    job["runners"],
+                    f"declares `runs-on: {job['runner']}`, which this parser "
+                    "cannot resolve to a label -- an expression naming "
+                    "anything but a matrix key of this same job reaches here "
+                    "unresolved, and is refused rather than skipped",
                 )
-                self.assertIn(
-                    job["runner"],
-                    RUNNER_JOB_CEILING_MINUTES,
-                    f"names runner {job['runner']!r}, whose platform job "
-                    "ceiling is not recorded; add it to "
-                    "RUNNER_JOB_CEILING_MINUTES with its documented limit",
-                )
+                for label in job["runners"]:
+                    self.assertIn(
+                        label,
+                        RUNNER_JOB_CEILING_MINUTES,
+                        f"names runner {label!r}, whose platform job "
+                        "ceiling is not recorded; add it to "
+                        "RUNNER_JOB_CEILING_MINUTES with its documented limit",
+                    )
 
     def test_every_job_declares_a_cap(self):
         """A job with no cap escapes the ceiling check entirely.
@@ -11331,9 +11577,9 @@ class DeclaredJobCapIsEnforceableTests(unittest.TestCase):
         # into three failures. Nothing reaches a `continue` without having
         # already failed something.
         for job in self._jobs():
-            if job["caller"] or job["timeout"] is None:
+            if job["caller"] or job["timeout"] is None or job["runners"] is None:
                 continue
-            ceiling = RUNNER_JOB_CEILING_MINUTES.get(job["runner"])
+            ceiling = _lowest_ceiling(job["runners"])
             if ceiling is None:
                 continue
             with self.subTest(file=job["file"], job=job["job"]):
@@ -11341,11 +11587,12 @@ class DeclaredJobCapIsEnforceableTests(unittest.TestCase):
                     job["timeout"],
                     ceiling,
                     f"declares timeout-minutes: {job['timeout']} on runner "
-                    f"{job['runner']!r}, whose platform ceiling is {ceiling} "
-                    "minutes and cannot be raised from configuration; the "
-                    "declared number is a fiction and the job dies at the "
-                    "ceiling with an annotation naming a limit this repository "
-                    "does not declare anywhere",
+                    f"{job['runner']!r} -- resolving to {job['runners']} -- "
+                    f"whose lowest platform ceiling is {ceiling} minutes and "
+                    "cannot be raised from configuration; the declared number "
+                    "is a fiction and the job dies at the ceiling with an "
+                    "annotation naming a limit this repository does not "
+                    "declare anywhere",
                 )
 
 
@@ -11466,6 +11713,751 @@ class WorkflowJobParserTests(unittest.TestCase):
             "jobs:\n  a:\n    runs-on: ubuntu-latest\n    timeout-minutes: 5\n"
         )
         self.assertEqual([job["job"] for job in jobs], ["a"])
+
+class CiRequiredAggregatorTests(unittest.TestCase):
+    """The one required check, held to the shape that makes it one.
+
+    🔴 **Every failure this class guards against is GREEN.** An aggregate that
+    lost `always()` is *skipped* rather than failed on the runs it exists to
+    block; one that accepted `skipped` reports success over a job that quietly
+    stopped running; one whose `needs` omitted a job reports success having
+    never waited for it. None of the three produces a red check anywhere, which
+    is why they are pinned here rather than left to be noticed.
+
+    ⚠️ **Read as text, not parsed.** This suite runs on a bare interpreter with
+    no dependency install, exactly as the existing workflow assertions do.
+    """
+
+    CI = Path(__file__).resolve().parents[2] / "workflows" / "ci.yml"
+    AGGREGATE = "ci-required"
+
+    def _text(self):
+        """Return the whole workflow file.
+
+        Returns:
+            `ci.yml` as text.
+        """
+
+        return self.CI.read_text(encoding="utf-8")
+
+    def _aggregate_block(self):
+        """Return the aggregate job's own text, bounded to that job.
+
+        Bounded rather than swept to end-of-file: an unbounded window makes
+        every `assertIn` below pass by reading some other job's lines, which is
+        the mirror mistake of an empty window and the one that stays green.
+
+        Returns:
+            The job's text.
+        """
+
+        text = self._text()
+        start = text.index("\n  " + self.AGGREGATE + ":")
+        rest = text[start + 1 :]
+        end = re.search(r"\n  [A-Za-z_][\w-]*:\n", rest)
+        block = rest[: end.start()] if end else rest
+        self.assertIn(f"{self.AGGREGATE}:", block)
+        self.assertLess(len(block), len(text) // 2, "the job window did not close")
+        return block
+
+    def _declared_needs(self):
+        """Return the job ids the aggregate declares it depends on.
+
+        Returns:
+            The ids, in the order written.
+
+        Raises:
+            AssertionError: The aggregate declares no flow-style `needs:`.
+        """
+
+        found = re.search(r"^    needs: \[(.+)\]$", self._aggregate_block(), re.M)
+        self.assertIsNotNone(found, "the aggregate declares no flow-style `needs:`")
+        return [item.strip() for item in found.group(1).split(",")]
+
+    def test_the_aggregate_depends_on_every_other_job_in_the_file(self):
+        """🔴 The clause a job added later must fail rather than slip past.
+
+        Derived from the file rather than from a list kept beside it: a
+        hand-maintained list guards the jobs somebody remembered, and the next
+        job lands outside the aggregate while every check stays green. That is
+        the exact shape of a required check that protects less than it claims.
+        """
+
+        in_file = {
+            job["job"] for job in _declared_jobs(self.CI) if job["job"] != self.AGGREGATE
+        }
+        self.assertEqual(
+            set(self._declared_needs()),
+            in_file,
+            "a job in this workflow is not a dependency of the aggregate, so a "
+            "pull request can go green without it having succeeded",
+        )
+
+    def test_the_aggregate_opts_out_of_being_skipped(self):
+        """Without `always()` it is skipped, not failed, when a dependency fails.
+
+        GitHub skips a job whose dependency failed unless the job says
+        otherwise, and a skipped required check does not report failure. The
+        aggregate would then be absent from the very runs it exists to block.
+        """
+
+        self.assertIn("if: ${{ always() }}", self._aggregate_block())
+
+    def test_every_dependency_is_compared_against_success_by_name(self):
+        """The strict comparison, once per dependency.
+
+        A dependency present in `needs` but absent from the comparison is
+        waited for and then ignored -- which reads exactly like a job that is
+        checked.
+        """
+
+        block = self._aggregate_block()
+        for dependency in self._declared_needs():
+            with self.subTest(dependency=dependency):
+                # 🔴 A hyphenated job id is NOT reachable by property access in
+                # an Actions expression -- the parser reads the hyphen as an
+                # operator -- so `needs.fast-extras.result` does not fail
+                # loudly, it evaluates to something else entirely. The index
+                # form is mandatory for those ids and optional for the rest,
+                # which is why this asks for the right one per id rather than
+                # accepting either everywhere.
+                reference = (
+                    f"needs['{dependency}'].result != 'success'"
+                    if "-" in dependency
+                    else f"needs.{dependency}.result != 'success'"
+                )
+                self.assertIn(
+                    reference,
+                    block,
+                    f"{dependency!r} is waited for but never compared against "
+                    "`success` in the spelling its id requires, so its result "
+                    "cannot fail this check",
+                )
+
+    def test_the_loose_result_test_is_absent(self):
+        """`!contains(needs.*.result, 'failure')` treats `skipped` as acceptable.
+
+        Which is exactly how a required job that quietly stopped running goes
+        unnoticed. The strict form costs a line per dependency and says what it
+        means.
+        """
+
+        self.assertNotIn("needs.*.result", self._aggregate_block())
+
+    def test_the_only_conditional_dependency_is_the_one_that_skips_by_design(self):
+        """🔴 The event-conditional clause is an exemption and must stay narrow.
+
+        `review_replies` runs on `pull_request` only -- there is no pull request
+        to ask about on a push or a manual run -- so it is skipped there by
+        design. Requiring `success` unconditionally would paint `main` red on
+        every push; accepting `skipped` unconditionally would hide a job that
+        genuinely stopped running. Requiring success exactly on the event where
+        the job is scheduled is neither, and it is sound only while it applies
+        to that one job. A second dependency acquiring the same clause is a
+        second job nobody checks on three of the four events, so it is refused
+        here rather than discovered later.
+        """
+
+        block = self._aggregate_block()
+        guarded = re.findall(r"github\.event_name == 'pull_request' &&\s*\n?\s*needs\.([A-Za-z_][\w-]*)\.result", block)
+        self.assertEqual(
+            guarded,
+            ["review_replies"],
+            "exactly one dependency may be compared conditionally, and only "
+            "because its own `if:` skips it on every other event",
+        )
+
+    def test_the_conditional_clause_mirrors_that_jobs_own_condition(self):
+        """The exemption is only sound while the two conditions agree.
+
+        If `review_replies` stopped being `pull_request`-only, the clause above
+        would start excusing a job that was scheduled and skipped anyway. The
+        two lines live four hundred apart in one file, which is precisely the
+        arrangement that produced the runner-ceiling defect.
+        """
+
+        text = self._text()
+        self.assertEqual(
+            text.count("github.event_name == 'pull_request'"),
+            2,
+            "the aggregate's conditional clause and `review_replies`'s own "
+            "`if:` must both be present and must be the only two",
+        )
+
+    def test_no_expression_reaches_a_shell(self):
+        """🔴 The comparison happens in `if:`; the step is a bare `exit 1`.
+
+        A `${{ }}` expression is substituted as TEXT before the shell parses the
+        line, and `needs` carries job OUTPUTS as well as results -- so an
+        apostrophe or a crafted output breaks the quoting or injects commands.
+        It also prints every dependency's outputs into the log for no reason.
+        """
+
+        block = self._aggregate_block()
+        scripts = re.findall(r"^        run: (.+)$", block, re.M)
+        self.assertEqual(scripts, ["exit 1"])
+
+
+class MatrixRunnerResolutionTests(unittest.TestCase):
+    """`runs-on: ${{ matrix.os }}` names real labels, and the guard must see them.
+
+    🔴 **The ceiling guard is worthless against a matrix job it cannot read.**
+    Every check in :class:`DeclaredJobCapIsEnforceableTests` reads one runner
+    label, and the canonical spelling for a two-platform matrix is an expression
+    rather than a label. Refusing it -- which is what this parser did before this
+    class existed -- is the safe answer but not a usable one: the first matrix
+    job in the repository would then have had to choose between an unenforceable
+    cap and a weakened guard, which is the trade the whole mechanism exists to
+    refuse.
+
+    ⚠️ **`runner` keeps its meaning; `runners` is the new one and is the only
+    field a verdict reads.** `runner` is the scalar exactly as written, so it
+    still carries the text a failure message quotes. `runners` is the resolved
+    tuple of concrete labels, or ``None`` when this parser cannot resolve them.
+    The distinction is load-bearing rather than cosmetic: a job spelling
+    ``runs-on: ${{ inputs.os }}`` satisfies "``runner`` is not None" while having
+    no resolvable label at all, so a check reading `runner` would wave it
+    through.
+
+    ⚠️ **`exclude:` is deliberately not honoured.** It removes combinations, so
+    ignoring it can only over-approximate the label set -- the guard may demand a
+    recorded ceiling for a label that never actually runs. That is the safe
+    direction, and it is written down here so the next reader does not have to
+    ask.
+    """
+
+    def _write(self, body):
+        """Write a throwaway workflow and parse it.
+
+        Args:
+            body: The file's whole text.
+
+        Returns:
+            The parsed job dicts.
+        """
+
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        path = Path(tmp.name) / "throwaway.yml"
+        path.write_text(body, encoding="utf-8")
+        return _declared_jobs(path)
+
+    HEAD = "name: T\non:\n  workflow_dispatch:\njobs:\n"
+
+    def test_a_literal_runner_resolves_to_a_single_label(self):
+        """The unchanged case, pinned so the new field cannot regress it.
+
+        Every job in this repository today spells its runner literally. Were
+        ``runners`` not to cover that shape, the guard would start refusing
+        files it has been reading correctly for weeks.
+        """
+
+        jobs = self._write(
+            self.HEAD + "  a:\n    runs-on: ubuntu-slim\n    timeout-minutes: 5\n"
+        )
+        self.assertEqual(jobs[0]["runner"], "ubuntu-slim")
+        self.assertEqual(jobs[0]["runners"], ("ubuntu-slim",))
+
+    def test_a_flow_list_runs_on_is_one_runner_spec_and_not_a_label_list(self):
+        """🔴 The collision that would silently invent three unrecorded labels.
+
+        A flow list means two different things in the two places this parser
+        reads one. Under `runs-on:` it is ONE runner specification -- a set of
+        labels that must all be present on a single machine -- and
+        :data:`RUNNER_JOB_CEILING_MINUTES` already carries keys spelled exactly
+        that way. Under `strategy.matrix.<key>` it is a list of alternatives.
+        An implementation that "splits flow lists" wherever it finds them would
+        explode the self-hosted key into three labels, none of them recorded,
+        and report the wrong fault to whoever moved a job back to that fleet.
+        """
+
+        jobs = self._write(
+            self.HEAD
+            + "  a:\n    runs-on: [self-hosted, cap-main, noble]\n"
+            + "    timeout-minutes: 5\n"
+        )
+        self.assertEqual(jobs[0]["runners"], ("[self-hosted, cap-main, noble]",))
+        self.assertIn(jobs[0]["runners"][0], RUNNER_JOB_CEILING_MINUTES)
+
+    def test_a_flow_list_matrix_resolves_to_every_label_it_names(self):
+        """The shape this repository is about to commit."""
+
+        jobs = self._write(
+            self.HEAD
+            + "  a:\n    runs-on: ${{ matrix.os }}\n    timeout-minutes: 60\n"
+            + "    strategy:\n      matrix:\n"
+            + "        os: [ubuntu-latest, windows-latest]\n"
+        )
+        self.assertEqual(jobs[0]["runners"], ("ubuntu-latest", "windows-latest"))
+
+    def test_a_block_sequence_matrix_resolves_too(self):
+        """Legal YAML that GitHub accepts, so refusing it would be a wall.
+
+        ⚠️ The alternative -- refuse the block form and tell the author to write
+        a flow list -- was considered and rejected. A guard that dictates the
+        YAML style of the file it checks gets edited into silence the first time
+        that style is inconvenient.
+        """
+
+        jobs = self._write(
+            self.HEAD
+            + "  a:\n    runs-on: ${{ matrix.os }}\n    timeout-minutes: 60\n"
+            + "    strategy:\n      matrix:\n        os:\n"
+            + "          - ubuntu-latest\n          - windows-latest\n"
+        )
+        self.assertEqual(jobs[0]["runners"], ("ubuntu-latest", "windows-latest"))
+
+    def test_an_include_entry_adds_its_label_rather_than_being_ignored(self):
+        """🔴 A label the guard cannot see is a label it does not check.
+
+        ``strategy.matrix.include`` may introduce a runner the top-level list
+        never names. A parser reading only the list would resolve this job to
+        one label while the platform ran it on two, and the second would carry
+        an unchecked cap -- a guard that quietly stopped checking, which is the
+        exact shape the ceiling guard was written after.
+        """
+
+        jobs = self._write(
+            self.HEAD
+            + "  a:\n    runs-on: ${{ matrix.os }}\n    timeout-minutes: 60\n"
+            + "    strategy:\n      matrix:\n"
+            + "        os: [ubuntu-latest]\n"
+            + "        include:\n          - os: ubuntu-slim\n"
+        )
+        self.assertEqual(jobs[0]["runners"], ("ubuntu-latest", "ubuntu-slim"))
+
+    def test_a_matrix_expression_with_no_strategy_block_is_refused(self):
+        """Nothing to resolve against, so the answer is ``None``, not a guess."""
+
+        jobs = self._write(
+            self.HEAD + "  a:\n    runs-on: ${{ matrix.os }}\n    timeout-minutes: 60\n"
+        )
+        self.assertIsNone(jobs[0]["runners"])
+
+    def test_a_matrix_naming_a_key_the_strategy_never_defines_is_refused(self):
+        """The expression reads the ``os`` key; the matrix defines ``python``.
+
+        GitHub would run this job with an empty `runs-on`. Resolving it against
+        some *other* key would be worse than refusing: the guard would then
+        report a ceiling for a runner this job never uses.
+        """
+
+        jobs = self._write(
+            self.HEAD
+            + "  a:\n    runs-on: ${{ matrix.os }}\n    timeout-minutes: 60\n"
+            + "    strategy:\n      matrix:\n        python: ['3.13']\n"
+        )
+        self.assertIsNone(jobs[0]["runners"])
+
+    def test_a_matrix_value_this_parser_cannot_read_is_refused(self):
+        """``fromJSON(...)`` and a nested expression both reach here unresolved.
+
+        Refused rather than partially resolved: half a label set checked is the
+        hollow guard again, and this parser is being extended precisely because
+        a check that cannot read a shape must say so.
+        """
+
+        for spelling in (
+            "        os: ${{ fromJSON(needs.setup.outputs.matrix) }}\n",
+            "        os: [ubuntu-latest, '${{ env.EXTRA }}']\n",
+        ):
+            with self.subTest(spelling=spelling.strip()):
+                jobs = self._write(
+                    self.HEAD
+                    + "  a:\n    runs-on: ${{ matrix.os }}\n    timeout-minutes: 60\n"
+                    + "    strategy:\n      matrix:\n"
+                    + spelling
+                )
+                self.assertIsNone(jobs[0]["runners"])
+
+    def test_a_non_matrix_expression_is_refused(self):
+        """Only a matrix reference is resolvable; every other expression is not.
+
+        ⚠️ **The `inputs` case is the one that matters here.** A reusable
+        workflow could take its runner as an input, and the caller would then
+        decide it -- so the label is not in this file at all. That spelling
+        satisfies "``runner`` is not None", which is exactly why the verdict
+        reads ``runners`` instead.
+        """
+
+        for expression in ("${{ vars.RUNNER }}", "${{ inputs.os }}"):
+            with self.subTest(expression=expression):
+                jobs = self._write(
+                    self.HEAD
+                    + f"  a:\n    runs-on: {expression}\n    timeout-minutes: 60\n"
+                )
+                self.assertIsNotNone(jobs[0]["runner"])
+                self.assertIsNone(jobs[0]["runners"])
+
+    def test_the_strategy_block_of_another_job_is_not_read_as_this_ones(self):
+        """The block is bounded to the job, and the bound is the point.
+
+        Without it a job with no `strategy:` resolves against its neighbour's,
+        which is how a runner nobody declared for it acquires a recorded
+        ceiling.
+        """
+
+        jobs = self._write(
+            self.HEAD
+            + "  a:\n    runs-on: ${{ matrix.os }}\n    timeout-minutes: 60\n"
+            + "  b:\n    runs-on: ubuntu-latest\n    timeout-minutes: 5\n"
+            + "    strategy:\n      matrix:\n        os: [ubuntu-latest]\n"
+        )
+        by_name = {job["job"]: job for job in jobs}
+        self.assertIsNone(by_name["a"]["runners"])
+
+    def test_a_key_outside_the_strategy_block_is_not_read_as_a_matrix_value(self):
+        """`env:` may legally carry an `os:` of its own, and it is not the matrix.
+
+        The scan is bounded to `strategy:` rather than run over the whole job
+        for this reason. An unbounded one resolves the job against a value that
+        has nothing to do with where it runs, and reports a confident wrong
+        ceiling rather than refusing.
+        """
+
+        jobs = self._write(
+            self.HEAD
+            + "  a:\n    runs-on: ${{ matrix.os }}\n    timeout-minutes: 60\n"
+            + "    env:\n      os: ubuntu-slim\n"
+        )
+        self.assertIsNone(jobs[0]["runners"])
+
+    def test_a_matrix_is_held_to_the_LOWEST_ceiling_of_its_labels(self):
+        """🔴 A matrix job is as constrained as its most constrained leg.
+
+        Taking the highest, or the first, would declare a 60-minute cap
+        enforceable on a matrix that includes a 15-minute runner -- and the
+        Windows leg would pass while the slim leg died at a limit no file
+        mentions. That is the original defect, reproduced one level up.
+        """
+
+        self.assertEqual(
+            _lowest_ceiling(("ubuntu-latest", "ubuntu-slim")),
+            RUNNER_JOB_CEILING_MINUTES["ubuntu-slim"],
+        )
+
+    def test_one_unrecorded_label_makes_the_whole_matrix_unresolvable(self):
+        """Not "the ceiling of the labels I recognised".
+
+        A minimum taken over the recorded subset is a confident answer about a
+        job that also runs somewhere nobody recorded. The unrecorded label
+        already fails its own check; this returns ``None`` so the cap check does
+        not additionally report a verdict it cannot support.
+        """
+
+        self.assertIsNone(_lowest_ceiling(("ubuntu-latest", "macos-latest")))
+
+    def test_a_trailing_comment_is_not_part_of_a_matrix_value(self):
+        """The tolerance `runs-on:` and `timeout-minutes:` already carry.
+
+        🔴 **Measured as a refusal before this was added.** A legal, commented
+        matrix resolved to ``None``, so the guard told the author their runner
+        was unresolvable while pointing at a line that names two ordinary
+        labels. Refusing is the safe direction, but a parser strict about one
+        key and lenient about another -- with no reason recorded for the
+        difference -- is the inconsistency this file already calls a defect.
+        """
+
+        jobs = self._write(
+            self.HEAD
+            + "  a:\n    runs-on: ${{ matrix.os }}\n    timeout-minutes: 60\n"
+            + "    strategy:\n      matrix:\n"
+            + "        os: [ubuntu-latest, windows-latest]  # both platforms\n"
+        )
+        self.assertEqual(jobs[0]["runners"], ("ubuntu-latest", "windows-latest"))
+
+    def test_a_trailing_comment_is_not_part_of_a_block_sequence_item(self):
+        """The same tolerance one level down, where the items are.
+
+        The two patterns must agree. A flow list that tolerates a comment while
+        a block sequence does not is the same unexplained asymmetry, just
+        smaller.
+        """
+
+        jobs = self._write(
+            self.HEAD
+            + "  a:\n    runs-on: ${{ matrix.os }}\n    timeout-minutes: 60\n"
+            + "    strategy:\n      matrix:\n        os:\n"
+            + "          - ubuntu-latest  # linux\n          - windows-latest\n"
+        )
+        self.assertEqual(jobs[0]["runners"], ("ubuntu-latest", "windows-latest"))
+
+    def test_a_key_whose_name_merely_starts_with_the_referenced_one_is_not_read(self):
+        """`os-arch` is not `os`, and resolving against it would be confident and wrong.
+
+        The mapping pattern is anchored on the colon for this reason. Without
+        that anchor a matrix carrying both keys resolves to the union of two
+        unrelated value sets, and the guard then demands a recorded ceiling for
+        an architecture name -- a failure that sends the reader to the wrong
+        table with no hint that the parser misread the file.
+        """
+
+        jobs = self._write(
+            self.HEAD
+            + "  a:\n    runs-on: ${{ matrix.os }}\n    timeout-minutes: 60\n"
+            + "    strategy:\n      matrix:\n"
+            + "        os-arch: [x64]\n        os: [ubuntu-latest]\n"
+        )
+        self.assertEqual(jobs[0]["runners"], ("ubuntu-latest",))
+
+    def test_a_strategy_at_step_depth_is_not_read_as_the_jobs_own(self):
+        """🔴 The bound that keeps the resolution the job's, not something inside it.
+
+        `strategy:` is anchored at exactly four spaces, the depth a job's own
+        keys sit at. A deeper one -- in a step, or in any nested mapping that
+        happens to use the word -- must not answer for the job, because the
+        labels it names have nothing to do with where the job runs. Refused, not
+        guessed: this job declares a matrix runner and no matrix, which is
+        exactly the shape the guard exists to reject.
+        """
+
+        jobs = self._write(
+            self.HEAD
+            + "  a:\n    runs-on: ${{ matrix.os }}\n    timeout-minutes: 60\n"
+            + "    steps:\n      - run: true\n        strategy:\n"
+            + "          matrix:\n            os: [ubuntu-slim]\n"
+        )
+        self.assertIsNone(jobs[0]["runners"])
+
+
+class RecordedTestCountTests(unittest.TestCase):
+    """Two documents quote how many tests are in this file. Both must be true.
+
+    🔴 **A quoted count is a claim that rots silently.** `README.md` tells a
+    contributor what to expect from a local run and `ci.yml` tells an operator
+    what the job covers; a reader who runs the suite and sees a different number
+    cannot tell whether tests were added, whether some failed to load, or whether
+    the document was simply never updated. The third of those is the only one
+    that is harmless, and it is indistinguishable from the second.
+
+    ⚠️ **Measured here, never incremented.** The count comes from the loader, so
+    a case that stops being collected -- a renamed method, a class that failed to
+    import -- lowers it and fails this, which arithmetic on the previous figure
+    could not do.
+
+    ⚠️ The cost is real and is the point: adding a test to this file means
+    updating two sentences. They were 24 out of date when this guard was written,
+    which is how long it takes.
+    """
+
+    #: The documents quoting the figure. Enumerated rather than swept: a sweep
+    #: for "a number near the word tests" over the whole tree is a guess, and
+    #: these two sentences are specific claims about this module.
+    QUOTING = (
+        Path(__file__).resolve().parents[1] / "README.md",
+        Path(__file__).resolve().parents[2] / "workflows" / "ci.yml",
+    )
+
+    def _total(self):
+        """Return how many test cases this module actually defines.
+
+        Returns:
+            The loader's count, which is the number the runner prints.
+        """
+
+        loader = unittest.defaultTestLoader
+        return loader.loadTestsFromModule(sys.modules[__name__]).countTestCases()
+
+    def test_both_documents_quote_the_real_count(self):
+        """The claim. Read from the loader, compared against each document."""
+
+        total = self._total()
+        for path in self.QUOTING:
+            with self.subTest(document=path.name):
+                # 🔴 A WHOLE number, not a substring. Measured while falsifying
+                # this guard: a document quoting `5390` satisfies a substring
+                # test for `539`, so the mutation that should have killed this
+                # case passed it instead. A count is exactly the kind of value
+                # whose neighbours contain it.
+                #
+                # `assertTrue`, not `assertIn`: the latter renders the haystack,
+                # and the haystack here is an entire document. The message IS
+                # the diagnosis, so it must not arrive under eight kilobytes of
+                # the file it is about.
+                self.assertTrue(
+                    re.search(rf"\b{total}\b", path.read_text(encoding="utf-8")),
+                    f"{path.name} does not quote {total}, which is how many "
+                    "tests this module now defines; update the sentence rather "
+                    "than deleting the number, because it is what tells a "
+                    "reader whether their local run was complete",
+                )
+
+    def test_the_count_is_derived_and_not_a_constant(self):
+        """🔴 The control: a hard-coded total would pass the case above for ever.
+
+        If the loader ever returned zero -- an import that half-failed, a
+        renamed module -- the check above would look for "0", find it in some
+        unrelated line of either document, and pass. This refuses that.
+        """
+
+        self.assertGreater(self._total(), 100)
+
+
+class NoDocumentClaimsTheRepositoryHasNoTestGateTests(unittest.TestCase):
+    """Seven sentences across six files said this repository ran no tests in CI.
+
+    🔴 **All seven were true when written, and one change falsified every one of
+    them at once.** They were not clustered: they sat in the workflow header, the
+    review prompt, the review guide, the `ci` rule file, the review workflow's
+    own preamble and twice in the setup README. A change that corrected the two
+    obvious ones would have left five standing, and the next reader would have
+    trusted whichever they found first.
+
+    ⚠️ **A guard rather than the grep that found them, and this repository has
+    already paid for the difference.** The sentence about self-hosted runners was
+    corrected in the `ci` rule file and survived in the parallel block in the
+    workflow; the automated review caught it on the next round. A one-time grep
+    is an act, not an invariant.
+
+    ⚠️ **One pattern per PHRASING, not one pattern.** The claim was written five
+    different ways, and the model this class follows -- the runner-claim guard --
+    works only because the phrase it forbids appears nowhere else in the tree.
+    None of these has that property on its own, so each is anchored tightly
+    enough not to fire on ordinary prose: `no workflow-level permissions:` is a
+    real sentence in `ci.yml` and must not match.
+
+    ⚠️ **The specimens below are PARAPHRASED or marked**, following the same
+    convention: this guard reads every file under `.github/`, and its own source
+    is one of them.
+    """
+
+    #: Each retired phrasing, with the sentence it came from named in the
+    #: comment rather than quoted. Anchored so ordinary prose does not match:
+    #: `only workflow` alone would fire on "no workflow-level `permissions:`",
+    #: which is a true sentence this repository needs to keep.
+    CLAIMS = (
+        # "this repository has no CI test job" / "no CI for its own code"  # noqa: ci-claim
+        re.compile(r"no CI (?:test job|for its own)"),
+        # "`claude-code-review.yml` is its only workflow"  # noqa: ci-claim
+        re.compile(r"is its only workflow"),  # noqa: ci-claim
+        # "This directory contains one workflow"  # noqa: ci-claim
+        re.compile(r"contains one workflow"),  # noqa: ci-claim
+        # "the two CI jobs" / "the two `ci.yml` jobs" -- an undercount now that  # noqa: ci-claim
+        # the caller, the aggregate and the broad job exist.
+        re.compile(r"the two (?:CI|`ci\.yml`) jobs"),
+    )
+
+    #: Suppress a deliberate match with this marker on the line, exactly as the
+    #: runner-claim guard does. By marker rather than by line number, so editing
+    #: this class cannot silently disable the sweep.
+    MARKER = "noqa: ci-claim"
+
+    def _root(self):
+        """Return the directory both the sweep and its controls walk.
+
+        🔴 **One expression, used by both.** When each computed its own root,
+        moving the sweep's left the control green over a walk that saw nothing.
+        A control that cannot see the thing it controls is not one.
+
+        Returns:
+            The `.github/` directory this suite lives under.
+        """
+
+        return Path(__file__).resolve().parents[2]
+
+    def _files(self):
+        """Yield every readable file under the swept root.
+
+        Walked rather than enumerated: an enumerated list guards the files
+        somebody thought of, and the next document lands unguarded while the
+        guard still passes.
+
+        Yields:
+            Each file path.
+        """
+
+        for path in sorted(self._root().rglob("*")):
+            if path.is_file() and "__pycache__" not in path.parts:
+                yield path
+
+    def test_every_rule_recognises_the_claim_it_forbids(self):
+        """🔴 The control the sweep cannot give itself.
+
+        The sweep below asserts an EMPTY list. A mistyped pattern passes it for
+        ever. These specimens are the retired sentences, close enough to the
+        originals to be recognised and marked so they do not become the leak
+        they describe.
+        """
+
+        specimens = (
+            "reason that is false here: this repository has no CI test job",  # noqa: ci-claim
+            "named here rather than left to be discovered: no CI for its own code",  # noqa: ci-claim
+            "`claude-code-review.yml` is its only workflow, so nothing else ran",  # noqa: ci-claim
+            "This directory contains one workflow and the review system",  # noqa: ci-claim
+            "`ubuntu-slim` for the two CI jobs, so no runner group",  # noqa: ci-claim
+            "`ubuntu-slim` for the two `ci.yml` jobs -- GitHub-hosted",  # noqa: ci-claim
+        )
+        for specimen in specimens:
+            with self.subTest(specimen=specimen):
+                self.assertTrue(
+                    any(rule.search(specimen) for rule in self.CLAIMS),
+                    "no rule recognises a sentence this guard exists to forbid",
+                )
+
+    def test_no_rule_fires_on_the_true_sentences_it_sits_beside(self):
+        """The other control: a rule matching everything would also pass.
+
+        Each of these is a real sentence in this tree that a looser pattern
+        would have caught -- and the response to a guard that cries wolf is to
+        delete the sentence, which is the reasoning this guard exists to
+        preserve.
+        """
+
+        for sentence in (
+            "This file has no workflow-level `permissions:`, so a new job",
+            "the only workflow-level binding kitty reads",
+            "the two review-system jobs stay on `ubuntu-slim`",
+            "no CI runner group has to be granted",
+        ):
+            with self.subTest(sentence=sentence):
+                firing = [rule.pattern for rule in self.CLAIMS if rule.search(sentence)]
+                self.assertFalse(firing, f"{sentence!r} -> {firing}")
+
+    def test_the_sweep_reaches_the_files_it_claims_to(self):
+        """🔴 A walk that found nothing passes the sweep below in silence.
+
+        Named files rather than a count: a count drifts with every document
+        added, so it would be edited rather than believed. These four are the
+        surfaces the claim actually lived on.
+        """
+
+        found = {path.name for path in self._files()}
+        for name in ("ci.yml", "REVIEW_PROMPT.md", "REVIEW_GUIDE.md", "README.md"):
+            with self.subTest(name=name):
+                self.assertIn(name, found)
+
+    def test_no_document_says_this_repository_has_no_test_gate(self):
+        """The sweep. Walked, not enumerated."""
+
+        root = self._root()
+        offences = []
+        for path in self._files():
+            try:
+                text = path.read_text(encoding="utf-8")
+            except (UnicodeDecodeError, OSError):
+                # A binary file cannot carry a reviewable sentence, and failing
+                # on one would make this guard about file types.
+                continue
+            for lineno, line in enumerate(text.splitlines(), 1):
+                if self.MARKER in line:
+                    continue
+                for rule in self.CLAIMS:
+                    if rule.search(line):
+                        offences.append(
+                            f"{path.relative_to(root).as_posix()}:{lineno}: "
+                            f"{line.strip()[:100]}"
+                        )
+
+        self.assertFalse(
+            offences,
+            "this repository DOES run its tests in CI -- `ci.yml` calls the "
+            "broad selection on both platforms and aggregates it into "
+            "`ci-required`. Rewrite each of these to say what is true now "
+            "(which jobs the gate does and does not cover) rather than "
+            "deleting the sentence, so the reasoning survives:\n  "
+            + "\n  ".join(offences),
+        )
+
 
 class NoDocumentMisdescribesTheSlimRunnerTests(unittest.TestCase):
     """`ubuntu-slim` is one of GitHub's standard public labels. Four files said otherwise.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,17 @@ name: CI
 # fork pull request, whose head branch produces no upstream `push` run, so
 # nothing else would cover it.
 #
+# ⚠️ **`labeled` and `unlabeled` are in the list because §10.3 specifies them,
+# and the cost is worth stating since nothing keys off a label yet.** A label
+# toggle re-runs the whole two-platform gate and, with the `concurrency` block
+# below, cancels any run already in flight for the ref. Today no job has a
+# label-dependent `if:`, so that spend buys nothing; they are kept anyway because
+# the design puts them here for the jobs that will (a `live` opt-in is the
+# expected first), and because dropping an event from a `types:` list is the
+# category of edit this whole comment exists to warn about -- silent, and worst
+# on the pull requests nobody is watching. Revisit when the first label-gated
+# job lands, not before.
+#
 # ⚠️ `branches: [main]` is KEPT rather than dropped. The design's snippet shows
 # only `types:`, and the filter is orthogonal to the point it makes: a fork pull
 # request targeting `main` still triggers this workflow, which is the failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,14 @@ jobs:
     # its own instead of the platform killing the job at the same instant -- and still
     # ~2.9x the measured maximum above.
     timeout-minutes: 10
+    # 🔴 Declared, not inherited -- the same reasoning as `review_replies` below,
+    # which has carried its own block since it was written. This job checks out
+    # the repository and runs a test file; it needs `contents: read` and nothing
+    # more. ⚠️ The gap here predates the test jobs and was surfaced by the code
+    # scanner when they landed; it is closed while the file is open rather than
+    # left as the one job in it that inherits.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -198,6 +206,14 @@ jobs:
     # `runs-on:` nor `timeout-minutes:`, and GitHub's supported-keyword list for
     # such a job names neither. The cap that matters lives beside the matrix, in
     # the called workflow, where the runner it must clear is written.
+    #
+    # ⚠️ `permissions:` IS legal on a caller job -- it is in GitHub's supported
+    # keyword list for one, unlike `runs-on:` and `timeout-minutes:`, so
+    # declaring it does not forfeit the exemption those two checks grant. It
+    # bounds what the called workflow can be granted, which is why it is here as
+    # well as there.
+    permissions:
+      contents: read
     uses: ./.github/workflows/tests-broad.yml
 
   ci-required:
@@ -227,6 +243,11 @@ jobs:
     # but it is declared, and strictly below the ceiling, because a job with no
     # cap is checked against nothing.
     timeout-minutes: 10
+    # 🔴 Empty, deliberately, and it is the honest value rather than a cautious
+    # one. This job checks out nothing, calls no API and runs one shell builtin;
+    # every permission it inherited would be one it never used. An empty block
+    # grants none of them.
+    permissions: {}
     steps:
       - name: Fail unless every dependency succeeded
         # 🔴 **`success` is required explicitly, once per dependency, rather

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,19 +8,36 @@ name: CI
 # So the review system's own tests run here, in a job the review workflow cannot
 # influence.
 #
-# ⚠️ **This file is deliberately NOT this repository's test suite.** It does not
-# run `pytest`, `ruff`, or anything under `tests/`. That is a real gap and it is
-# named here rather than left to be discovered: this repository has no CI for its
-# own code, and adding it is a separate piece of work with its own decisions
-# (which Python versions, what to do about the tests that need a browser, how to
-# gate the live-network tests). Nothing below should be read as covering it.
+# ⚠️ **This file also carries the repository's own test gate, and it is a CALLER
+# rather than the place the jobs are written.** It holds `uses:` lines and one
+# `needs:` list; each test job lives in its own reusable workflow beside this
+# one. The test-suite design commits to that shape because several later steps
+# add jobs in parallel, and two pull requests editing one workflow conflict --
+# with the worse outcome being a rebase that silently drops the other's edit.
+# The `needs:` list below is the one contended region, and the order in which
+# steps may mutate it is declared in
+# `.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md`.
 #
-# ⚠️ **The upstream repository gates both jobs on a `changes` job** that computes
+# 🔴 **This file used to say the repository ran none of its own tests here. That
+# is no longer true, and the sentence has been rewritten rather than deleted so
+# the reasoning survives.** What is true now is narrower: the gate here runs ONE
+# broad selection -- the hermetic and subsystem tests, on Linux and Windows, at
+# Python 3.13. It does not yet run the browser tests, the packaging tests, the
+# type-check job, the coverage controls or the live canaries. Each of those is a
+# separate job with its own decisions, and each joins `ci-required.needs` as it
+# lands. Read a green `ci-required` as "the broad selection passed on both
+# platforms", not as "everything this project can check has been checked".
+#
+# ⚠️ **The upstream repository gates its jobs on a `changes` job** that computes
 # path filters, and carries a guard proving every job is either gated or
-# explicitly exempt. There is no `changes` job here: this repository is small
-# enough that both jobs run in seconds, and a path filter is a second place for
-# the file list to drift out of step with `select_rules.py`. If a third job ever
-# lands here, revisit that.
+# explicitly exempt. There is still no `changes` job here, and the arrival of the
+# test jobs is the moment that decision was said to need revisiting -- so it was.
+# It stands, for a changed reason. The two review jobs run in seconds and gating
+# them would only add a second place for the file list to drift out of step with
+# `select_rules.py`. The test job is the opposite case: a path filter that
+# skipped it would make `ci-required` green having run nothing, since a skipped
+# dependency is a *pass* to `needs` and only the explicit `success` comparison
+# below catches it. A gate is worth more than the minutes a filter would save.
 #
 # 🔴 **Both jobs run on GitHub-hosted `ubuntu-slim`, not on the self-hosted fleet the
 # upstream repository uses.** A runner group carries an "Allow public repositories"
@@ -39,17 +56,44 @@ name: CI
 # the same label and was killed mid-run five times on a merge-gating check before
 # anyone paired the two lines. `DeclaredJobCapIsEnforceableTests` pairs them now.
 
+# 🔴 **The trigger list must be COMPLETE, because naming `types:` REPLACES the
+# default set rather than extending it.** The defaults are `opened`,
+# `reopened` and `synchronize`; a list naming only the label events would stop
+# this workflow running when a pull request is opened at all. That is worst on a
+# fork pull request, whose head branch produces no upstream `push` run, so
+# nothing else would cover it.
+#
+# ⚠️ `branches: [main]` is KEPT rather than dropped. The design's snippet shows
+# only `types:`, and the filter is orthogonal to the point it makes: a fork pull
+# request targeting `main` still triggers this workflow, which is the failure
+# mode that snippet exists to prevent. Dropping it would newly run a nine-minute
+# two-platform suite on pull requests targeting any branch, which is a spend
+# decision this file was not asked to make.
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
+    types: [opened, reopened, synchronize, labeled, unlabeled]
   workflow_dispatch:
+
+# 🔴 Added with the test jobs, not before them. The two review jobs finish in
+# seconds, so superseding them saved nothing; the broad selection is roughly nine
+# minutes per leg on Linux and more on Windows, and without this a series of
+# rapid pushes starts a full two-platform run per push with the earlier ones
+# still going. Scoped per ref so `main` and each pull request are independent.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   review-scripts:
-    # The Claude review system's own tests -- 513 of them, covering the rule
+    # The Claude review system's own tests -- 543 of them, covering the rule
     # selector, the result classifier, the failure notices, the prompt redactor,
-    # the findings schema and the workflow's own wiring.
+    # the findings schema, the workflow's own wiring, the workflow parser behind
+    # the runner-ceiling guard, and the `ci-required` aggregation.
     #
     # Pure Python and subprocesses, no service container, no pip install at all --
     # the suite runs in about a second.
@@ -146,3 +190,81 @@ jobs:
           "$pythonLocation/bin/python" .github/review/scripts/check_review_replies.py \
             --repo "${{ github.repository }}" \
             --pr "${{ github.event.pull_request.number }}"
+
+  broad:
+    # The repository's own suite, on Linux and Windows. A caller job: it declares
+    # `uses:` and nothing else, which is what makes it exempt from the
+    # runner-ceiling checks -- a reusable-workflow call legally declares neither
+    # `runs-on:` nor `timeout-minutes:`, and GitHub's supported-keyword list for
+    # such a job names neither. The cap that matters lives beside the matrix, in
+    # the called workflow, where the runner it must clear is written.
+    uses: ./.github/workflows/tests-broad.yml
+
+  ci-required:
+    # 🔴 **The one check branch protection requires.** Requiring every
+    # matrix-generated check by name is brittle: adding a Python or `mcp` axis
+    # renames the checks and silently drops the old names from the protection
+    # rule, leaving a gate that protects nothing while still reporting green.
+    # This job runs no tests, depends on every other job, and fails unless each
+    # one succeeded -- so the matrix can change without touching repository
+    # settings.
+    #
+    # 🔴 **`always()` is what makes the check real, and omitting it is silent.**
+    # When a dependency fails, GitHub SKIPS its dependents rather than failing
+    # them, and a skipped required check does not report failure. Without this
+    # line the aggregate would be skipped -- not red -- on exactly the runs it
+    # exists to block.
+    #
+    # ⚠️ A cancelled run also reaches here and resolves red, deliberately: a
+    # merge gate that cannot say the suite passed must not say it did. With
+    # `cancel-in-progress` above, a superseded run is cancelled and reports red,
+    # and the run that superseded it is the one branch protection reads.
+    if: ${{ always() }}
+    needs: [review-scripts, review_replies, broad]
+    runs-on: ubuntu-latest
+    # An ordinary GitHub-hosted label, whose platform ceiling is 6 hours. This
+    # job starts a shell and exits, so the cap is a backstop and nothing else --
+    # but it is declared, and strictly below the ceiling, because a job with no
+    # cap is checked against nothing.
+    timeout-minutes: 10
+    steps:
+      - name: Fail unless every dependency succeeded
+        # 🔴 **`success` is required explicitly, once per dependency, rather
+        # than the looser one-liner that asks whether any result contains
+        # 'failure'.** That form treats `skipped` as acceptable, which is
+        # exactly how a required job that quietly stopped running goes
+        # unnoticed. (The forbidden spelling is described rather than written
+        # out: a guard in `.github/review/tests/test_review_scripts.py` greps
+        # this block for it, and quoting it here would trip that guard on its
+        # own explanation -- the same convention the runner-claim guard uses.)
+        #
+        # ⚠️ **`review_replies` is the one dependency compared conditionally, and
+        # the condition mirrors that job's own `if:` rather than relaxing this
+        # one.** That job runs on `pull_request` only -- there is no pull request
+        # to ask about on a push or a manual run -- so it is *skipped* on those
+        # events by design. Requiring `success` unconditionally would paint
+        # `main` red on every push; accepting `skipped` unconditionally would
+        # hide a job that genuinely stopped running. Requiring success exactly on
+        # the event where the job is scheduled is neither.
+        # `test_the_ci_job_runs_only_on_pull_requests` pins that job's condition,
+        # so the two cannot drift apart unnoticed.
+        #
+        # 🔴 **No expression substitution inside `run:`.** The comparison happens
+        # in the Actions `if:` expression and the shell step is a bare `exit 1`.
+        # Interpolating `${{ toJSON(needs) }}` into a script substitutes it as
+        # text before the shell parses the line, and `needs` carries job OUTPUTS
+        # as well as results -- so a crafted output can break the quoting or
+        # inject commands. Listing the dependencies costs a line each and keeps
+        # untrusted data out of the shell entirely.
+        # 🔴 **`needs['review-scripts']`, not `needs.review-scripts`.** A job id
+        # containing a hyphen is not reachable by property access in an Actions
+        # expression -- the parser reads the hyphen as an operator -- so the dot
+        # spelling does not fail loudly, it evaluates to something else. The
+        # index form is required for exactly the ids that carry a hyphen, and
+        # the guard holds this block to it.
+        if: >-
+          needs['review-scripts'].result != 'success' ||
+          (github.event_name == 'pull_request' &&
+           needs.review_replies.result != 'success') ||
+          needs.broad.result != 'success'
+        run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ concurrency:
 
 jobs:
   review-scripts:
-    # The Claude review system's own tests -- 543 of them, covering the rule
+    # The Claude review system's own tests -- 551 of them, covering the rule
     # selector, the result classifier, the failure notices, the prompt redactor,
     # the findings schema, the workflow's own wiring, the workflow parser behind
     # the runner-ceiling guard, and the `ci-required` aggregation.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1802,9 +1802,16 @@ jobs:
             # nothing, and it needs none of the deferred work: making the notice
             # and the job summary able to say "not timed" needs `Resolve outcome`
             # to emit a `measured` output, which those two render from and cannot
-            # see. That residual is unfixed and deliberate; this comment is its
-            # only record, because this repository has no design document to
-            # carry it.
+            # see. That residual is unfixed and deliberate, and this comment is
+            # its record. ⚠️ It used to add a clause denying that this repository
+            # has any design document to carry such a note -- described rather
+            # than quoted, for the reason the paragraph below gives. That clause
+            # is false: `.system_design/` exists and holds the test-suite design
+            # and its implementation plan
+            # -- and the honest position is narrower: those documents are about
+            # the test suite, this residual is about the review workflow, and
+            # nobody has yet decided where review-workflow decisions belong. The
+            # comment stays the record until they do.
             #
             # ⚠️ The retired drafts are PARAPHRASED above, never quoted: the
             # wiring test reads this whole step including its comments, on

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -302,11 +302,14 @@ jobs:
     # observed run is 207s are exactly the lightweight workload that label is for. The
     # review workflow and the two `ci.yml` review jobs therefore no longer share one
     # label, which is a real cost -- see `ci.yml`, where it is recorded on both jobs.
-    # ⚠️ "The two workflows" is how this read before the test jobs landed; there are
-    # three workflow files now, and `tests-broad.yml` runs on `ubuntu-latest` too. The
-    # cost this sentence records is unchanged -- it was always about these jobs and
-    # that one -- but its arithmetic was not, so it is corrected rather than left to
-    # be read as a claim about the tree.
+    # ⚠️ This used to count the workflows in the tree rather than name the jobs it
+    # is about, and went wrong the moment the test jobs landed. The cost it records
+    # is unchanged -- it was always about these two jobs and this one -- so it now
+    # names them and counts nothing. 🔴 **A count in prose is a claim nothing
+    # checks**, which is why `rules/ci.md` had its own removed in the same branch;
+    # this comment then reintroduced one two commits later, in the one file no
+    # guard reads. Name what a sentence is about; leave the arithmetic to the
+    # `EXPECTED_WORKFLOW_FILES` set, which is pinned against the tree.
     #
     # ⚠️ The pairing of this label with the cap below is now checked by
     # `DeclaredJobCapIsEnforceableTests`, so neither line can move without the other.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,14 @@ name: Claude Code Review
 #
 # ⚠️ **THAT LAST CATEGORY IS THE ONE TO READ CAREFULLY.** The reference repository
 # pairs this workflow with four `lint`-job guard scripts and a set of design
-# documents. **This repository has neither** -- `claude-code-review.yml` is its
-# only workflow. Where a comment below used to cite a guard as enforcement, it now
-# says plainly that the invariant is a convention instead. A convention that reads
-# like an enforced invariant is worse than an acknowledged one, because the next
-# person trusts it.
+# documents. **This repository has neither of those**, and the sentence that used
+# to follow -- that this was its only workflow -- is no longer true either: there
+# is a `ci.yml` running the review system's own tests and the repository's broad
+# test selection. What has not changed is the point the sentence was making.
+# Where a comment below used to cite an upstream guard as enforcement, it now
+# says plainly that the invariant is a convention instead. A convention that
+# reads like an enforced invariant is worse than an acknowledged one, because the
+# next person trusts it.
 #
 # ⚠️ **Every measurement quoted below was taken on the reference repository, not
 # on this one.** They are kept because they are what sized these numbers, and each

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -300,8 +300,13 @@ jobs:
     # the cap below becomes enforceable for the first time and the distribution should
     # shorten as well. `ci.yml` deliberately KEEPS `ubuntu-slim`: two jobs whose slowest
     # observed run is 207s are exactly the lightweight workload that label is for. The
-    # two workflows therefore no longer share one label, which is a real cost -- see
-    # `ci.yml`, where it is recorded on both jobs.
+    # review workflow and the two `ci.yml` review jobs therefore no longer share one
+    # label, which is a real cost -- see `ci.yml`, where it is recorded on both jobs.
+    # ⚠️ "The two workflows" is how this read before the test jobs landed; there are
+    # three workflow files now, and `tests-broad.yml` runs on `ubuntu-latest` too. The
+    # cost this sentence records is unchanged -- it was always about these jobs and
+    # that one -- but its arithmetic was not, so it is corrected rather than left to
+    # be read as a claim about the tree.
     #
     # ⚠️ The pairing of this label with the cap below is now checked by
     # `DeclaredJobCapIsEnforceableTests`, so neither line can move without the other.

--- a/.github/workflows/tests-broad.yml
+++ b/.github/workflows/tests-broad.yml
@@ -1,0 +1,123 @@
+name: Tests (broad)
+
+# The repository's own test suite, on both platforms it supports.
+#
+# ⚠️ **A reusable workflow, called from `ci.yml`, and that shape is deliberate.**
+# The test-suite design commits every CI job to its own file so that `ci.yml`
+# holds nothing but `uses:` lines and one `needs:` list. Several later steps add
+# jobs in parallel; if each edited a shared workflow they would conflict, and the
+# worse outcome is a rebase that silently drops the other's edit. The `needs:`
+# list stays the one contended region, and the steps mutating it are ordered in
+# `.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md`.
+#
+# ⚠️ **Transitional by design.** Section 8B of `.system_design/TEST_SUITE.md`
+# asks for one broad selection first, so that a gate exists at all, and splits it
+# into the normative `fast` and `subsystem` jobs in the next step. This file is
+# that first selection. It is NOT the job table of section 10.3 and should not be
+# read as it.
+#
+# 🔴 **The selection deliberately INCLUDES `subsystem`.** The worker retry,
+# cleanup and streaming tests are the reason the test-suite design exists, and
+# they sit at the subsystem layer because they need a real child process. A
+# `fast`-only gate excludes them by construction, so the aggregate would go green
+# while exactly those tests sat unprotected. What is excluded is only what a
+# plain runner genuinely cannot do: a browser and the network.
+#
+# 🔴 **This job requires no repository secret, and that is an invariant worth
+# keeping rather than an accident.** GitHub withholds secrets from a workflow
+# triggered by a fork's pull request, so a job that needed one would be red on
+# every outside contribution -- and a merge gate that cannot go green for a
+# contributor is not a gate, it is a wall. The selection reaches no network and
+# `tests/conftest.py` supplies a dummy provider key when the environment has
+# none. A step added here that reads `secrets.*` breaks fork pull requests, and
+# nothing else will say so: on a fork the secret resolves to the empty string
+# rather than failing.
+#
+# 🔴 **`--ignore=tests/package` is NOT redundant with the `package` marker.** A
+# marker exclusion only helps when the marker is present. A file under
+# `tests/package/` whose author forgot `@pytest.mark.package` is still collected
+# by the marker expression alone, and would then run against the source checkout
+# while claiming to have tested an installed wheel. Path and marker together;
+# neither alone. The directory does not exist yet -- this is the job that must
+# already be right when it does.
+
+on:
+  workflow_call:
+
+jobs:
+  broad:
+    # 🔴 **The matrix lives HERE, in the called workflow, not on the caller.**
+    # A caller job may legally carry a `strategy:` and pass the leg in with
+    # `with:`, and that shape was rejected: the runner would then be spelled
+    # `runs-on: ${{ inputs.os }}`, whose value is decided by whoever calls the
+    # workflow and is therefore not resolvable from any file. The runner-ceiling
+    # guard refuses what it cannot resolve, so that arrangement would have put a
+    # job beyond the reach of the check -- which is the failure the guard exists
+    # to prevent, not a shape to route around it with.
+    strategy:
+      # Both legs report. A Windows failure that hid the Linux result would cost
+      # a whole round trip on the one platform this repository has the least
+      # evidence about.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    # 🔴 Measured, not guessed, and strictly below the runner's ceiling. The
+    # selection takes 8m39s on a developer's Linux machine (785 passed, 2
+    # skipped, 787 selected); this cap is roughly seven times that, because it
+    # must also cover Windows -- where a suite that spawns child processes and
+    # shells out to mypy commonly runs two to three times slower -- plus a cold
+    # dependency install. Both labels above are ordinary GitHub-hosted runners
+    # with a 6-hour platform ceiling, and 60 is strictly under it, so this
+    # number can actually fire and produce a diagnosis of its own rather than
+    # dying at the same instant the platform kills the job.
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          # 3.13 only, deliberately. The compatibility matrix over Python and
+          # `mcp` versions arrives with the normative split; adding it here
+          # would quadruple the first gate's runtime for no coverage this step
+          # is responsible for.
+          python-version: "3.13"
+      - name: Install the project and its dev extras
+        # `bash` on both platforms, so one command line is read one way. The
+        # Windows default is PowerShell, and a selection expression that must be
+        # quoted identically in two shells is a difference nobody sees until the
+        # marker expression silently changes meaning on one of them.
+        shell: bash
+        # 🔴 `.[dev]`, not the pinned ratchet lane. The selection includes
+        # `subsystem` cases that shell out to `mypy`, and `mypy` lives only in
+        # the `dev` extra. With it absent the harness's shell-out cases fail
+        # while its configuration-reading cases still pass, which reads as a
+        # partial breakage rather than a missing tool -- so the harness raises
+        # "mypy never ran" instead, naming the install as the cause.
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+      - name: Run the hermetic and subsystem selection
+        shell: bash
+        # 🔴 **`--min-selected` is the floor, and it is read from an observed
+        # run.** `--strict-markers` rejects an unknown mark applied to a test; it
+        # says nothing about a job whose `-m` expression matches two tests when
+        # it should match seven hundred. A selector matching *nothing* is safe by
+        # accident -- pytest exits 5 and the step fails -- but the dangerous case
+        # is a selector that matches a handful, which exits 0 and goes green.
+        # The floor is enforced inside pytest, where collection is authoritative
+        # and the test exit code is preserved.
+        #
+        # ⚠️ **Update this number in the same pull request that deliberately adds
+        # tests to, or removes them from, this selection** -- and read it from
+        # the run, never from a number written down earlier. Note the shape that
+        # is NOT an addition to the selection: the first test carrying a
+        # `chromium`, `live` or `package` marker is deselected here, so it lowers
+        # this count. Today those three markers select zero of the 787, so this
+        # floor is the whole suite; the step that adds the first browser test
+        # owns lowering it, and the failure message it would otherwise get names
+        # the wrong cause.
+        run: >-
+          python -m pytest
+          --ignore=tests/package
+          -m "not live and not chromium and not package"
+          --min-selected 787

--- a/.github/workflows/tests-broad.yml
+++ b/.github/workflows/tests-broad.yml
@@ -72,6 +72,20 @@ jobs:
     # number can actually fire and produce a diagnosis of its own rather than
     # dying at the same instant the platform kills the job.
     timeout-minutes: 60
+    # 🔴 Declared, not inherited, and complete rather than partial. This file has
+    # no workflow-level `permissions:`, so without this block the job takes the
+    # organisation default -- which is wider than anything here needs. `contents:
+    # read` is exactly what `actions/checkout` requires and nothing else: this job
+    # installs a package and runs tests, it writes nothing back to the repository
+    # and speaks to no API. Naming any permission zeroes the rest, so the one
+    # grant is the whole grant.
+    #
+    # ⚠️ A reusable workflow cannot be granted more than its caller holds, so this
+    # is a ceiling as well as a floor -- which is why the caller in `ci.yml`
+    # declares the same thing rather than leaving it to be inherited from
+    # whatever else calls this file later.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -2004,11 +2004,19 @@ plan is built would let exactly that recur while B–D are in flight.
 
 The minimum viable gate is small and ships as soon as A lands:
 
-1. One workflow running
+1. One job running
    **`pytest --ignore=tests/package -m "not live and not chromium and not package"`**
    on Linux and Windows, Python 3.13. The `--ignore` is not redundant with the
    marker: §10.3 requires it on every source-checkout job precisely because the
    marker is the thing that gets forgotten.
+
+   ⚠️ **"One job", not "one workflow" — corrected when it landed.** §1.3 of the
+   implementation plan requires each job to live in its **own reusable workflow
+   file**, with `ci.yml` holding nothing but `uses:` lines and the `needs:` list,
+   so that steps adding jobs in parallel contend only on that list. This
+   paragraph said "one workflow" and the sentence below said every later job is
+   "added to the same workflow", which is the opposite rule. Anyone implementing
+   E4-3 or E4-4 from this section alone would have followed the wrong one.
 2. The `ci-required` aggregation job (§10.3) as the **required check** under
    branch protection on `main`.
 
@@ -2021,9 +2029,10 @@ therefore excludes only what the first runner genuinely cannot do: Chromium and
 the network. Those tests are portable by design (§5.2), so both platforms can run
 them from day one.
 
-Every later job — `fast-extras`, `chromium`, `package` — is added to the same
-workflow and to `ci-required`'s `needs` as its tests come into existence, and the
-broad selection is split into the named jobs of §10.3 at that point. The
+Every later job — `fast-extras`, `chromium`, `package` — arrives as **its own
+reusable workflow file**, called from `ci.yml` and added to `ci-required`'s
+`needs` as its tests come into existence, and the broad selection is split into
+the named jobs of §10.3 at that point. The
 nightlies are **not** added to `ci-required` (§10.3).
 
 **C. Add the production seams** in §11 — the rest of the design depends on them.
@@ -2149,10 +2158,19 @@ justified in `pyproject.toml`.
 | `mutation` (nightly) | `mutmut run` over the §3.2 scope | — | Linux |
 | `types` | `mypy` over the Protocol-carrying modules | **`.[dev]`** — needs `mypy` | Python 3.13 | Linux |
 | `coverage` | pinned lane; runs the three controls of §10.4 | `requirements-ratchet.txt` (no `mypy`) | Python 3.13, pinned | Linux |
-| `ci-required` | aggregation only — no tests | — | Linux |
+| `broad` (transitional) | `--ignore=tests/package -m "not live and not chromium and not package"` | `.[dev]` | Python 3.13 | Windows + Linux |
+| `ci-required` | aggregation only — no tests | — | | Linux |
 
 `fast`, `fast-extras`, `subsystem`, `chromium`, `package`, `types` and `coverage`
 run on every push and PR.
+
+**`broad` is the CI-skeleton step's transitional job and is not part of this
+table's steady state.** §8B asks for one broad selection first, so that a gate
+exists at all before the rest of the design is built; E4-3 replaces it with
+`fast` and `subsystem`, whose union is the same set of tests. It is listed here
+so the recorded job set in `.github/review/tests/test_review_scripts.py` does not
+name a job this table never mentions — a reader finding a job there and not here
+has no way to tell a transitional one from an accident.
 
 **The `coverage` job is where §10.4's controls actually execute**, and it is a
 required dependency of `ci-required` (which remains the only *required check*).
@@ -2234,10 +2252,32 @@ Two consequences for the jobs in this table:
 2. **A matrix runner must carry a recorded ceiling before it can be named.**
    `fast` and `subsystem` above run on Windows + Linux, whose canonical spelling
    is `runs-on: ${{ matrix.os }}`. That resolves to no entry in the ceiling table
-   and will fail the guard on E4-1's first commit, by design — the ceiling for a
+   and failed the guard on E4-1's first commit, by design — the ceiling for a
    matrix runner is a decision worth making when the matrix is written rather
-   than discovered later, when the check has gone hollow. E4-1 extends the table;
-   the failure message names it.
+   than discovered later, when the check has gone hollow. The failure message
+   names the table.
+
+   **What that step did about it, since "extend the table" was only half.** The
+   parser now resolves `${{ matrix.<key> }}` against the job's **own**
+   `strategy:` block, and exposes the resolved labels as a field separate from
+   the `runs-on:` scalar; every verdict reads the resolved field, because a job
+   spelling `runs-on: ${{ inputs.os }}` has a scalar and no resolvable label at
+   all. Three consequences worth carrying:
+
+   - **A matrix job is held to the LOWEST ceiling among its labels.** Taking the
+     highest, or the first, would call a 60-minute cap enforceable on a matrix
+     that also runs somewhere with a 15-minute ceiling — the original defect,
+     one level up.
+   - **`include:` entries are unioned in; `exclude:` is deliberately ignored.**
+     An `include:` may name a runner the top-level list never does, and a label
+     the guard cannot see is a label it does not check. `exclude:` only removes
+     combinations, so ignoring it over-approximates, which is the safe direction.
+   - **The matrix must live in the called workflow, not on the caller.** A caller
+     job may legally carry a `strategy:` and pass the leg in with `with:`, but
+     the runner is then spelled `${{ inputs.os }}`, whose value is decided by
+     whoever calls the workflow and is resolvable from no file. The guard refuses
+     what it cannot resolve, so that arrangement would put a job beyond its
+     reach.
 
 A **caller job** — one that only declares `uses:` to call a reusable workflow, as
 §1.3 of the implementation plan requires `ci.yml`'s jobs to become — legally
@@ -2261,13 +2301,17 @@ default and inspect results itself:
 ```yaml
 ci-required:
   if: ${{ always() }}          # without this the job is skipped, not failed
-  needs: [fast, fast-extras, subsystem, chromium, package, types, coverage]
+  needs: [review-scripts, review_replies,
+          fast, fast-extras, subsystem, chromium, package, types, coverage]
   runs-on: ubuntu-latest
   timeout-minutes: 10          # every job declares one, strictly below its
                                # runner's ceiling -- see the paragraph above
   steps:
     - name: Fail unless every dependency succeeded
       if: >-
+        needs['review-scripts'].result != 'success' ||
+        (github.event_name == 'pull_request' &&
+         needs.review_replies.result != 'success') ||
         needs.fast.result != 'success' ||
         needs['fast-extras'].result != 'success' ||
         needs.subsystem.result != 'success' ||
@@ -2277,6 +2321,30 @@ ci-required:
         needs.coverage.result != 'success'
       run: exit 1
 ```
+
+**The two review-system jobs are dependencies too, and that is what keeps "the
+only required check" true.** They were not in this list until the CI-skeleton
+step, which is when it stopped being a list of test jobs and became the thing
+branch protection reads. Leaving them out would have meant either three required
+checks — contradicting the paragraph above — or one required check that had
+silently stopped covering the merge gate `review_replies` exists to provide.
+
+🔴 **`needs['review-scripts']`, not `needs.review-scripts`.** A job id
+containing a hyphen is not reachable by property access in an Actions expression;
+the parser reads the hyphen as an operator, so the dot spelling does not fail
+loudly — it evaluates to something else. Two ids in this list carry one.
+
+⚠️ **`review_replies` is the one dependency compared conditionally, and the
+condition mirrors that job's own `if:` rather than relaxing this one.** It runs
+on `pull_request` only — there is no pull request to ask about on a push or a
+manual run — so it is *skipped* on those events by design. Requiring `success`
+unconditionally would paint `main` red on every push; accepting `skipped`
+unconditionally is the loose form this section forbids. Requiring success exactly
+on the event where the job is scheduled is neither, and it is sound **only while
+it applies to that one job**: a second dependency acquiring the same clause is a
+second job nobody checks on three of the four events.
+`test_the_only_conditional_dependency_is_the_one_that_skips_by_design` and
+`test_the_conditional_clause_mirrors_that_jobs_own_condition` hold both halves.
 
 **No expression substitution inside `run:`.** The comparison happens in the
 Actions `if:` expression, and the shell step is a bare `exit 1`. Interpolating

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -20,8 +20,12 @@ So there is no interim enforcement phase. **E4-1 is authored early and merges wi
 which is what TEST_SUITE §8B asks for. Every later job is added and activated
 incrementally on top of an already-enforced gate.
 
-Before E1-6 the repository has no CI, exactly as today. That is the honest
-position, and it is short.
+Before E1-6 the repository had no CI for its own code. **"Exactly as today" is
+how this sentence read until E4-1 landed and made it false**, which is worth
+leaving visible: this paragraph sits outside `.github/`, so the sweep guard that
+now catches that claim class cannot see it. The scope of that guard is the
+directories it walks, and a design document is not one of them — a correction
+here is a person's job, and this is the record that it was needed.
 
 ### 1.2 A job never becomes required before its tests exist
 

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -817,6 +817,43 @@ typo'd selector fails the job.
   Merges only once E1-6 lands, so it is green from its first run.
   *Verify:* a failing test makes `ci-required` red; a **skipped** dependency also
   makes it red; a fork PR triggers the workflow; the job is green on merge.
+
+  > **Implementation notes, added on merge.**
+  >
+  > - **`ci-required.needs` includes the two review-system jobs**, not only the
+  >   test job. Excluding them would have meant either three required checks —
+  >   contradicting §10.3's "it is the only required check" — or one required
+  >   check that had silently stopped covering the `review_replies` merge gate.
+  >   `review_replies` is `pull_request`-only, so it is compared under
+  >   `github.event_name == 'pull_request'`; that is not the loose `skipped`
+  >   acceptance §10.3 forbids, it requires success exactly on the event where
+  >   the job is scheduled. Two guards hold it: one refuses a second dependency
+  >   acquiring the same clause, and one pins the two conditions to each other.
+  > - **The runner-ceiling guard was extended, not relaxed.** It failed on the
+  >   first commit exactly as this entry predicted. The parser now resolves a
+  >   matrix runner against the job's own `strategy:` block into a field
+  >   separate from the `runs-on:` scalar, every verdict reads the resolved
+  >   field, a matrix is held to the **lowest** ceiling among its labels, and
+  >   `include:` entries are unioned in. `windows-latest` was recorded at 360.
+  > - **The matrix lives in the called workflow, not on the caller.** A caller
+  >   job may carry a `strategy:`, but its runner would then be
+  >   `${{ inputs.os }}` — decided outside the file and resolvable from none of
+  >   it — which would put the job beyond the guard's reach.
+  > - **Seven sentences in six files said this repository ran no tests in CI.**
+  >   All were true when written and one change falsified them together. Each is
+  >   rewritten rather than deleted, and a sweep guard now fails on any
+  >   reintroduction, with a control per phrasing and a control that the walk
+  >   reached real files.
+  > - **`concurrency` was added to `ci.yml`** with the test jobs and not before:
+  >   the review jobs finish in seconds, so superseding them saved nothing,
+  >   while the broad selection is roughly nine minutes per leg.
+  >
+  > **Deferred:** a typo in an *exclusion* term of the marker expression is
+  > invisible to the floor, measured — `-m "... and not packaage"` still selects
+  > 787 and exits 0. The floor catches under-selection, which is the dangerous
+  > case; it cannot catch an exclusion that excludes nothing while the excluded
+  > markers select nothing anyway. This resolves itself as those markers acquire
+  > tests, and is recorded rather than solved.
 - **E4-2.** No diff to the repository. This is §8B's minimum viable gate and it
   lands immediately after green — which is why E4-3 declares `complete E4-2`
   rather than relying on prose ordering.
@@ -1286,6 +1323,17 @@ duplicating tests or touching the same files.
   are hermetic and belong in the fast lane. Every claim this step adds there
   needs its own `chromium` or `subsystem` marker, or a step written against a
   locally installed Chromium quietly acquires cases that run everywhere.
+  **This step therefore owns lowering the broad job's `--min-selected` floor,
+  and its acceptance check must say so.** E4-1 measured that floor at 787 —
+  which is the *whole* suite, because `chromium`, `live` and `package` today
+  select zero of it. The first `chromium`-marked case this step adds is
+  deselected by the broad job and drops the count below the floor, so the job
+  exits 4 with *"check the -m expression against the registered markers"*: a
+  message naming the wrong cause, on a step whose selector is fine. §10.3's
+  maintenance rule covers deliberate additions **to** a selection and does not
+  cover this shape, which is a deliberate addition **outside** one.
+  *Verify, added:* the broad job's floor is lowered in the same pull request by
+  exactly the number of cases this step marks, read from an observed run.
   **Added scope: settle one §10.4 sentence this step is now the owner of.** §10.4
   holds two positions about hermetic tests on `omit`-ed modules and nothing
   reconciles them. One blesses the practice — "an L1 test on an omitted module,

--- a/tests/test_min_selected_guard.py
+++ b/tests/test_min_selected_guard.py
@@ -214,20 +214,39 @@ def test_guard_stands_down_when_the_run_has_already_failed() -> None:
     )
 
 
-def test_option_default_is_zero(pytestconfig: pytest.Config) -> None:
-    """Assert the option is registered in the **running** pytest, defaulting to 0
+def test_option_is_registered_in_the_running_pytest(pytestconfig: pytest.Config) -> None:
+    """Assert the option is registered in the **running** pytest
 
     Read through ``pytestconfig`` rather than from the source: this is the case
     that notices if ``tests/conftest.py`` stops being an initial conftest and the
-    registration silently stops happening.
+    registration silently stops happening. ``getoption`` raises ``ValueError``
+    for an unregistered name, so reaching the assertion at all is most of the
+    claim.
+
+    🔴 **This case used to assert the value was 0, and that was a latent defect
+    rather than a stricter check.** ``getoption`` returns the **effective**
+    value, not the declared default, so the assertion held only for invocations
+    that omitted the option -- which was every invocation until CI began passing
+    a floor. The first real CI run would have failed here, on a test whose
+    subject is unrelated to anything the run was doing, with a message about a
+    design requirement that was being met.
+
+    ⚠️ **The default's behaviour is pinned elsewhere and deliberately not
+    re-asserted here.** ``test_without_the_option_an_empty_selection_still_exits_five``
+    runs a child with no floor over a selection matching nothing: a default above
+    zero would arm the guard, and that child would exit 4 instead of 5. That is a
+    behavioural check of the default which no supplied option can disturb, which
+    is exactly what this one could not be.
 
     Args:
         pytestconfig: The session's configuration, injected by pytest.
     """
-    assert pytestconfig.getoption(OPTION) == 0, (
-        f"pytest reports {OPTION} = {pytestconfig.getoption(OPTION)!r}; section "
-        "10.3 of TEST_SUITE.md requires a default of 0 so that every invocation "
-        "without the option is unaffected."
+    selected = pytestconfig.getoption(OPTION)
+
+    assert isinstance(selected, int) and selected >= 0, (
+        f"pytest reports {OPTION} = {selected!r}; section 10.3 of TEST_SUITE.md "
+        "requires an integer floor, and a negative one would arm the guard "
+        "against a count it can never fall below."
     )
 
 


### PR DESCRIPTION
## Context for the Product Owner

**Today, nothing tests this product before it merges.** The repository has two CI
jobs and both check the *code-review robot*, not the application. The project's
own 787 tests run only on a developer's machine, and only if they choose to run
them. Anyone can merge a broken build and every check stays green.

Two consequences this pull request ends:

1. **There is no merge gate.** After this lands there is one check, `ci-required`,
   that goes red if any test fails — or is silently skipped, which is the failure
   mode that is easy to get wrong and impossible to notice. The next ticket makes
   it the required check under branch protection.
2. **A credential-leak control is switched off.** This is a **public** repository.
   `tests/test_corpus_policy.py` is 158 tests whose entire job is to stop a saved
   web page being committed with a session cookie, an `Authorization` header, a
   bearer token or an email address inside it. Nothing runs them. A contributor
   could commit a page carrying a credential and every check on their pull request
   would be green. This pull request is what turns that control on.

What this does **not** yet cover, so a green tick is not over-read: the browser
tests, the packaging tests, the type-check job, the coverage controls and the
live-network canaries are each a separate job with its own decisions, and each
joins the gate as it lands. Read a green `ci-required` as *"the broad selection
passed on Linux and Windows"*, not as *"everything was checked"*.

Implements plan step **E4-1**.

---

## What changed

`ci.yml` becomes a **caller**. It invokes a new reusable workflow
`tests-broad.yml` — `pytest --ignore=tests/package -m "not live and not chromium
and not package"` on `ubuntu-latest` and `windows-latest` at Python 3.13 — and
declares `ci-required`, the aggregation job.

The selection **deliberately includes `subsystem`**. Section 8B is explicit: the
worker retry, cleanup and streaming tests are the reason this design exists, and
they need a real child process. A `fast`-only gate would have gone green with
exactly those tests unprotected.

### The runner-ceiling guard was extended, not relaxed

It failed on the first commit, exactly as the plan predicted. The canonical
spelling for an OS matrix is `runs-on: ${{ matrix.os }}`, which resolves to no
entry in the ceiling table, and the guard **refuses what it cannot resolve**.
The cheap way past was to make it accept an unresolved runner; that is the one
edit that makes the whole guard hollow, and it is not what happened.

The parser now resolves the expression against the job's **own** `strategy:`
block, into a field separate from the `runs-on:` scalar. That separation is
load-bearing: a job spelling `runs-on: ${{ inputs.os }}` has a non-empty scalar
and **no resolvable label at all**, so a check reading the scalar would find a
string and wave it through. Every verdict reads the resolved field.

- **A matrix is held to the LOWEST ceiling among its labels.** Taking the highest
  would call a 60-minute cap enforceable on a matrix that also runs on a
  15-minute runner — the original defect, one level up.
- **`include:` entries are unioned in; `exclude:` is ignored.** A label the guard
  cannot see is a label it does not check. Ignoring `exclude:` can only
  over-approximate, which is the safe direction.
- **A flow list means two different things.** Under `runs-on:` it is *one* runner
  specification (the ceiling table already holds keys spelled that way); under
  `strategy.matrix` it is a list of alternatives. Conflating them would have
  exploded `[self-hosted, cap-main, noble]` into three unrecorded labels.

`windows-latest` recorded at 360, re-confirmed against GitHub's Actions limits
reference rather than recalled.

### The aggregate covers every job

A first draft had it cover only the test job, because `review_replies` is
`pull_request`-only and is *skipped* on a push — which a strict `success`
comparison turns into a red `main` every time. Design review showed **both**
available answers broke something written down: excluding the review jobs means
either three required checks (contradicting §10.3's "it is the only required
check") or one required check that had quietly stopped covering the merge gate
`review_replies` provides.

The answer that breaks neither: compare that one dependency **conditioned on the
event**, so success is required exactly when the job was scheduled to run. Two
guards keep the exemption from spreading — one refuses a second dependency
acquiring the same clause, one pins the aggregate's condition to
`review_replies`'s own.

Also: **`needs['review-scripts']`, not `needs.review-scripts`.** A hyphen is an
operator to the Actions expression parser, so the dot spelling does not fail
loudly — it evaluates to something else.

### A latent defect the first real CI run would have hit

`test_option_default_is_zero` asserted `--min-selected` was 0 by reading the
**effective** value from the running session rather than the declared default. It
held for every invocation that omitted the option — which was all of them, until
this job started passing a floor. Measured: under `--min-selected 1` the old
assertion fails. The first CI run would have gone red on a test unrelated to
anything the run was doing, complaining about a requirement that was being met.

It now asserts what it means — that the option is *registered*, which is the
conftest-loading claim it exists for. The default's **behaviour** stays pinned by
a child-process control that no supplied flag can disturb.

### Documents this change falsified

**Seven sentences in six files** said this repository ran no tests in CI. All were
true when written; one change falsified them together, and they were not
clustered. Each is rewritten rather than deleted, and a sweep guard now fails on
any reintroduction — one pattern per phrasing, plus a control that each pattern
recognises the claim it forbids, a control that none fires on the true sentences
beside them, and a control that the walk reached real files.

**Two documents quoted how many tests the guard file holds; both were stale.** A
guard now measures the count from the loader and holds both to it. It caught
itself on its first run, then caught a weakness of its own — a substring test for
`539` is satisfied by `5390`, so the mutation that should have killed it passed.
It matches a whole number now.

---

## Measured, not assumed

| | |
|---|---|
| Collected by the selection, Linux | **787** |
| Result | **785 passed, 2 skipped** |
| Wall-clock, cold / warm under the exact CI command line | **8m39s** / **2m22s** |
| Nested full-suite child run inside the ledger guard | **74.8s** against its 300s bound |
| Guard suite | **513 → 551**, green |
| `timeout-minutes` | **60** — ~7× the Linux measurement, must also cover Windows and a cold install, strictly below the 360 ceiling so it can produce a diagnosis of its own |

### Later commits on this branch

- **c59a734** — least-privilege `permissions:` on every job, closing three CodeQL
  findings. `contents: read` where a checkout happens, `permissions: {}` on
  `ci-required`, which checks out nothing and runs one shell builtin.
- **1ca43b6** — two holes in this branch's own guards, found by code review.
  The matrix parser **truncated** a runner list on a comment between items and on
  a flow-style `include:`, resolving a matrix to a set missing its most
  constrained member: measured, a 60-minute cap then PASSED against a leg that
  dies at 15. And the guard tying `ci-required`'s conditional excuse to the job it
  excuses counted string occurrences, which cannot see a **widened** condition —
  measured, widening that job's own trigger left all 545 cases green over a hole
  in which `ci-required` reports green on a failed merge gate. Both fixed and
  falsified. Also: four requirements that traced to no test at all now have one.
- **662adff** — the automated review found the claim sweep's documentation
  overclaiming: two sentences denying a design document exists survived in a
  spelling its patterns could not see. Corrected, vocabulary widened, and the
  `labeled`/`unlabeled` triggers now record why they are there and what they cost.

**Nineteen faults were injected and every one was caught**: dropping the ceiling
entry; capping at the ceiling and above it; a matrix gaining a short-ceilinged
runner; a caller job declaring `runs-on:`; dropping `always()`; dropping a
dependency from `needs`; dropping one from the comparison; reverting to dot
notation on a hyphenated id; interpolating `toJSON(needs)` into the shell; moving
the conditional excuse onto the wrong job; extending it to a second; loosening
`review_replies`'s own condition; reintroducing a retired claim; mistyping a
guard pattern; pointing a sweep at an empty directory; both count mutations;
dropping the colon anchor from the matrix-key pattern; and loosening the
`strategy:` depth anchor.

---

## The Windows leg: was unverified, now measured

**Reported green on this pull request's first run.** Both platforms select
exactly **787**, so the floor needed no change:

| Leg | Selected | Result | Wall-clock |
|---|---|---|---|
| `ubuntu-latest` | 787 | **785 passed, 2 skipped** | 100.0 s |
| `windows-latest` | 787 | **784 passed, 3 skipped** | 134.4 s |

Windows skips one test more than Linux. That is a platform-conditional `skipif`,
not a collection divergence — a skipped test is still a *selected* one, which is
why the floor is identical on both while the pass counts differ by one.

**What this retires.** `BASELINE_FAILURES.md` recorded the last Windows run at
**449** cases, and nothing had re-derived it since; roughly **338 tests had never
executed on Windows**. They now have, and they pass. So the "suite green on both
platforms" milestone was not resting on stale evidence — but it is worth saying
plainly that until this run it was true by luck rather than by evidence, and from
here it is re-checked on every pull request.

`timeout-minutes: 60` is comfortable against both: the slower leg took 3 m 21 s
end to end including a cold dependency install.

## Noted, deliberately not fixed

`.github/review/rules/docs.md` states this repository has no `.system_design/`
directory. That is false, and was false before this change — nothing here makes
it more or less so — so it is left for its own ticket rather than folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjohLW13mJzzmuP6RETGPv
