### PR TITLE
Answer for the domains we own, and decline in the one way the router can catch (plan step E5-2)

### DIFF
--- a/.github/review/rules/python-tests.md
+++ b/.github/review/rules/python-tests.md
@@ -48,7 +48,7 @@
 
 ## The guard tests — treat these as load-bearing
 
-Fifteen tests exist to hold an invariant that nothing else enforces. A pull request
+Sixteen tests exist to hold an invariant that nothing else enforces. A pull request
 that changes what they guard, without changing them, is a finding; a pull request
 that *weakens* one to make a change pass is a critical finding.
 

--- a/.github/workflows/tests-broad.yml
+++ b/.github/workflows/tests-broad.yml
@@ -64,7 +64,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     # 🔴 Measured, not guessed, and strictly below the runner's ceiling. The
     # selection takes 8m39s on a developer's Linux machine (785 passed, 2
-    # skipped, 787 selected); this cap is roughly seven times that, because it
+    # skipped, 787 selected). ⚠️ That is the run this cap was DERIVED from and it
+    # is deliberately not restated as the selection grows -- the live figure is
+    # the floor below, 948 at the time of writing. Re-deriving the cap needs a
+    # fresh timing on comparable hardware, which nobody has taken; this cap is
+    # roughly seven times that measured duration, because it
     # must also cover Windows -- where a suite that spawns child processes and
     # shells out to mypy commonly runs two to three times slower -- plus a cold
     # dependency install. Both labels above are ordinary GitHub-hosted runners
@@ -126,7 +130,7 @@ jobs:
         # the run, never from a number written down earlier. Note the shape that
         # is NOT an addition to the selection: the first test carrying a
         # `chromium`, `live` or `package` marker is deselected here, so it lowers
-        # this count. Today those three markers select zero of the 787, so this
+        # this count. Today those three markers select zero of the 948, so this
         # floor is the whole suite; the step that adds the first browser test
         # owns lowering it, and the failure message it would otherwise get names
         # the wrong cause.
@@ -134,4 +138,4 @@ jobs:
           python -m pytest
           --ignore=tests/package
           -m "not live and not chromium and not package"
-          --min-selected 787
+          --min-selected 948

--- a/.github/workflows/tests-broad.yml
+++ b/.github/workflows/tests-broad.yml
@@ -66,7 +66,7 @@ jobs:
     # selection takes 8m39s on a developer's Linux machine (785 passed, 2
     # skipped, 787 selected). ⚠️ That is the run this cap was DERIVED from and it
     # is deliberately not restated as the selection grows -- the live figure is
-    # the floor below, 948 at the time of writing. Re-deriving the cap needs a
+    # the floor below, 1009 at the time of writing. Re-deriving the cap needs a
     # fresh timing on comparable hardware, which nobody has taken; this cap is
     # roughly seven times that measured duration, because it
     # must also cover Windows -- where a suite that spawns child processes and
@@ -130,7 +130,7 @@ jobs:
         # the run, never from a number written down earlier. Note the shape that
         # is NOT an addition to the selection: the first test carrying a
         # `chromium`, `live` or `package` marker is deselected here, so it lowers
-        # this count. Today those three markers select zero of the 948, so this
+        # this count. Today those three markers select zero of the 1009, so this
         # floor is the whole suite; the step that adds the first browser test
         # owns lowering it, and the failure message it would otherwise get names
         # the wrong cause.
@@ -138,4 +138,4 @@ jobs:
           python -m pytest
           --ignore=tests/package
           -m "not live and not chromium and not package"
-          --min-selected 948
+          --min-selected 1009

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -461,12 +461,19 @@ examples do not.
 There is **no inverse serializer**, so "round-trip" is not a property this suite
 can state. The per-parser properties are instead:
 
-- *Identifier preservation* — for a generated URL built from known identifiers
-  (site, question id, owner/repo/number, article title, arXiv id), the parser
-  returns exactly those identifiers.
-- *Stable rejection* — a rejected URL raises that parser's own error type, never
-  a bare `Exception`, and rejection does not depend on trailing slashes, case in
-  the scheme, or query-string order.
+- *Identifier preservation* — for a URL built from known identifiers (site,
+  question id, owner/repo/number, article title, arXiv id), the parser returns
+  exactly those identifiers. **Built from a table, not generated.** The word
+  changed when E5-2 landed, rather than the module being bent to fit the older
+  one: E5-1 owns the generated space, and these are per-parser facts over small
+  enumerable inputs, which a parametrised table names in the failure report
+  where a shrunk counterexample would not.
+- *Stable rejection* — a rejected URL raises that parser's own error type, and
+  rejection does not depend on trailing slashes, case in the scheme, or
+  query-string order. **Scoped to the branches each parser's own guards reach**,
+  which is narrower than "never a bare `Exception`" and is narrower for a
+  measured reason: two inputs escape every parser *before* any guard runs, and
+  §14 records them.
 
 **E5-1 shipped a production fix, following E5-8's precedent above.** A test
 step changing production code is the exception, not the rule, and the reason is
@@ -623,10 +630,14 @@ bring them together. **So apart from that one structurally-separated pair, the
 host predicates are what keeps every pair apart**, and that is what the property
 guards — *in one direction only*, which is the part worth stating precisely.
 Deleting a host guard, or widening it into space another parser
-claims, is killed. Widening one into **unclaimed** space is invisible: measured,
-`notarxiv.org`, `notwikipedia.org` and `notgithub.com` all pass the entire fast
-suite, because nothing then accepts a URL twice and a mutual-exclusivity
-property has nothing to see.
+claims, is killed. Widening one into **unclaimed** space is invisible to *this*
+property: measured while E5-1 was written, `notarxiv.org`, `notwikipedia.org`
+and `notgithub.com` all passed the entire fast suite, because nothing then
+accepts a URL twice and a mutual-exclusivity property has nothing to see. **They
+no longer pass** — E5-2 landed a row per host in
+`tests/test_url_parser_identifiers.py`, which is where that claim lives now. The
+blindness of the property itself is unchanged; what changed is that something
+else covers it.
 
 *An earlier draft closed the sentence above with "the other seven pairs".
 Seven reconciles with none of the three models — they leave eight, ten and six
@@ -660,31 +671,39 @@ Kept because deleting a pre-existing branch is a behaviour change E5-1 was not
 asked for; recorded because the mutation step will otherwise surface it as a
 survivor with nothing to consult.
 
-**Adjacent widenings are recorded, not fixed.** `parse_arxiv_url` matches
-`endswith("arxiv.org")` with **no leading dot**, so `notarxiv.org` is accepted —
-the same defect class as the one E5-1 fixed in StackExchange, but it produces no
-overlap today and so is outside a step whose claim is exclusivity. And the
-`*.stackexchange.com` branch takes only the first label, so
+**Adjacent widenings were recorded here, and E5-2 has since closed the host
+ones.** The paragraph keeps the tense it was written in with the outcome added,
+because the reasoning is what a future reader needs and deleting it would leave
+only the answer. `parse_arxiv_url` matched `endswith("arxiv.org")` with **no
+leading dot**, so `notarxiv.org` was accepted — the same defect class as the one
+E5-1 fixed in StackExchange, but it produced no overlap and so sat outside a step
+whose claim is exclusivity. **Repaired in E5-2**; see its landing note below.
+And the `*.stackexchange.com` branch takes only the first label, so
 `math.meta.stackexchange.com` derives `math` where the API's
 `api_site_parameter` is `math.meta`; a characterisation test pins today's wrong
-answer so a future correction is visible rather than silent. And all four non-StackExchange parsers admit unclaimed host space without any
-test noticing, in two distinct conditions that an earlier draft collapsed into
-one count:
+answer so a future correction is visible rather than silent. **That one is still
+open** — it is a slug-derivation defect, not a host one, and E5-2 closed only the
+hosts. All four non-StackExchange parsers admitted unclaimed host space without
+any test noticing, in two distinct conditions that an earlier draft collapsed
+into one count:
 
-- **arXiv needs no mutation at all.** `endswith("arxiv.org")` is *already* a
-  bare suffix test, so `notarxiv.org` is accepted on `main` today. A live
-  defect, not a survivable mutation.
-- **Three admit a widening mutation** that no test kills: `wikipedia.py`'s
+- **arXiv needed no mutation at all.** `endswith("arxiv.org")` was *already* a
+  bare suffix test, so `notarxiv.org` was accepted on `main`. A live defect, not
+  a survivable mutation — and the one production edit E5-2 shipped.
+- **Three admitted a widening mutation** that no test killed: `wikipedia.py`'s
   `endswith(".wikipedia.org")` weakened to a bare suffix, and both GitHub
   parsers' `host not in {"github.com", "www.github.com"}` weakened to a suffix
-  test.
+  test. Each was re-measured against the full gate selection immediately before
+  E5-2 was written — 858 passed, 2 skipped, on every one — and each now fails a
+  named row.
 
 That is the arithmetic behind "three widenings" and "four parsers" — the two
 numbers count different things and the sentence used to give one of them without
 saying which. All four are the defect class E5-1 fixed on the StackExchange side
-and pinned with the `notstackoverflow.com` rows; all four belong to E5-2's
-stable-rejection claim. All are named here so the next reader
-does not re-derive them, and so a mutation report has an answer to point at.
+and pinned with the `notstackoverflow.com` rows; all four were E5-2's
+stable-rejection claim and all four are now closed. All are named here so the
+next reader does not re-derive them, and so a mutation report has an answer to
+point at.
 
 **`_QUESTION_RE` and `_ANSWER_RE` stay unanchored, and the honest reason is
 narrower than the one first written here.** An earlier version of this paragraph
@@ -694,10 +713,87 @@ closest candidate, the Teams `/c/<team>/questions/<id>/…` form, lives on
 `stackoverflowteams.com`, which this allowlist rejects, so it argues against the
 claim rather than for it. The real reason is simply that after the host fix,
 anchoring buys nothing, and narrowing acceptance is a behaviour change E5-1 was
-not asked to make. Nothing currently guards it: `search`→`match` on either
-pattern passes the whole suite, as does dropping the `q` alternative that real
-short links like `https://es.stackoverflow.com/q/12345` depend on. Those cases
-are handed to E5-2.
+not asked to make. Nothing guarded it when this was written: `search`→`match` on
+either pattern passed the whole suite, as did dropping the `q` alternative that
+real short links like `https://es.stackoverflow.com/q/12345` depend on. All three
+were re-measured before E5-2 and all three still survived; **E5-2 owns them
+now.** The two `search` rows are pinned as *characterisation, not endorsement*,
+and say so in their docstring — the anchoring option this section keeps open is
+expected to **delete** them rather than work around them. The `q` row is an
+ordinary claim: that alternative is what the share dialog produces.
+
+**Done, in E5-2 (2026-09-06).** `tests/test_url_parser_identifiers.py` — 88
+cases over the five parsers, table-driven, no Hypothesis. It owns identifier
+preservation, typed rejection over every guard-reached branch, the
+suffix-is-not-subdomain rejection handed here by E5-1, and stability of both
+answers under four surface variations.
+
+**One production edit: the arXiv host guard.** `endswith("arxiv.org")` became
+`host != "arxiv.org" and not host.endswith(".arxiv.org")`. *What changed in
+behaviour*, stated on E5-1's model rather than left to the diff: a host that
+merely ends with the string — `notarxiv.org`, `xarxiv.org`, anything registrable
+— is no longer claimed by the arXiv integration and now falls through to the
+universal HTML loader that owns unclaimed hosts. `arxiv.org` itself and every
+subdomain of it, `export.arxiv.org` included, are unaffected, and a row pins each
+direction: narrowing the guard to an equality fails the subdomain row, widening
+it back fails the `notarxiv.org` row.
+
+**The mutation record, from one measured run each, not from arithmetic.**
+Thirty-nine mutations applied one at a time from a pristine copy held outside the
+working tree; **thirty-seven killed by this module, one killed only by another
+module, one equivalent**:
+
+| Group | Tried | Killed here | Also killed by a per-parser module | Also killed by the exclusivity module |
+|---|---|---|---|---|
+| Every `raise` site in the five parse functions | 21 | 21 | 5 | 1 |
+| Host guards — arXiv reverted and narrowed, the three widenings | 5 | 5 | 0 | 0 |
+| Capture-group and slug derivation | 8 | 7 | 6 | 2 |
+| StackExchange path patterns — `q`, both `search`→`match` | 3 | 3 | 0 | 0 |
+| Path normalisation in `arxiv.py` — `unquote`, `rstrip` | 2 | 1 | 0 | 0 |
+
+The last two columns are why the third is not a coverage claim on its own.
+**Thirteen** of the kills are shared with something that already existed —
+eleven with the five per-parser modules, which all assert identifier
+preservation for their own parser and between them reach five of the twenty-one
+rejection branches, and two more with `test_url_parser_exclusivity.py`; one
+mutation is killed by both, so the distinct total is thirteen rather than
+fourteen. **Twenty-four kills are this module's alone**: fifteen raise sites,
+all five host guards, all three pattern mutations and the `unquote` line. E12-1
+reads this table, and "thirty-seven killed" without the split would credit this
+module with work `tests/test_github_issues.py` was already doing.
+
+**One mutation survives this module, and it is recorded rather than closed.**
+Narrowing `_derive_site_parameter`'s `*.stackexchange.com` branch — dropping the
+`.split(".")[0]` so the whole prefix becomes the slug — leaves all 88 cases
+green. The only allowlisted host with a two-label prefix there is
+`math.meta.stackexchange.com`, whose slug is the **characterised defect** three
+paragraphs above: `test_second_level_meta_community_derives_the_wrong_slug_today`
+in `tests/test_url_parser_exclusivity.py` pins `math`, and that is what kills the
+mutation. A row here would be a second owner of another module's characterisation
+and would break the day the defect is fixed, so E5-2 declined it. What E5-2's own
+StackExchange row *does* pin is the neighbouring **apex `.com` fall-through** —
+`es.stackoverflow.com` reaches that branch, not the `*.stackexchange.com` one,
+which is the opposite of the obvious reading and is why it is written down.
+
+**One equivalent mutant, recorded rather than removed.** `arxiv.py`'s
+`.rstrip("/")`: the next line filters empty segments out of the split, so
+`"/abs/2401.12345/"` yields the same parts with or without it. Measured. Its
+neighbour on the same line, `unquote`, is *not* equivalent and was surviving
+everything until a percent-encoded legacy identifier
+(`hep-th%2F9901001`) was added as a row — found by mutation, not by reading.
+
+**One dimension is unkillable by construction, and says so.** No parser reads
+`parsed.scheme`, and `urlsplit` lowercases `hostname` regardless, so the
+upper-case-scheme variation has no mutation that can fail it. Five rows of
+regression armour. Named here so a mutation report is not read as coverage.
+
+**Two defects are characterised rather than repaired, and both are in §14.**
+A malformed URL escapes all five parsers as `ValueError` before any guard runs;
+and a trailing slash joins the Wikipedia title. The first is the reason the
+typed-rejection claim above is scoped to guard-reached branches rather than
+stated as a universal — a 27-character input falsifies the universal, so the
+universal was never written.
+
 
 **Environment resolvers.** The `_resolve_*` families in `server.py`,
 `chromium_pool.py` and `nodriver_worker.py`, plus `_parse_port_range`,
@@ -4129,6 +4225,47 @@ is nothing to test.
   acceptance scenarios are reverse-engineered from tool docstrings rather than
   derived from stated acceptance criteria. Which convention should apply is a
   separate question from this document; the gap is the same either way.
+- **Every URL parser can raise a class the resolver does not catch, and two
+  inputs reach it.** `resolve_page_content_markdown` falls through to the next
+  stage only on each parser's *own* error type, so anything else escapes the
+  function; `get_content` then renders the exception's text into the Markdown it
+  returns to the calling model, and the URL never reaches the remaining stages or
+  the HTML loader. Two mechanisms, both measured on `main` at `7fb3e59`:
+  **(a)** a malformed URL — `https://[oops/abs/2401.12345`, twenty-seven
+  characters, an unmatched bracket read as an IPv6 literal — makes `urlsplit`
+  raise `ValueError` inside `parsed.hostname`, which is the *first* statement of
+  all five parse functions, so all five escape; **(b)** an id over CPython's
+  integer-string conversion ceiling makes `parse_stackexchange_url`'s bare
+  `int()` raise `ValueError`. Both GitHub parsers already wrap their conversion;
+  StackExchange does not.
+  **And the obvious repair for (b) is not a bound.** That ceiling is a
+  process-global interpreter setting — `PYTHONINTMAXSTRDIGITS`,
+  `-X int_max_str_digits`, `sys.set_int_max_str_digits()`. Measured with the
+  limit removed, the parser *accepts* a five-thousand-digit id and would forward
+  it to the Stack Exchange API, so a `try`/`except` around the conversion guards
+  a symptom on default-configured interpreters and nothing elsewhere.
+  **Characterised by E5-2, not repaired**, on the product owner's decision and on
+  the precedent this section already records for E5-8's SerpBase leak: that step
+  was scoped to a single production edit, pinned the behaviour and filed the gap.
+  `test_a_malformed_url_escapes_every_parser_as_a_foreign_class_today`,
+  `test_an_oversized_stackexchange_id_escapes_as_a_foreign_class_today` and
+  `test_the_parser_has_no_bound_of_its_own_on_the_id_length` in
+  `tests/test_url_parser_identifiers.py` pin all three facts, so the day someone
+  repairs it those tests fail and point at this entry. Deciding *where* the guard
+  belongs — five parsers, or one place in the resolver, which would also swallow
+  genuine parser defects — is the open question and has no owner yet.
+- **A trailing slash changes the Wikipedia article title.** `_WIKI_PATH_RE` is
+  `^/wiki/(.+)$` and captures greedily, so
+  `https://es.wikipedia.org/wiki/Manzana/` yields the title `Manzana/` and a
+  canonical URL carrying the slash. The MediaWiki request that follows asks for
+  an article that does not exist. The other four parsers are stable under the
+  same variation. **Characterised by E5-2, not repaired** —
+  `test_a_trailing_slash_changes_the_wikipedia_title_today` pins today's answer,
+  and the pair `("wikipedia", "trailing_slash")` is excluded by name from that
+  module's acceptance-stability rows so the exclusion is visible rather than
+  silent. §3.1 scopes E5-2's stability claim to *rejection*; normalising the
+  captured title changes which request the integration issues, which is a
+  production decision with no owner yet.
 - **`nodriver` and Chromium version drift** is untested at any layer. The worker
   carries compatibility shims (`_patch_nodriver_network_encoding`,
   `_is_snap_browser`), which implies breakage has happened and will recur.

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -473,7 +473,10 @@ can state. The per-parser properties are instead:
   query-string order. **Scoped to the branches each parser's own guards reach**,
   which is narrower than "never a bare `Exception`" and is narrower for a
   measured reason: two inputs escape every parser *before* any guard runs, and
-  §14 records them.
+  §14 records them. **Asserted over all twenty-one of those branches, minus one
+  named pair that does not hold** — see the landing note below; an earlier draft
+  varied one rejected URL per parser while this sentence read as though it
+  covered the branches, which is a gap the shipped rows now close.
 
 **E5-1 shipped a production fix, following E5-8's precedent above.** A test
 step changing production code is the exception, not the rule, and the reason is
@@ -722,11 +725,13 @@ and say so in their docstring — the anchoring option this section keeps open i
 expected to **delete** them rather than work around them. The `q` row is an
 ordinary claim: that alternative is what the share dialog produces.
 
-**Done, in E5-2 (2026-09-06).** `tests/test_url_parser_identifiers.py` — 88
+**Done, in E5-2 (2026-09-06).** `tests/test_url_parser_identifiers.py` — 149
 cases over the five parsers, table-driven, no Hypothesis. It owns identifier
-preservation, typed rejection over every guard-reached branch, the
-suffix-is-not-subdomain rejection handed here by E5-1, and stability of both
-answers under four surface variations.
+preservation, typed rejection over every one of the twenty-one guard-reached
+branches, the suffix-is-not-subdomain rejection handed here by E5-1, and
+stability of both answers under four surface variations — the rejection half
+crossed against **every** branch rather than one URL per parser, which is what
+turned the eighty-first pair into a finding rather than a blind spot.
 
 **One production edit: the arXiv host guard.** `endswith("arxiv.org")` became
 `host != "arxiv.org" and not host.endswith(".arxiv.org")`. *What changed in
@@ -791,7 +796,7 @@ regression armour. Named here so a mutation report is not read as coverage.
 A malformed URL escapes all five parsers as `ValueError` before any guard runs;
 and a trailing slash joins the Wikipedia title. The first is the reason the
 typed-rejection claim above is scoped to guard-reached branches rather than
-stated as a universal — a 27-character input falsifies the universal, so the
+stated as a universal — a 28-character input falsifies the universal, so the
 universal was never written.
 
 
@@ -4231,7 +4236,7 @@ is nothing to test.
   function; `get_content` then renders the exception's text into the Markdown it
   returns to the calling model, and the URL never reaches the remaining stages or
   the HTML loader. Two mechanisms, both measured on `main` at `7fb3e59`:
-  **(a)** a malformed URL — `https://[oops/abs/2401.12345`, twenty-seven
+  **(a)** a malformed URL — `https://[oops/abs/2401.12345`, twenty-eight
   characters, an unmatched bracket read as an IPv6 literal — makes `urlsplit`
   raise `ValueError` inside `parsed.hostname`, which is the *first* statement of
   all five parse functions, so all five escape; **(b)** an id over CPython's
@@ -4254,16 +4259,28 @@ is nothing to test.
   repairs it those tests fail and point at this entry. Deciding *where* the guard
   belongs — five parsers, or one place in the resolver, which would also swallow
   genuine parser defects — is the open question and has no owner yet.
-- **A trailing slash changes the Wikipedia article title.** `_WIKI_PATH_RE` is
+- **A trailing slash changes the Wikipedia article title, and in one case
+  changes whether the parser accepts at all.** `_WIKI_PATH_RE` is
   `^/wiki/(.+)$` and captures greedily, so
   `https://es.wikipedia.org/wiki/Manzana/` yields the title `Manzana/` and a
   canonical URL carrying the slash. The MediaWiki request that follows asks for
-  an article that does not exist. The other four parsers are stable under the
-  same variation. **Characterised by E5-2, not repaired** —
-  `test_a_trailing_slash_changes_the_wikipedia_title_today` pins today's answer,
-  and the pair `("wikipedia", "trailing_slash")` is excluded by name from that
-  module's acceptance-stability rows so the exclusion is visible rather than
-  silent. §3.1 scopes E5-2's stability claim to *rejection*; normalising the
+  an article that does not exist. **The worse half of the same root cause:**
+  `…/wiki/%09` is *declined* — a tab strips to nothing — while `…/wiki/%09/`
+  captures `%09/`, which unquotes to a tab and a slash and strips to `"/"`, so
+  the parser **returns** `title="/"` and the URL is claimed by the Wikipedia
+  integration instead of declining to the universal loader. Measured across the
+  whole grid: eighty-one (rejection branch, surface variation) pairs exist and
+  that is the **only** one that does not hold. It was found by the automated
+  review on E5-2's pull request, after a version of the module that varied one
+  rejected URL per parser — five of the twenty-one branches — under a design
+  sentence that read as though it covered all of them. The other four parsers
+  are stable under the same variation. **Characterised by E5-2, not repaired** —
+  `test_a_trailing_slash_changes_the_wikipedia_title_today` and
+  `test_a_trailing_slash_turns_the_empty_wikipedia_title_into_a_slash` pin
+  today's answers, and both excluded pairs — `("wikipedia", "trailing_slash")`
+  on the acceptance rows and `("wiki_empty_title", "trailing_slash")` on the
+  rejection rows — are excluded **by name**, so each exclusion is visible in the
+  source rather than absorbed into a smaller claim. §3.1 scopes E5-2's stability claim to *rejection*; normalising the
   captured title changes which request the integration issues, which is a
   production decision with no owner yet.
 - **`nodriver` and Chromium version drift** is untested at any layer. The worker

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -472,9 +472,18 @@ can state. The per-parser properties are instead:
   rejection does not depend on trailing slashes, case in the scheme, or
   query-string order. **Scoped to the branches each parser's own guards reach**,
   which is narrower than "never a bare `Exception`" and is narrower for a
-  measured reason: two inputs escape every parser *before* any guard runs, and
-  §14 records them. **Asserted over all twenty-one of those branches, minus one
-  named pair that does not hold** — see the landing note below; an earlier draft
+  measured reason: two inputs escape the claim, in **different** ways, and §14
+  records both. A malformed URL escapes **all five** parsers *before any guard
+  runs*, because `urlsplit` raises inside `parsed.hostname`. An oversized
+  StackExchange id escapes **one** parser, *after* its guards have run, because
+  only that parser's conversion is unwrapped — both GitHub parsers wrap the same
+  conversion and raise their own class, arXiv never converts an identifier to an
+  integer at all, and Wikipedia treats the digits as an article title. An earlier
+  draft compressed the two into "two inputs escape every parser before any guard
+  runs", which is true of the first and of neither half of the second, and
+  contradicted §14's own record three sections down.
+  **Asserted over all twenty-one of those branches, minus one named pair that
+  does not hold** — see the landing note below; an earlier draft
   varied one rejected URL per parser while this sentence read as though it
   covered the branches, which is a gap the shipped rows now close.
 
@@ -769,8 +778,11 @@ module with work `tests/test_github_issues.py` was already doing.
 
 **One mutation survives this module, and it is recorded rather than closed.**
 Narrowing `_derive_site_parameter`'s `*.stackexchange.com` branch — dropping the
-`.split(".")[0]` so the whole prefix becomes the slug — leaves all 88 cases
-green. The only allowlisted host with a two-label prefix there is
+`.split(".")[0]` so the whole prefix becomes the slug — leaves all **149** cases
+green. Re-measured against the widened module rather than carried over from the
+88-case measurement it was first written against: none of the rows added by the
+widening reaches a two-label prefix under `stackexchange.com`, and the run
+confirms it rather than the reasoning standing alone. The only allowlisted host with a two-label prefix there is
 `math.meta.stackexchange.com`, whose slug is the **characterised defect** three
 paragraphs above: `test_second_level_meta_community_derives_the_wrong_slug_today`
 in `tests/test_url_parser_exclusivity.py` pins `math`, and that is what kills the
@@ -789,8 +801,11 @@ everything until a percent-encoded legacy identifier
 
 **One dimension is unkillable by construction, and says so.** No parser reads
 `parsed.scheme`, and `urlsplit` lowercases `hostname` regardless, so the
-upper-case-scheme variation has no mutation that can fail it. Five rows of
-regression armour. Named here so a mutation report is not read as coverage.
+upper-case-scheme variation has no mutation that can fail it. **Twenty-three
+rows** of regression armour — eighteen on the rejection side and five on the
+acceptance side, counted after the widening rather than left at the five the
+figure named when the rejection half varied one URL per parser. Named here so a
+mutation report is not read as coverage.
 
 **Two defects are characterised rather than repaired, and both are in §14.**
 A malformed URL escapes all five parsers as `ValueError` before any guard runs;

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -1058,9 +1058,13 @@ duplicating tests or touching the same files.
   mutant into a killed one. Stated as three numbers because E12-1 consults this
   record and "no survivors" alone cannot be reconciled with the equivalents named
   below: the equivalent is the `meta.<x>.com` branch, which is *not* counted
-  among the nine, and three further mutations survive **by construction** —
+  among the nine, and three further mutations survived **by construction** —
   widening the non-StackExchange host guards into unclaimed space, which this
-  property cannot see and E5-2 now owns. Three findings came from hunting
+  property cannot see. **That number is now zero, and not because this property
+  changed:** E5-2 landed a row per host in
+  `tests/test_url_parser_identifiers.py`, so the mutations are killed there.
+  Corrected here rather than only in E5-2's bullet, because a stale survivor
+  count is what E12-1 would consult. Three findings came from hunting
   survivors rather than from this bullet: the dot (`notstackoverflow.com` became
   a community and every test passed), the generator crossing path prefixes
   instead of identifier vocabularies (which left the arXiv and Wikipedia guards
@@ -1077,11 +1081,16 @@ duplicating tests or touching the same files.
   is observable by definition; it is a recorded defect, filed in §3.1 under the
   widenings left unfixed. An earlier draft called them two, contradicting this
   bullet's own singular count three sentences above.
-- **E5-2.** For each of the five parsers: a generated URL built from known
-  identifiers returns exactly those identifiers; a rejected URL raises that
-  parser's own error type; rejection is stable across trailing slashes, scheme
-  case and query order. *Verify:* each property fails if its parser's group
-  extraction is off by one, and if the parser raises bare `Exception`.
+- **E5-2.** For each of the five parsers: a URL built from known identifiers
+  returns exactly those identifiers; a rejected URL raises that parser's own
+  error type; rejection is stable across trailing slashes, scheme case and query
+  order. *Verify:* each property fails if its parser's group extraction is off by
+  one, and if the parser raises bare `Exception`.
+
+  **"Built", not "generated" — the word changed when the step landed rather than
+  the module being bent to fit it.** E5-1 owns the generated space. These are
+  per-parser facts over small enumerable inputs, and a parametrised table names
+  each case in the failure report where a shrunk counterexample would not.
 
   **Also owns, handed over by E5-1: suffix-is-not-subdomain rejection for the
   four non-StackExchange parsers.** *Verify additionally:* each parser rejects a
@@ -1102,6 +1111,36 @@ duplicating tests or touching the same files.
   belonging here: `_QUESTION_RE`/`_ANSWER_RE` survive `search`→`match`, and
   `_QUESTION_RE` survives losing its `q` alternative, which real short links
   such as `https://es.stackoverflow.com/q/12345` depend on.
+
+  **Landed.** `tests/test_url_parser_identifiers.py` — 88 table-driven cases.
+  It ships **one** production edit, the arXiv host guard, which the bullet above
+  hands here by name: `endswith("arxiv.org")` became
+  `host != "arxiv.org" and not host.endswith(".arxiv.org")`, so a host that
+  merely ends with the string now falls through to the universal HTML loader.
+  Both directions are pinned — narrowing the guard to an equality fails the
+  `export.arxiv.org` row.
+
+  **Thirty-nine mutations tried: thirty-seven killed here, one killed only by
+  `test_url_parser_exclusivity.py`, one equivalent**, and thirteen of the
+  thirty-seven are shared with a module that already existed rather than owned
+  here. The per-group table, the survivor and its owner, and the equivalent are
+  in §3.1 of `TEST_SUITE.md`, written once from one measured run; E12-1 reads it
+  there.
+
+  **Three claims were narrowed against what was measured, and the narrowing is
+  the finding.** The bullet above says a rejected URL raises the parser's own
+  type. A twenty-seven-character malformed URL falsifies that in **all five**
+  parsers — `urlsplit` raises inside `parsed.hostname`, the first statement of
+  every parse function — and an over-long StackExchange id falsifies it in one.
+  So the shipped claim is scoped to the branches each parser's own guards reach,
+  all twenty-one of them, and the two escapes are pinned as characterisation and
+  filed in §14. Likewise "rejection is stable across trailing slashes" is exactly
+  right and acceptance is not: a trailing slash changes the Wikipedia title, so
+  the acceptance rows exclude that one pair by name. Repairing either was
+  declined by the product owner on E5-8's precedent — a test step ships one
+  production edit — and, for the id, because the ceiling is a process-global
+  interpreter setting rather than anything the parser enforces.
+
 - **E5-3.** Owns `server.py`'s `_resolve_transport`, `_resolve_host_port`,
   `_resolve_tool_total_timeout_seconds`, `_resolve_web_search_max_concurrency`,
   `_resolve_transport_security`, `_cors_origin_regex`, `_get_int_env`,

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -1112,7 +1112,7 @@ duplicating tests or touching the same files.
   `_QUESTION_RE` survives losing its `q` alternative, which real short links
   such as `https://es.stackoverflow.com/q/12345` depend on.
 
-  **Landed.** `tests/test_url_parser_identifiers.py` — 88 table-driven cases.
+  **Landed.** `tests/test_url_parser_identifiers.py` — 149 table-driven cases.
   It ships **one** production edit, the arXiv host guard, which the bullet above
   hands here by name: `endswith("arxiv.org")` became
   `host != "arxiv.org" and not host.endswith(".arxiv.org")`, so a host that
@@ -1129,7 +1129,7 @@ duplicating tests or touching the same files.
 
   **Three claims were narrowed against what was measured, and the narrowing is
   the finding.** The bullet above says a rejected URL raises the parser's own
-  type. A twenty-seven-character malformed URL falsifies that in **all five**
+  type. A twenty-eight-character malformed URL falsifies that in **all five**
   parsers — `urlsplit` raises inside `parsed.hostname`, the first statement of
   every parse function — and an over-long StackExchange id falsifies it in one.
   So the shipped claim is scoped to the branches each parser's own guards reach,

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -1134,9 +1134,15 @@ duplicating tests or touching the same files.
   every parse function — and an over-long StackExchange id falsifies it in one.
   So the shipped claim is scoped to the branches each parser's own guards reach,
   all twenty-one of them, and the two escapes are pinned as characterisation and
-  filed in §14. Likewise "rejection is stable across trailing slashes" is exactly
-  right and acceptance is not: a trailing slash changes the Wikipedia title, so
-  the acceptance rows exclude that one pair by name. Repairing either was
+  filed in §14. Likewise "rejection is stable across trailing slashes" needed
+  narrowing on **both** sides, and only the acceptance side was obvious. A
+  trailing slash changes the Wikipedia title, so the acceptance rows exclude that
+  pair by name. It also flips one *rejection* into an acceptance —
+  `…/wiki/%09` is declined and `…/wiki/%09/` returns `title="/"` — which the
+  first version of this step could not see, because its stability rows varied one
+  rejected URL per parser while the bullet above quantified over the branches.
+  The shipped rows cross **every** branch: eighty-one pairs, of which that is the
+  only one that does not hold, and it is excluded by name too. Repairing either was
   declined by the product owner on E5-8's precedent — a test step ships one
   production edit — and, for the id, because the ceiling is a process-global
   interpreter setting rather than anything the parser enforces.

--- a/src/kindly_web_search_mcp_server/content/arxiv.py
+++ b/src/kindly_web_search_mcp_server/content/arxiv.py
@@ -80,7 +80,12 @@ def parse_arxiv_url(url: str) -> str:
         raise ArxivError("URL has no hostname.")
 
     host = host_raw.lower()
-    if not host.endswith("arxiv.org"):
+    # `arxiv.org` itself, or a subdomain of it. Written as an equality plus a
+    # dot-prefixed suffix rather than as a bare `endswith("arxiv.org")`, which
+    # also matched `notarxiv.org` -- registrable by anyone, and answered by this
+    # integration instead of by the universal HTML loader that owns unclaimed
+    # hosts.
+    if host != "arxiv.org" and not host.endswith(".arxiv.org"):
         raise ArxivError(f"Unsupported arXiv host: {host}")
 
     path = parsed.path or ""

--- a/src/kindly_web_search_mcp_server/content/resolver.py
+++ b/src/kindly_web_search_mcp_server/content/resolver.py
@@ -38,9 +38,15 @@ async def resolve_page_content_markdown(
 
     Stage 1: StackExchange API (StackOverflow + stackexchange network).
     Stage 2: GitHub Issue API (GitHub GraphQL).
-    Stage 3: Wikipedia API (MediaWiki Action API).
-    Stage 4: arXiv (Atom API + PDF → Markdown).
-    Stage 5: Universal HTML loader fallback (headless Nodriver).
+    Stage 3: GitHub Discussion API (GitHub GraphQL).
+    Stage 4: Wikipedia API (MediaWiki Action API).
+    Stage 5: arXiv (Atom API + PDF → Markdown).
+    Stage 6: Universal HTML loader fallback (headless Nodriver).
+
+    A stage claims the URL when its parser returns; the body below falls through
+    to the next stage only when the parser raises that stage's **own** error
+    type. Any other exception escapes this function entirely — see section 14 of
+    ``.system_design/TEST_SUITE.md`` for the two inputs that reach it.
     """
     if diagnostics:
         diagnostics.emit("resolver.start", "Resolving URL", {"url": url})

--- a/tests/test_url_parser_identifiers.py
+++ b/tests/test_url_parser_identifiers.py
@@ -47,20 +47,32 @@ five, and ``pytest.raises`` alone is an ``isinstance`` check. That is precisely
 the mis-typing this module exists to catch, so every ``pytest.raises`` here is
 followed by ``assert type(caught.value) is …``.
 
-**Every rejection row also asserts a fragment of the message its branch
-produces, and that is what makes the row count falsifiable.** Each parser has
-between three and seven ``raise`` sites, and a table of rejection URLs that all
-happened to trip the *host* guard would look exactly like coverage of all of
-them. The fragment names which branch the row reached. It is a mild coupling to
-a literal in the source, taken knowingly. No fragment quotes anything but static
-English and the hostname already present in the URL under test.
+**Every row of the twenty-one-branch table also asserts a fragment of the
+message its branch produces, and that is what makes the row count falsifiable.**
+Each parser has between three and seven ``raise`` sites, and a table of rejection
+URLs that all happened to trip the *host* guard would look exactly like coverage
+of all of them. The fragment names which branch the row reached. It is a mild
+coupling to a literal in the source, taken knowingly. No fragment quotes anything
+but static English and the hostname already present in the URL under test.
+
+**The other eighty-four rejection rows assert the class only, and inherit their
+branch attribution rather than restating it.** The eighty surface rows vary a URL
+whose branch the table above already pinned, and the four suffix rows are about
+*which host* is refused rather than which branch refuses it. Scoped here because
+the paragraph above, written as "every rejection row", was an overclaim inside
+this module's own scope — and a reader auditing which claims are self-asserting
+cannot tell the two kinds apart from a sentence that covers both.
 
 The parsers are pure functions of a string, so nothing here reads the clock, the
 network or the environment — with one deliberate exception, the interpreter's
 integer-string conversion ceiling, which **two** fixtures manage and restore.
-Three cases depend on that ceiling and all three take a fixture; a case that
-merely read it would pass or fail on an environment variable nobody in the pull
-request chose.
+**Four** cases depend on it, in **both** directions, and each takes the fixture
+for its direction: three need the documented default restored, and would fail
+under ``PYTHONINTMAXSTRDIGITS=0``; one needs the ceiling *removed*, and would
+fail under the default ambient CI actually runs. Counting only the first three —
+as an earlier draft did — describes the design correctly in one ambient and
+misdescribes it in the other. A case that merely read the setting would pass or
+fail on an environment variable nobody in the pull request chose.
 """
 
 from __future__ import annotations

--- a/tests/test_url_parser_identifiers.py
+++ b/tests/test_url_parser_identifiers.py
@@ -66,13 +66,23 @@ cannot tell the two kinds apart from a sentence that covers both.
 The parsers are pure functions of a string, so nothing here reads the clock, the
 network or the environment — with one deliberate exception, the interpreter's
 integer-string conversion ceiling, which **two** fixtures manage and restore.
-**Four** cases depend on it, in **both** directions, and each takes the fixture
-for its direction: three need the documented default restored, and would fail
-under ``PYTHONINTMAXSTRDIGITS=0``; one needs the ceiling *removed*, and would
-fail under the default ambient CI actually runs. Counting only the first three —
-as an earlier draft did — describes the design correctly in one ambient and
-misdescribes it in the other. A case that merely read the setting would pass or
-fail on an environment variable nobody in the pull request chose.
+**Twelve rows** depend on it, in **both** directions, and each takes the fixture
+for its direction. Measured by stripping the fixtures and running both ambients:
+
+* **Eleven** need the documented default restored, and fail under
+  ``PYTHONINTMAXSTRDIGITS=0`` — the two unconvertible-id rows of the branch
+  table, the **eight** surface rows that vary those two branches, and the
+  oversized-identifier escape case.
+* **One** needs the ceiling *removed*, and fails under the default ambient CI
+  actually runs.
+
+Counted in rows, because every other figure in this module is — "149 cases",
+"the other eighty-four rejection rows". Two earlier drafts said "three", which
+counts *test functions* and silently drops the eight surface rows; both the
+default-ambient direction and the row granularity had to be measured rather than
+reasoned about, and each was wrong the first time. A case that merely read the
+setting would pass or fail on an environment variable nobody in the pull request
+chose.
 """
 
 from __future__ import annotations
@@ -710,7 +720,10 @@ def test_rejection_does_not_depend_on_the_surface_of_the_url(
 
     Args:
         default_int_digits: Fixture pinning the interpreter's integer-string
-            conversion ceiling, for the same two rows the table above needs it.
+            conversion ceiling. **Eight** of this grid's rows need it — the two
+            unconvertible-id branches crossed against all four variations — not
+            the two the branch table needs, which is what an earlier draft of
+            this line said.
         label: The rejection branch's parametrisation id.
         parse: The parser callable.
         error: The class the resolver catches for this parser.

--- a/tests/test_url_parser_identifiers.py
+++ b/tests/test_url_parser_identifiers.py
@@ -1,0 +1,954 @@
+"""Assert what each URL parser returns on its own, and how it declines.
+
+:mod:`~kindly_web_search_mcp_server.content.resolver` routes a URL by offering
+it to five parsers in a fixed order and taking the first that does not raise.
+``tests/test_url_parser_exclusivity.py`` owns the claim that **at most one**
+parser accepts. This module owns the two claims that property is structurally
+blind to, both handed here by that step:
+
+* **Identifier preservation.** A URL composed from known identifiers returns
+  exactly those identifiers — not a neighbouring capture group, not a
+  truncation. Exclusivity is satisfied by a parser that accepts and answers
+  wrongly.
+* **Typed rejection.** A declining parser raises **its own** error class, which
+  is the only class the resolver catches. Exclusivity counts any exception as a
+  non-acceptance, which is the broader reading and the right one for *that*
+  claim; here the type is the claim. A parser raising anything else escapes
+  ``resolve_page_content_markdown`` entirely — the URL never reaches the later
+  stages, and ``get_content`` renders the exception text into the Markdown it
+  hands back to the calling model.
+
+**The typed-rejection claim is scoped to the branches each parser's own guards
+reach, and the scope is load-bearing rather than cautious.** Two inputs escape
+that scope today, both measured, both characterised below rather than repaired:
+a malformed URL raises out of ``urlsplit`` before any guard runs, in **all
+five** parsers, and an over-long StackExchange id raises out of ``int``. §14 of
+``TEST_SUITE.md`` records the class and its follow-up. Stating the domain is
+what keeps the twenty-one rows below from reading as a universal that a
+27-character input falsifies.
+
+**What this module deliberately does not own.** The five per-parser modules
+(``tests/test_arxiv.py`` and its siblings) hold the documented real-world URL
+shapes each integration advertises. **All five** already assert identifier
+preservation for their own parser, and between them they reach five of the
+twenty-one rejection branches — so **eleven** of the mutations this module kills
+are killed there as well. Counting `tests/test_url_parser_exclusivity.py` as
+pre-existing too, which it is, the figure is **thirteen**. Both numbers are
+measured, and both are stated because the sentence is otherwise ambiguous about
+which set "there" means. ``TEST_SUITE.md`` §3.1 attributes each kill to the
+module that produced it rather than letting this one claim them all. Those files
+are **not** edited from here: they belong to the pytest-migration batches, whose
+verify clause is "only the listed files change".
+
+**Every exception assertion compares the exact class, never ``isinstance``.**
+All five error classes subclass :class:`RuntimeError` and nothing else, so they
+are siblings: an ``isinstance`` assertion against one would pass on any of the
+five, and ``pytest.raises`` alone is an ``isinstance`` check. That is precisely
+the mis-typing this module exists to catch, so every ``pytest.raises`` here is
+followed by ``assert type(caught.value) is …``.
+
+**Every rejection row also asserts a fragment of the message its branch
+produces, and that is what makes the row count falsifiable.** Each parser has
+between three and seven ``raise`` sites, and a table of rejection URLs that all
+happened to trip the *host* guard would look exactly like coverage of all of
+them. The fragment names which branch the row reached. It is a mild coupling to
+a literal in the source, taken knowingly. No fragment quotes anything but static
+English and the hostname already present in the URL under test.
+
+The parsers are pure functions of a string, so nothing here reads the clock, the
+network or the environment — with one deliberate exception, the interpreter's
+integer-string conversion ceiling, which **two** fixtures manage and restore.
+Three cases depend on that ceiling and all three take a fixture; a case that
+merely read it would pass or fail on an environment variable nobody in the pull
+request chose.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from kindly_web_search_mcp_server.content import resolver
+from kindly_web_search_mcp_server.content.arxiv import ArxivError, parse_arxiv_url
+from kindly_web_search_mcp_server.content.github_discussions import (
+    GitHubDiscussionError,
+    GitHubDiscussionTarget,
+    parse_github_discussion_url,
+)
+from kindly_web_search_mcp_server.content.github_issues import (
+    GitHubIssueError,
+    GitHubIssueTarget,
+    parse_github_issue_url,
+)
+from kindly_web_search_mcp_server.content.stackexchange import (
+    StackExchangeError,
+    StackExchangeTarget,
+    parse_stackexchange_url,
+)
+from kindly_web_search_mcp_server.content.wikipedia import (
+    WikipediaError,
+    WikipediaTarget,
+    parse_wikipedia_url,
+)
+
+
+@dataclass(frozen=True)
+class ParserCase:
+    """One parser, with a URL it accepts and the answer that URL must produce.
+
+    Attributes:
+        name: The parser's short name, used as the parametrisation id.
+        parse: The parser callable itself.
+        error: The error class this parser raises, and the only one the resolver
+            catches on its behalf.
+        accepted_url: A URL built from the identifiers in ``expected``.
+        expected: The exact value ``parse(accepted_url)`` must return.
+        rejected_url: A URL this parser must decline.
+    """
+
+    name: str
+    parse: Callable[[str], Any]
+    error: type[Exception]
+    accepted_url: str
+    expected: Any
+    rejected_url: str
+
+
+#: One row per parser, in the order the resolver tries them.
+#:
+#: **Every identifier component is pairwise distinct within its row**, which is
+#: what makes a shifted capture-group index observable. A GitHub row built from
+#: ``("x", "x", 1)`` returns the same tuple whichever way the groups are read;
+#: ``octocat`` / ``hello-world`` / ``42`` cannot be permuted into itself.
+#:
+#: Two rows are shaped by a specific mutation rather than by realism:
+#:
+#: * The StackExchange row uses ``es.stackoverflow.com`` so the derived slug is
+#:   ``es.stackoverflow``, two labels rather than one. The branch it reaches is
+#:   the **apex ``.com`` fall-through**, not the ``*.stackexchange.com`` one —
+#:   measured, and worth stating because the obvious reading is the other way
+#:   round. Narrowing that fall-through to a first label makes the slug ``es``
+#:   and fails this row; on ``stackoverflow.com`` the slug is one label already
+#:   and the same mutation would return the same answer.
+#:
+#:   The sibling mutation — narrowing the ``*.stackexchange.com`` branch —
+#:   **survives this module**, because the only host with a two-label prefix
+#:   there is ``math.meta.stackexchange.com``, whose slug is a *characterised
+#:   defect* owned by ``tests/test_url_parser_exclusivity.py``. A row here would
+#:   duplicate that module's claim and break when the defect is fixed.
+#:   ``TEST_SUITE.md`` §3.1 records the survivor and its owner.
+#: * The arXiv row uses the legacy ``hep-th/9901001`` shape. The identifier is
+#:   assembled from ``parts[1:]``, so only a multi-segment identifier can tell
+#:   that from ``parts[1:2]``. ``tests/test_arxiv.py`` already uses one, so this
+#:   row is a second owner of that mutation rather than its only one — measured,
+#:   and recorded that way in ``TEST_SUITE.md`` §3.1 rather than claimed here.
+PARSER_CASES: tuple[ParserCase, ...] = (
+    ParserCase(
+        name="stackexchange",
+        parse=parse_stackexchange_url,
+        error=StackExchangeError,
+        accepted_url="https://es.stackoverflow.com/questions/12345/titulo",
+        expected=StackExchangeTarget(
+            site="es.stackoverflow", question_id=12345, answer_id=None
+        ),
+        rejected_url="https://example.org/questions/12345/titulo",
+    ),
+    ParserCase(
+        name="github_issue",
+        parse=parse_github_issue_url,
+        error=GitHubIssueError,
+        accepted_url="https://github.com/octocat/hello-world/issues/42",
+        expected=GitHubIssueTarget(owner="octocat", repo="hello-world", number=42),
+        rejected_url="https://github.com/octocat/hello-world/pull/42",
+    ),
+    ParserCase(
+        name="github_discussion",
+        parse=parse_github_discussion_url,
+        error=GitHubDiscussionError,
+        accepted_url="https://github.com/octocat/hello-world/discussions/42",
+        expected=GitHubDiscussionTarget(
+            owner="octocat", repo="hello-world", number=42
+        ),
+        rejected_url="https://github.com/octocat/hello-world/issues/42",
+    ),
+    ParserCase(
+        name="wikipedia",
+        parse=parse_wikipedia_url,
+        error=WikipediaError,
+        accepted_url="https://es.wikipedia.org/wiki/Manzana",
+        expected=WikipediaTarget(
+            api_base_url="https://es.wikipedia.org/w/api.php",
+            canonical_url="https://es.wikipedia.org/wiki/Manzana",
+            host="es.wikipedia.org",
+            title="Manzana",
+        ),
+        rejected_url="https://es.wikipedia.org/notwiki/Manzana",
+    ),
+    ParserCase(
+        name="arxiv",
+        parse=parse_arxiv_url,
+        error=ArxivError,
+        accepted_url="https://arxiv.org/abs/hep-th/9901001",
+        expected="hep-th/9901001",
+        rejected_url="https://arxiv.org/other/2401.12345",
+    ),
+)
+
+
+@pytest.mark.parametrize("case", PARSER_CASES, ids=lambda c: c.name)
+def test_a_url_built_from_known_identifiers_returns_exactly_those_identifiers(
+    case: ParserCase,
+) -> None:
+    """Assert the parser returns the identifiers its URL was composed from.
+
+    Whole-value equality rather than field-by-field assertions: the parsers
+    return frozen dataclasses, so one ``==`` covers every field and a field
+    added later cannot slip past this assertion. It still has to be given an
+    expected value in ``PARSER_CASES``, which is the point — the edit is
+    unavoidable rather than optional.
+
+    Args:
+        case: The parser under test and the answer its URL must produce.
+    """
+    assert case.parse(case.accepted_url) == case.expected
+
+
+#: Every ``raise`` site reachable in the five parse functions, one row each —
+#: three StackExchange, three GitHub Issues, three GitHub Discussions, five
+#: Wikipedia, seven arXiv.
+#:
+#: The rows are the behavioural half of "never a foreign class": a mutation that
+#: changes any single ``raise`` in any of the five functions fails exactly one
+#: row. A single rejection URL per parser could not do that — it would leave
+#: between two and six sites in each parser unexercised while reading as full
+#: coverage.
+REJECTION_CASES: tuple[
+    tuple[str, Callable[[str], Any], type[Exception], str, str], ...
+] = (
+    # StackExchange — three sites.
+    (
+        "se_no_host",
+        parse_stackexchange_url,
+        StackExchangeError,
+        "/questions/12345",
+        "no hostname",
+    ),
+    (
+        "se_off_network_host",
+        parse_stackexchange_url,
+        StackExchangeError,
+        "https://example.org/questions/12345",
+        "Unsupported StackExchange host",
+    ),
+    (
+        "se_no_question_or_answer",
+        parse_stackexchange_url,
+        StackExchangeError,
+        "https://stackoverflow.com/users/1/jon-skeet",
+        "not a recognized StackExchange",
+    ),
+    # GitHub Issues — three sites.
+    (
+        "issue_foreign_host",
+        parse_github_issue_url,
+        GitHubIssueError,
+        "https://example.org/octocat/hello-world/issues/42",
+        "Unsupported GitHub host",
+    ),
+    (
+        "issue_wrong_path",
+        parse_github_issue_url,
+        GitHubIssueError,
+        "https://github.com/octocat/hello-world/pull/42",
+        "not a recognized GitHub Issue",
+    ),
+    # The third site is the conversion guard, and it is reachable for the same
+    # reason the StackExchange one is: CPython refuses to build an int from more
+    # than 4300 decimal digits. GitHub's parsers already wrap the conversion,
+    # which is what makes this row a *rejection* here and an escape there.
+    (
+        "issue_unconvertible_number",
+        parse_github_issue_url,
+        GitHubIssueError,
+        "https://github.com/octocat/hello-world/issues/" + "1" * 5000,
+        "Invalid issue number",
+    ),
+    # GitHub Discussions — the same three.
+    (
+        "discussion_foreign_host",
+        parse_github_discussion_url,
+        GitHubDiscussionError,
+        "https://example.org/octocat/hello-world/discussions/42",
+        "Unsupported GitHub host",
+    ),
+    (
+        "discussion_wrong_path",
+        parse_github_discussion_url,
+        GitHubDiscussionError,
+        "https://github.com/octocat/hello-world/issues/42",
+        "not a recognized GitHub Discussion",
+    ),
+    (
+        "discussion_unconvertible_number",
+        parse_github_discussion_url,
+        GitHubDiscussionError,
+        "https://github.com/octocat/hello-world/discussions/" + "1" * 5000,
+        "Invalid discussion number",
+    ),
+    # Wikipedia — five sites.
+    (
+        "wiki_no_host",
+        parse_wikipedia_url,
+        WikipediaError,
+        "/wiki/Manzana",
+        "no hostname",
+    ),
+    (
+        "wiki_foreign_host",
+        parse_wikipedia_url,
+        WikipediaError,
+        "https://example.org/wiki/Manzana",
+        "Unsupported Wikipedia host",
+    ),
+    (
+        "wiki_wrong_path",
+        parse_wikipedia_url,
+        WikipediaError,
+        "https://es.wikipedia.org/notwiki/Manzana",
+        "not a recognized Wikipedia article",
+    ),
+    # `%09` is a tab: it survives `unquote`, is not a space so the underscore
+    # substitution leaves it alone, and `.strip()` then empties it. Any non-space
+    # whitespace does the same -- `%0A`, `%0B`, `%0C`. A space does not: `%20`
+    # becomes an underscore, which `.strip()` keeps. `_WIKI_PATH_RE` requires at
+    # least one character after `/wiki/`, so an empty capture cannot get here.
+    (
+        "wiki_empty_title",
+        parse_wikipedia_url,
+        WikipediaError,
+        "https://es.wikipedia.org/wiki/%09",
+        "Empty article title",
+    ),
+    (
+        "wiki_non_article_namespace",
+        parse_wikipedia_url,
+        WikipediaError,
+        "https://es.wikipedia.org/wiki/Talk:Manzana",
+        "Non-article Wikipedia namespace",
+    ),
+    # arXiv — seven sites.
+    ("arxiv_no_host", parse_arxiv_url, ArxivError, "/abs/2401.12345", "no hostname"),
+    (
+        "arxiv_foreign_host",
+        parse_arxiv_url,
+        ArxivError,
+        "https://example.org/abs/2401.12345",
+        "Unsupported arXiv host",
+    ),
+    ("arxiv_no_path", parse_arxiv_url, ArxivError, "https://arxiv.org", "no path"),
+    (
+        "arxiv_single_segment",
+        parse_arxiv_url,
+        ArxivError,
+        "https://arxiv.org/abs",
+        "not a recognized arXiv paper",
+    ),
+    (
+        "arxiv_wrong_prefix",
+        parse_arxiv_url,
+        ArxivError,
+        "https://arxiv.org/other/2401.12345",
+        "not a recognized arXiv abs/pdf",
+    ),
+    (
+        "arxiv_empty_identifier",
+        parse_arxiv_url,
+        ArxivError,
+        "https://arxiv.org/pdf/.pdf",
+        "Empty arXiv identifier",
+    ),
+    (
+        "arxiv_unrecognized_identifier",
+        parse_arxiv_url,
+        ArxivError,
+        "https://arxiv.org/abs/nope",
+        "Unrecognized arXiv identifier format",
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    ("label", "parse", "error", "url", "fragment"),
+    REJECTION_CASES,
+    ids=[row[0] for row in REJECTION_CASES],
+)
+def test_every_rejection_branch_raises_its_own_error_class(
+    default_int_digits: None,
+    label: str,
+    parse: Callable[[str], Any],
+    error: type[Exception],
+    url: str,
+    fragment: str,
+) -> None:
+    """Assert one ``raise`` site produces the parser's own class, and only it.
+
+    **The whole table takes the conversion-ceiling fixture, not just the two rows
+    that need it.** ``issue_unconvertible_number`` and
+    ``discussion_unconvertible_number`` are the only path to those parsers'
+    third ``raise`` site, and they reach it only because CPython's default
+    ``int_max_str_digits`` is 4300. Measured: under ``PYTHONINTMAXSTRDIGITS=0``
+    and without the fixture, both rows fail with ``DID NOT RAISE`` — so the
+    twenty-one-row claim silently lost two rows on an environment nobody in the
+    pull request chose. Applying the fixture per row would need a second
+    parametrisation axis to carry it; applying it to the table costs one
+    ``sys.set_int_max_str_digits`` call per row and makes every row's meaning
+    independent of the ambient interpreter.
+
+    Args:
+        default_int_digits: Fixture pinning the interpreter's integer-string
+            conversion ceiling to its documented default.
+        label: The row's parametrisation id, naming the branch.
+        parse: The parser callable.
+        error: The class the resolver catches for this parser.
+        url: A URL that reaches exactly the branch ``label`` names.
+        fragment: A substring of that branch's message, which is what
+            distinguishes this row from every other row on the same parser.
+    """
+    with pytest.raises(error) as caught:
+        parse(url)
+
+    assert type(caught.value) is error
+    assert fragment in str(caught.value), (
+        f"{label} was meant to reach the branch whose message contains "
+        f"{fragment!r}, but the parser raised {str(caught.value)!r}. The row is "
+        f"exercising a different branch than it claims, so the site it names is "
+        f"untested."
+    )
+
+
+def test_the_error_classes_asserted_here_are_the_ones_the_resolver_imports() -> None:
+    """Assert this module's error classes are the set the resolver routes on.
+
+    Without this, adding a sixth parser, or renaming an error class, would leave
+    every row above green while the resolver stopped catching what they assert.
+
+    **Imports, not the resolver's body — and that is a decision taken from the
+    sibling module rather than freshly.**
+    ``tests/test_url_parser_exclusivity.py`` records that proving real dispatch
+    means parsing the resolver's body, "a different and more brittle claim",
+    and declines it for the same reason. Re-opening that here would give one
+    question two answers. Import is a deliberate proxy and it catches the
+    realistic mistake, which is a sixth parser arriving with nobody editing
+    this module.
+    """
+    imported = {
+        name for name in vars(resolver) if name.endswith("Error")
+    }
+
+    asserted = {case.error.__name__ for case in PARSER_CASES}
+
+    assert imported == asserted, (
+        f"resolver.py routes on {sorted(imported)}, but this module asserts "
+        f"{sorted(asserted)}. A parser raising a class the resolver does not "
+        f"catch escapes resolve_page_content_markdown entirely."
+    )
+
+
+#: A host that merely *ends with* a parser's accepted domain — every one of them
+#: registrable by anyone.
+#:
+#: The mutual-exclusivity step fixed and pinned exactly this class on the
+#: StackExchange side, and cannot reach the other four: a guard widened into
+#: host space **no second parser claims** produces no overlap, so nothing
+#: accepts a URL twice and the property has nothing to see. Measured before this
+#: module existed — all three of these hosts, and the arXiv one below, passed the
+#: entire gate selection.
+#:
+#: arXiv is the row that needed no mutation. ``parse_arxiv_url`` matched
+#: ``endswith("arxiv.org")`` with no leading dot, so ``notarxiv.org`` was
+#: accepted on ``main`` — a live defect, repaired with this module rather than
+#: a mutant this module kills.
+SUFFIX_NOT_SUBDOMAIN_CASES: tuple[
+    tuple[str, Callable[[str], Any], type[Exception], str], ...
+] = (
+    ("arxiv", parse_arxiv_url, ArxivError, "https://notarxiv.org/abs/2401.12345"),
+    (
+        "wikipedia",
+        parse_wikipedia_url,
+        WikipediaError,
+        "https://notwikipedia.org/wiki/Manzana",
+    ),
+    (
+        "github_issue",
+        parse_github_issue_url,
+        GitHubIssueError,
+        "https://notgithub.com/octocat/hello-world/issues/42",
+    ),
+    (
+        "github_discussion",
+        parse_github_discussion_url,
+        GitHubDiscussionError,
+        "https://notgithub.com/octocat/hello-world/discussions/42",
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    ("label", "parse", "error", "url"),
+    SUFFIX_NOT_SUBDOMAIN_CASES,
+    ids=[row[0] for row in SUFFIX_NOT_SUBDOMAIN_CASES],
+)
+def test_a_host_that_only_ends_with_the_accepted_domain_is_rejected(
+    label: str,
+    parse: Callable[[str], Any],
+    error: type[Exception],
+    url: str,
+) -> None:
+    """Assert a lookalike domain is not claimed by the integration it imitates.
+
+    Args:
+        label: The parser's short name.
+        parse: The parser callable.
+        error: The class it must raise.
+        url: A URL on a host that only ends with the accepted domain.
+    """
+    with pytest.raises(error) as caught:
+        parse(url)
+
+    assert type(caught.value) is error
+
+
+#: The hosts each guard must keep accepting — the control on the test above.
+#:
+#: Without these rows, narrowing a host guard until it rejects everything would
+#: satisfy the suffix cases perfectly. Each parser's rule is written differently
+#: and the rows follow the rule rather than a single phrasing: arXiv accepts the
+#: apex and its subdomains, Wikipedia accepts subdomains only, and both GitHub
+#: parsers accept exactly two hosts. ``export.arxiv.org`` is the row that matters
+#: most — the repair had to keep the apex *and* its subdomains, and an equality
+#: test would have kept only the apex.
+ACCEPTED_HOST_CASES: tuple[tuple[str, Callable[[str], Any], str], ...] = (
+    ("arxiv_apex", parse_arxiv_url, "https://arxiv.org/abs/2401.12345"),
+    ("arxiv_subdomain", parse_arxiv_url, "https://export.arxiv.org/abs/2401.12345"),
+    (
+        "wikipedia_subdomain",
+        parse_wikipedia_url,
+        "https://es.wikipedia.org/wiki/Manzana",
+    ),
+    (
+        "github_apex",
+        parse_github_issue_url,
+        "https://github.com/octocat/hello-world/issues/42",
+    ),
+    (
+        "github_www",
+        parse_github_issue_url,
+        "https://www.github.com/octocat/hello-world/issues/42",
+    ),
+    (
+        "github_discussion_www",
+        parse_github_discussion_url,
+        "https://www.github.com/octocat/hello-world/discussions/42",
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    ("label", "parse", "url"),
+    ACCEPTED_HOST_CASES,
+    ids=[row[0] for row in ACCEPTED_HOST_CASES],
+)
+def test_the_hosts_each_parser_owns_are_still_accepted(
+    label: str, parse: Callable[[str], Any], url: str
+) -> None:
+    """Assert the guard that rejects a lookalike still admits the real thing.
+
+    Args:
+        label: The row's parametrisation id.
+        parse: The parser callable.
+        url: A URL on a host the parser owns.
+    """
+    parse(url)
+
+
+def _with_trailing_slash(url: str) -> str:
+    """Append a slash to a URL's path.
+
+    Args:
+        url: The URL to vary. No URL in this module carries a query string, so
+            appending is enough and no splitting is needed.
+
+    Returns:
+        The same URL with one more slash at the end of its path.
+    """
+    return f"{url}/"
+
+
+def _with_upper_case_scheme(url: str) -> str:
+    """Upper-case a URL's scheme.
+
+    Args:
+        url: The URL to vary.
+
+    Returns:
+        The same URL spelled ``HTTPS://``.
+
+    Raises:
+        AssertionError: When ``url`` is not spelled ``https://``, which would
+            make this variation a silent no-op and the rows using it vacuous.
+    """
+    varied = url.replace("https://", "HTTPS://", 1)
+    assert varied != url, f"{url!r} is not an https URL, so this varies nothing"
+    return varied
+
+
+def _with_a_query(url: str) -> str:
+    """Append two parameters no parser reads.
+
+    Args:
+        url: The URL to vary.
+
+    Returns:
+        The same URL carrying ``utm_source`` before ``ref``.
+    """
+    return f"{url}?utm_source=b&ref=a"
+
+
+def _with_the_query_reversed(url: str) -> str:
+    """Append the same two parameters in the opposite order.
+
+    Args:
+        url: The URL to vary.
+
+    Returns:
+        The same URL carrying ``ref`` before ``utm_source``.
+    """
+    return f"{url}?ref=a&utm_source=b"
+
+
+#: The surface variations §3.1 names, as functions of a URL. Each is a shape a
+#: clipboard produces without anyone meaning anything by it.
+#:
+#: **Query order is two variations, not one, and that is what makes the claim
+#: falsifiable.** A single appended query string tests only that a query is
+#: ignored; order-independence needs both orderings compared against the same
+#: expected answer.
+#:
+#: **The scheme variation has no killing mutation, by construction.** No parser
+#: reads ``parsed.scheme``, and ``urlsplit`` lowercases ``hostname`` regardless
+#: of how the scheme is spelled. It is regression armour, and it is named as such
+#: in ``TEST_SUITE.md`` §3.1 so a mutation report is not read as coverage.
+SURFACE_VARIATIONS: tuple[tuple[str, Callable[[str], str]], ...] = (
+    ("trailing_slash", _with_trailing_slash),
+    ("upper_case_scheme", _with_upper_case_scheme),
+    ("query", _with_a_query),
+    ("query_reversed", _with_the_query_reversed),
+)
+
+
+@pytest.mark.parametrize(
+    ("variation_name", "vary"),
+    SURFACE_VARIATIONS,
+    ids=[name for name, _ in SURFACE_VARIATIONS],
+)
+@pytest.mark.parametrize("case", PARSER_CASES, ids=lambda c: c.name)
+def test_rejection_does_not_depend_on_the_surface_of_the_url(
+    case: ParserCase, variation_name: str, vary: Callable[[str], str]
+) -> None:
+    """Assert a declined URL is declined the same way after a cosmetic change.
+
+    This is the claim §3.1 states — *rejection* is stable. Acceptance stability
+    is asserted separately below, because it does not hold for one parser under
+    one variation, and collapsing the two would mean either overstating the
+    claim or dropping a parser from it entirely.
+
+    Args:
+        case: The parser under test and a URL it declines.
+        variation_name: The variation's parametrisation id.
+        vary: The transform applied to the URL.
+    """
+    with pytest.raises(case.error) as caught:
+        case.parse(vary(case.rejected_url))
+
+    assert type(caught.value) is case.error
+
+
+#: Every (parser, variation) pair whose *acceptance* is invariant — all of them
+#: but one.
+#:
+#: ``("wikipedia", "trailing_slash")`` is excluded because the answer genuinely
+#: changes there, and that is a finding rather than an exemption:
+#: :func:`test_a_trailing_slash_changes_the_wikipedia_title_today` pins what
+#: happens instead. Excluding the pair rather than the parser keeps Wikipedia
+#: under the other three variations, where the claim does hold.
+ACCEPTANCE_SURFACE_ROWS: tuple[
+    tuple[ParserCase, str, Callable[[str], str]], ...
+] = tuple(
+    (case, variation_name, vary)
+    for case in PARSER_CASES
+    for variation_name, vary in SURFACE_VARIATIONS
+    if (case.name, variation_name) != ("wikipedia", "trailing_slash")
+)
+
+
+@pytest.mark.parametrize(
+    ("case", "variation_name", "vary"),
+    ACCEPTANCE_SURFACE_ROWS,
+    ids=[f"{case.name}-{name}" for case, name, _ in ACCEPTANCE_SURFACE_ROWS],
+)
+def test_accepted_identifiers_do_not_depend_on_the_surface_of_the_url(
+    case: ParserCase, variation_name: str, vary: Callable[[str], str]
+) -> None:
+    """Assert a cosmetic change to an accepted URL changes no identifier.
+
+    Args:
+        case: The parser under test and a URL it accepts.
+        variation_name: The variation's parametrisation id.
+        vary: The transform applied to the URL.
+    """
+    assert case.parse(vary(case.accepted_url)) == case.expected
+
+
+def test_a_percent_encoded_arxiv_identifier_is_decoded_before_it_is_matched() -> None:
+    """Assert the path is percent-decoded, which nothing else in the tree pins.
+
+    A legacy arXiv identifier carries a slash — ``hep-th/9901001`` — and a client
+    that percent-encodes path separators sends ``hep-th%2F9901001``. The parser
+    calls :func:`~urllib.parse.unquote` before splitting, so the encoded form
+    reaches the same identifier as the plain one.
+
+    Added because a mutation found the line unowned: with the ``unquote`` call
+    removed, every other case in this module and in all five per-parser modules
+    still passed, and the encoded identifier failed the format check instead of
+    resolving. It is a one-row claim, and it is the only thing holding that call.
+
+    The neighbouring ``.rstrip("/")`` on the same line is a different matter and
+    is **recorded as an equivalent mutant** rather than given a row: the next
+    line filters empty segments out of the split, so the trailing slash is
+    dropped either way. Measured. ``TEST_SUITE.md`` §3.1 carries it so a mutation
+    report has an answer to point at.
+    """
+    assert parse_arxiv_url("https://arxiv.org/abs/hep-th%2F9901001") == "hep-th/9901001"
+
+
+def test_a_trailing_slash_changes_the_wikipedia_title_today() -> None:
+    """Characterise the one parser whose acceptance is not surface-invariant.
+
+    ``_WIKI_PATH_RE`` is ``^/wiki/(.+)$`` and captures greedily, so a trailing
+    slash becomes part of the title. The request that follows asks MediaWiki for
+    ``Manzana/``, which is not the article the URL names, and the canonical URL
+    handed back to the caller carries the slash too.
+
+    **Characterised, not repaired.** §3.1 scopes this step's stability claim to
+    *rejection*; normalising the captured title changes which request the
+    Wikipedia integration issues, which is a behaviour change no step has been
+    asked for. Pinning today's answer is what makes a future correction visible
+    instead of silent — the same treatment ``math.meta.stackexchange.com``
+    already receives in ``tests/test_url_parser_exclusivity.py``. §14 records the
+    gap and names this test as its characterisation.
+    """
+    target = parse_wikipedia_url("https://es.wikipedia.org/wiki/Manzana/")
+
+    assert target.title == "Manzana/"
+    assert target.canonical_url == "https://es.wikipedia.org/wiki/Manzana/"
+
+
+#: A URL `urlsplit` refuses to parse: an unmatched bracket reads as the start of
+#: an IPv6 literal. Twenty-seven characters, and nothing exotic about it — this
+#: is the shape a model produces from a truncated or concatenated link.
+MALFORMED_URL = "https://[oops/abs/2401.12345"
+
+
+@pytest.mark.parametrize(
+    "parse",
+    [case.parse for case in PARSER_CASES],
+    ids=[case.name for case in PARSER_CASES],
+)
+def test_a_malformed_url_escapes_every_parser_as_a_foreign_class_today(
+    parse: Callable[[str], Any],
+) -> None:
+    """Characterise the escape the typed-rejection claim is scoped around.
+
+    ``parsed.hostname`` is read as the first act of every one of the five parse
+    functions, and ``urlsplit`` raises :class:`ValueError` before any guard can
+    run. :class:`ValueError` is not any parser's own class, so
+    ``resolve_page_content_markdown``'s ``except`` clause does not catch it: the
+    URL never reaches the later stages, and ``get_content`` renders the
+    exception's text into the Markdown it returns to the calling model.
+
+    **This asserts today's wrong answer on purpose.** The repair is one guard
+    per parser, five modules, and this step ships one production edit — the same
+    scoping the search-provider error-path step recorded when it found a
+    credential leak it was not scoped to fix. ``TEST_SUITE.md`` §14 carries the
+    gap and its follow-up. When the repair lands, this test fails and points at
+    the decision instead of letting the change go unnoticed.
+
+    Args:
+        parse: One of the five parser callables.
+    """
+    with pytest.raises(ValueError) as caught:
+        parse(MALFORMED_URL)
+
+    assert type(caught.value) is ValueError
+
+
+@pytest.fixture
+def unbounded_int_digits() -> Iterator[None]:
+    """Remove the interpreter's integer-string conversion limit for one test.
+
+    The 4300-digit default is **process-global and settable from outside the
+    process** — ``PYTHONINTMAXSTRDIGITS``, ``-X int_max_str_digits`` and
+    :func:`sys.set_int_max_str_digits` all move it. A case that merely reads it
+    is therefore not deterministic: under ``PYTHONINTMAXSTRDIGITS=0`` the
+    conversion below succeeds and the case asserting an exception fails, on an
+    environment nobody in the pull request chose.
+
+    So the pair of cases sets the limit rather than reading it: one restores the
+    documented default and asserts the escape, the other removes the limit and
+    asserts what happens instead. Between them they say the honest thing — the
+    parser has **no bound of its own**.
+
+    Yields:
+        ``None``; the previous limit is restored on teardown.
+    """
+    previous = sys.get_int_max_str_digits()
+    sys.set_int_max_str_digits(0)
+    try:
+        yield
+    finally:
+        sys.set_int_max_str_digits(previous)
+
+
+@pytest.fixture
+def default_int_digits() -> Iterator[None]:
+    """Pin the interpreter's integer-string conversion limit to CPython's default.
+
+    See :func:`unbounded_int_digits` for why the limit is set rather than read.
+
+    Yields:
+        ``None``; the previous limit is restored on teardown.
+    """
+    previous = sys.get_int_max_str_digits()
+    sys.set_int_max_str_digits(sys.int_info.default_max_str_digits)
+    try:
+        yield
+    finally:
+        sys.set_int_max_str_digits(previous)
+
+
+#: A StackExchange question id of five thousand digits — over CPython's default
+#: conversion ceiling, and matched by ``_QUESTION_RE`` like any other run of
+#: digits.
+OVERSIZED_ID_URL = "https://stackoverflow.com/q/" + "1" * 5000
+
+
+def test_an_oversized_stackexchange_id_escapes_as_a_foreign_class_today(
+    default_int_digits: None,
+) -> None:
+    """Characterise the second escape: an id ``int`` refuses to build.
+
+    ``parse_stackexchange_url`` converts the matched id with a bare ``int``,
+    unlike both GitHub parsers, which wrap theirs. Over the interpreter's
+    conversion ceiling that raises :class:`ValueError` — again a class the
+    resolver does not catch, so the URL never reaches the later stages.
+
+    Characterised rather than repaired, for the reason
+    :func:`test_a_malformed_url_escapes_every_parser_as_a_foreign_class_today`
+    gives, and for one more that is specific to this input: see
+    :func:`test_the_parser_has_no_bound_of_its_own_on_the_id_length`.
+
+    Args:
+        default_int_digits: Fixture pinning the conversion ceiling.
+    """
+    with pytest.raises(ValueError) as caught:
+        parse_stackexchange_url(OVERSIZED_ID_URL)
+
+    assert type(caught.value) is ValueError
+
+
+def test_the_parser_has_no_bound_of_its_own_on_the_id_length(
+    unbounded_int_digits: None,
+) -> None:
+    """Assert the ceiling above is the interpreter's, not the parser's.
+
+    This is what makes the "wrap the conversion" repair insufficient rather than
+    merely out of scope. With the interpreter's limit removed the parser accepts
+    the id and would forward five thousand digits to the Stack Exchange API, so
+    a ``try``/``except`` around the conversion would guard the *symptom* on
+    default-configured interpreters and nothing at all elsewhere.
+
+    Recorded in ``TEST_SUITE.md`` §14 with the follow-up that owns the decision.
+
+    Args:
+        unbounded_int_digits: Fixture removing the conversion ceiling.
+    """
+    target = parse_stackexchange_url(OVERSIZED_ID_URL)
+
+    assert target.site == "stackoverflow"
+    assert len(str(target.question_id)) == 5000
+
+
+def test_a_short_question_link_is_read_as_a_question() -> None:
+    """Assert ``/q/<id>`` resolves to a question id, not to nothing.
+
+    Stack Exchange's own share dialog produces this form, so it is the shape a
+    user is most likely to paste. ``_QUESTION_RE`` accepts ``questions`` or
+    ``q``; nothing pinned the second alternative before this test, and dropping
+    it left the whole gate selection green while every shared link stopped
+    resolving.
+    """
+    target = parse_stackexchange_url("https://es.stackoverflow.com/q/12345")
+
+    assert target == StackExchangeTarget(
+        site="es.stackoverflow", question_id=12345, answer_id=None
+    )
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        (
+            "https://stackoverflow.com/beta/questions/12345",
+            StackExchangeTarget(
+                site="stackoverflow", question_id=12345, answer_id=None
+            ),
+        ),
+        (
+            "https://stackoverflow.com/beta/a/54321",
+            StackExchangeTarget(
+                site="stackoverflow", question_id=None, answer_id=54321
+            ),
+        ),
+    ],
+    ids=["question_marker", "answer_marker"],
+)
+def test_a_marker_below_the_root_of_the_path_is_still_read(
+    url: str, expected: StackExchangeTarget
+) -> None:
+    """Characterise the unanchored search both StackExchange patterns perform.
+
+    **This pins today's behaviour; it does not endorse it, and the URLs are
+    synthetic.** ``TEST_SUITE.md`` §3.1 records that the claim these markers
+    "appear mid-path on real URLs" had no citation and no URL anyone could
+    produce on an allowlisted host — the closest candidate lives on
+    ``stackoverflowteams.com``, which the allowlist rejects. Nothing is known to
+    need this form.
+
+    The same section keeps anchoring open as a future option, so the value here
+    is regression visibility rather than a promise: changing either ``search`` to
+    ``match`` narrows what the tool resolves, and before this test it was
+    invisible. **A step that anchors these patterns is expected to delete these
+    two rows**, not to work around them.
+
+    Args:
+        url: A URL whose marker is not the first path segment.
+        expected: The target the parser produces for it today.
+    """
+    assert parse_stackexchange_url(url) == expected

--- a/tests/test_url_parser_identifiers.py
+++ b/tests/test_url_parser_identifiers.py
@@ -25,7 +25,7 @@ a malformed URL raises out of ``urlsplit`` before any guard runs, in **all
 five** parsers, and an over-long StackExchange id raises out of ``int``. §14 of
 ``TEST_SUITE.md`` records the class and its follow-up. Stating the domain is
 what keeps the twenty-one rows below from reading as a universal that a
-27-character input falsifies.
+28-character input falsifies.
 
 **What this module deliberately does not own.** The five per-parser modules
 (``tests/test_arxiv.py`` and its siblings) hold the documented real-world URL
@@ -110,7 +110,6 @@ class ParserCase:
             catches on its behalf.
         accepted_url: A URL built from the identifiers in ``expected``.
         expected: The exact value ``parse(accepted_url)`` must return.
-        rejected_url: A URL this parser must decline.
     """
 
     name: str
@@ -118,7 +117,6 @@ class ParserCase:
     error: type[Exception]
     accepted_url: str
     expected: Any
-    rejected_url: str
 
 
 #: One row per parser, in the order the resolver tries them.
@@ -158,7 +156,6 @@ PARSER_CASES: tuple[ParserCase, ...] = (
         expected=StackExchangeTarget(
             site="es.stackoverflow", question_id=12345, answer_id=None
         ),
-        rejected_url="https://example.org/questions/12345/titulo",
     ),
     ParserCase(
         name="github_issue",
@@ -166,7 +163,6 @@ PARSER_CASES: tuple[ParserCase, ...] = (
         error=GitHubIssueError,
         accepted_url="https://github.com/octocat/hello-world/issues/42",
         expected=GitHubIssueTarget(owner="octocat", repo="hello-world", number=42),
-        rejected_url="https://github.com/octocat/hello-world/pull/42",
     ),
     ParserCase(
         name="github_discussion",
@@ -176,7 +172,6 @@ PARSER_CASES: tuple[ParserCase, ...] = (
         expected=GitHubDiscussionTarget(
             owner="octocat", repo="hello-world", number=42
         ),
-        rejected_url="https://github.com/octocat/hello-world/issues/42",
     ),
     ParserCase(
         name="wikipedia",
@@ -189,7 +184,6 @@ PARSER_CASES: tuple[ParserCase, ...] = (
             host="es.wikipedia.org",
             title="Manzana",
         ),
-        rejected_url="https://es.wikipedia.org/notwiki/Manzana",
     ),
     ParserCase(
         name="arxiv",
@@ -197,7 +191,6 @@ PARSER_CASES: tuple[ParserCase, ...] = (
         error=ArxivError,
         accepted_url="https://arxiv.org/abs/hep-th/9901001",
         expected="hep-th/9901001",
-        rejected_url="https://arxiv.org/other/2401.12345",
     ),
 )
 
@@ -653,31 +646,99 @@ SURFACE_VARIATIONS: tuple[tuple[str, Callable[[str], str]], ...] = (
 )
 
 
-@pytest.mark.parametrize(
-    ("variation_name", "vary"),
-    SURFACE_VARIATIONS,
-    ids=[name for name, _ in SURFACE_VARIATIONS],
+#: Every (rejection branch, variation) pair, minus the pairs that cannot exist
+#: and the one that does not hold.
+#:
+#: **This runs over all twenty-one branches, not over one rejected URL per
+#: parser, and the difference is not cosmetic.** An earlier version varied five
+#: URLs — one per parser — and §3.1's claim was written as though it covered the
+#: branches. Eighty-one pairs exist and exactly one fails; varying five of them
+#: could not see it, and the automated review is what found the gap.
+#:
+#: Two exclusions, and they are different in kind:
+#:
+#: * The three relative-URL rows carry no scheme, so there is nothing for the
+#:   scheme variation to vary. Arithmetic, not an exemption — 21 x 4 - 3 = 81.
+#: * ``("wiki_empty_title", "trailing_slash")`` **flips from rejection to
+#:   acceptance**, and is excluded by name with
+#:   :func:`test_a_trailing_slash_turns_the_empty_wikipedia_title_into_a_slash`
+#:   pinning what happens instead.
+REJECTION_SURFACE_ROWS: tuple[
+    tuple[str, Callable[[str], Any], type[Exception], str, str, Callable[[str], str]],
+    ...
+] = tuple(
+    (label, parse, error, url, variation_name, vary)
+    for label, parse, error, url, _fragment in REJECTION_CASES
+    for variation_name, vary in SURFACE_VARIATIONS
+    if not (variation_name == "upper_case_scheme" and not url.startswith("https://"))
+    and (label, variation_name) != ("wiki_empty_title", "trailing_slash")
 )
-@pytest.mark.parametrize("case", PARSER_CASES, ids=lambda c: c.name)
+
+
+@pytest.mark.parametrize(
+    ("label", "parse", "error", "url", "variation_name", "vary"),
+    REJECTION_SURFACE_ROWS,
+    ids=[f"{label}-{name}" for label, _, _, _, name, _ in REJECTION_SURFACE_ROWS],
+)
 def test_rejection_does_not_depend_on_the_surface_of_the_url(
-    case: ParserCase, variation_name: str, vary: Callable[[str], str]
+    default_int_digits: None,
+    label: str,
+    parse: Callable[[str], Any],
+    error: type[Exception],
+    url: str,
+    variation_name: str,
+    vary: Callable[[str], str],
 ) -> None:
     """Assert a declined URL is declined the same way after a cosmetic change.
 
-    This is the claim §3.1 states — *rejection* is stable. Acceptance stability
-    is asserted separately below, because it does not hold for one parser under
-    one variation, and collapsing the two would mean either overstating the
-    claim or dropping a parser from it entirely.
+    This is the claim §3.1 states — *rejection* is stable — and it is asserted
+    over every branch the claim quantifies over rather than over one URL per
+    parser. Acceptance stability is asserted separately below, because it holds
+    for fewer pairs and saying so is the honest shape.
 
     Args:
-        case: The parser under test and a URL it declines.
+        default_int_digits: Fixture pinning the interpreter's integer-string
+            conversion ceiling, for the same two rows the table above needs it.
+        label: The rejection branch's parametrisation id.
+        parse: The parser callable.
+        error: The class the resolver catches for this parser.
+        url: The branch's URL, before the variation.
         variation_name: The variation's parametrisation id.
         vary: The transform applied to the URL.
     """
-    with pytest.raises(case.error) as caught:
-        case.parse(vary(case.rejected_url))
+    with pytest.raises(error) as caught:
+        parse(vary(url))
 
-    assert type(caught.value) is case.error
+    assert type(caught.value) is error
+
+
+def test_a_trailing_slash_turns_the_empty_wikipedia_title_into_a_slash() -> None:
+    """Characterise the one rejection that a cosmetic change turns into a claim.
+
+    ``https://es.wikipedia.org/wiki/%09`` is declined — the tab survives
+    ``unquote``, is not a space so the underscore substitution leaves it, and
+    ``.strip()`` empties it. Append a slash and the greedy capture takes
+    ``%09/``, which unquotes to ``"\t/"`` and strips to ``"/"`` — not empty, not
+    a namespace prefix. So the parser **returns**, and the URL is claimed by the
+    Wikipedia integration instead of declining to the universal loader.
+
+    Same root cause as
+    :func:`test_a_trailing_slash_changes_the_wikipedia_title_today` — a greedy
+    ``_WIKI_PATH_RE`` capture normalised too late — and the same treatment:
+    characterised, not repaired, and recorded in ``TEST_SUITE.md`` §14 with the
+    ticket that owns the decision. This one is the worse half of the pair,
+    because it changes *whether* the parser accepts rather than only *what* it
+    returns, and it is the only one of eighty-one (branch, variation) pairs that
+    does not hold.
+
+    Found by the automated review on the pull request, after a version of this
+    module that varied one rejected URL per parser and a §3.1 sentence that read
+    as though it covered all twenty-one branches.
+    """
+    target = parse_wikipedia_url("https://es.wikipedia.org/wiki/%09/")
+
+    assert target.title == "/"
+    assert target.canonical_url == "https://es.wikipedia.org/wiki//"
 
 
 #: Every (parser, variation) pair whose *acceptance* is invariant — all of them
@@ -761,7 +822,7 @@ def test_a_trailing_slash_changes_the_wikipedia_title_today() -> None:
 
 
 #: A URL `urlsplit` refuses to parse: an unmatched bracket reads as the start of
-#: an IPv6 literal. Twenty-seven characters, and nothing exotic about it — this
+#: an IPv6 literal. Twenty-eight characters, and nothing exotic about it — this
 #: is the shape a model produces from a truncated or concatenated link.
 MALFORMED_URL = "https://[oops/abs/2401.12345"
 


### PR DESCRIPTION
Plan step **E5-2** · [KMCP-50](https://shelpuk.atlassian.net/browse/KMCP-50)

## Context for the Product Owner

The `get_content` tool turns a URL into clean Markdown for a model. It does that
by offering the URL to five specialist handlers in a fixed order — Stack
Exchange, GitHub Issues, GitHub Discussions, Wikipedia, arXiv — and using the
first one that says "that URL is mine." Whichever handler claims it decides which
API we call and what the user gets back.

The previous ticket proved no URL is ever claimed by **two** handlers. This one
covers what that proof cannot see: whether a handler that claims a URL returns
the **right** identifiers, and whether a handler that declines does so in the one
way the router knows how to catch. A handler that declines the wrong way stops
the URL dead — it never reaches the remaining handlers or the general web-page
loader, and the model gets a raw Python error message instead of a page.

**What changes for a user of this server:**

- **A lookalike domain no longer gets an arXiv answer.** `notarxiv.org` — which
  anyone can register — was being claimed by the arXiv handler, because the
  domain check matched any host merely *ending* in `arxiv.org`. Such hosts now
  fall through to the general web-page loader. `arxiv.org` and every real
  subdomain, `export.arxiv.org` included, are unaffected.
- **Nothing else changes behaviour.** Everything else in this PR is tests and
  written record.

**Two defects found and deliberately not fixed here**, on the decision that a
test step ships one production edit — the same call the search-provider step made
when it found a credential leak outside its scope. Both are recorded in the
design's open-gaps section with the evidence, and both are pinned by tests so
they cannot change unnoticed:

1. **A malformed URL stops all five handlers.** A 28-character URL with an
   unmatched bracket makes Python's URL parser throw before any handler's own
   checks run, in every one of the five. The model sees
   `Failed to retrieve page content: ValueError: Invalid IPv6 URL`. Deciding
   where the guard belongs — five handlers, or one place in the router, which
   would also swallow genuine handler bugs — needs an owner.
2. **A trailing slash breaks a Wikipedia lookup**, and in one case changes
   whether the handler claims the URL at all. `…/wiki/Manzana/` resolves to the
   article title `Manzana/`, so we query Wikipedia for an article that does not
   exist; and `…/wiki/%09`, which is correctly *declined*, becomes *accepted*
   with the title `/` once a slash is appended.

## What landed

`tests/test_url_parser_identifiers.py` — 149 table-driven cases covering
identifier preservation, all 21 rejection branches across the five parsers, the
suffix-is-not-subdomain rejection handed over by E5-1, and stability of both
answers under four surface variations (trailing slash, scheme case, and query
parameters in both orders). The rejection half is crossed against **every**
branch — 81 (branch, variation) pairs — not one URL per parser.

One production edit: `arxiv.py`'s host guard, `endswith("arxiv.org")` →
`host != "arxiv.org" and not host.endswith(".arxiv.org")`.

## Evidence

**Thirty-nine mutations**, applied one at a time from a pristine copy held
outside the working tree. **37 killed here, 1 killed only by
`test_url_parser_exclusivity.py`, 1 equivalent.**

Six of them survived the **entire gate selection** on `main` before this PR —
858 passed on every run — and each now fails a named row:

| Mutation | Before | Now |
|---|---|---|
| `wikipedia.py` `.wikipedia.org` → bare suffix | survives | killed |
| `github_issues.py` host set → suffix test | survives | killed |
| `github_discussions.py` host set → suffix test | survives | killed |
| `_QUESTION_RE.search` → `.match` | survives | killed |
| `_ANSWER_RE.search` → `.match` | survives | killed |
| `_QUESTION_RE` loses its `q` alternative | survives | killed |

`notarxiv.org` needed no mutation — it was accepted on `main`.

**13 of the 37 kills are shared with tests that already existed** (11 with the
five per-parser modules, 2 with the exclusivity module, one counted in both).
That split is in the design record so the future mutation-testing step does not
credit this module with work `test_github_issues.py` was already doing.

**One survivor and one equivalent are recorded rather than hidden**, both with
their reasons, so a mutation report has something to point at.

Full gate selection on this branch: **1007 passed, 2 skipped, 1009 collected.**
The module also passes 149/149 under `PYTHONINTMAXSTRDIGITS=0`, which is not
incidental — see below.

## Review findings already addressed

A `system-design-reviewer` pass and a `code-reviewer` pass ran before this PR
opened. Three findings changed the work materially:

- The reviewer measured that **two of my rejection tests silently depended on a
  process-global Python setting**. Under `PYTHONINTMAXSTRDIGITS=0` they stopped
  testing anything and the suite went red for a reason nobody chose. Both now
  take a fixture that sets and restores the ceiling.
- **My Stack Exchange row reaches a different branch than I had documented**, and
  the mutation I claimed it killed actually survives. Corrected in the test, the
  spec and the design record, and recorded as a named survivor with its owner
  rather than closed by a row that would duplicate another module's claim.
- The typed-rejection claim was written as a universal; **one 28-character input
  falsifies it in all five parsers**. It is now scoped to the branches each
  parser's own guards reach, with the escape characterised and filed.

The automated review on this PR then found two more, both fixed in `e6c37fc`:

- **The stability rows covered 5 of the 21 rejection branches** while the design
  sentence read as though they covered all of them. Widened rather than narrowed
  — and measuring the full grid first turned up the `%09` flip above, which five
  rows could never have seen.
- **The malformed URL is 28 characters, not 27**, repeated in four places that
  each called the figure measured. Corrected against `len`.

## Also in this PR, named so neither reads as scope creep

- **`resolver.py`'s docstring listed five stages where there are six**, and
  omitted GitHub Discussions entirely. Verified against `main` before changing
  it. Corrected, in the function this step re-establishes the ordering of.
- **`.github/review/rules/python-tests.md` said "Fifteen tests"** above a table
  of sixteen rows — a row was added without bumping the count. Pre-existing, not
  from this ticket; corrected because a wrong count in a merge-gating rules file
  is cheap to fix and confusing to leave.

## The collection floor

`--min-selected` was **787** and the selection is now 1009 — the floor had 161
tests of unnoticed slack from concurrent merges before this branch added any.
Read from this branch's run and updated in both live copies. The third occurrence of `787` in that file is a
historical timing measurement taken on other hardware; it is marked as such
rather than overwritten with a number nobody measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H2WVNiG3yzp2QkJo4w9b9c


[KMCP-50]: https://shelpuk.atlassian.net/browse/KMCP-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ