### PR TITLE
Name section 14 as the owner, now that the follow-up tickets are withdrawn

### DIFF
--- a/tests/test_url_parser_identifiers.py
+++ b/tests/test_url_parser_identifiers.py
@@ -22,9 +22,9 @@ blind to, both handed here by that step:
 reach, and the scope is load-bearing rather than cautious.** Two inputs escape
 that scope today, both measured, both characterised below rather than repaired:
 a malformed URL raises out of ``urlsplit`` before any guard runs, in **all
-five** parsers, and an over-long StackExchange id raises out of ``int``. §14 of
-``TEST_SUITE.md`` §14 records the class, and is its only owner. Stating the domain is
-what keeps the twenty-one rows below from reading as a universal that a
+five** parsers, and an over-long StackExchange id raises out of ``int``.
+``TEST_SUITE.md`` §14 records the class, and is its only owner. Stating the
+domain is what keeps the twenty-one rows below from reading as a universal that a
 28-character input falsifies.
 
 **What this module deliberately does not own.** The five per-parser modules

--- a/tests/test_url_parser_identifiers.py
+++ b/tests/test_url_parser_identifiers.py
@@ -23,7 +23,7 @@ reach, and the scope is load-bearing rather than cautious.** Two inputs escape
 that scope today, both measured, both characterised below rather than repaired:
 a malformed URL raises out of ``urlsplit`` before any guard runs, in **all
 five** parsers, and an over-long StackExchange id raises out of ``int``. §14 of
-``TEST_SUITE.md`` records the class and its follow-up. Stating the domain is
+``TEST_SUITE.md`` §14 records the class, and is its only owner. Stating the domain is
 what keeps the twenty-one rows below from reading as a universal that a
 28-character input falsifies.
 
@@ -750,8 +750,8 @@ def test_a_trailing_slash_turns_the_empty_wikipedia_title_into_a_slash() -> None
     Same root cause as
     :func:`test_a_trailing_slash_changes_the_wikipedia_title_today` — a greedy
     ``_WIKI_PATH_RE`` capture normalised too late — and the same treatment:
-    characterised, not repaired, and recorded in ``TEST_SUITE.md`` §14 with the
-    ticket that owns the decision. This one is the worse half of the pair,
+    characterised, not repaired, and recorded in ``TEST_SUITE.md`` §14, which is
+    where the decision lives. This one is the worse half of the pair,
     because it changes *whether* the parser accepts rather than only *what* it
     returns, and it is the only one of eighty-one (branch, variation) pairs that
     does not hold.
@@ -873,8 +873,10 @@ def test_a_malformed_url_escapes_every_parser_as_a_foreign_class_today(
     per parser, five modules, and this step ships one production edit — the same
     scoping the search-provider error-path step recorded when it found a
     credential leak it was not scoped to fix. ``TEST_SUITE.md`` §14 carries the
-    gap and its follow-up. When the repair lands, this test fails and points at
-    the decision instead of letting the change go unnoticed.
+    gap, and carries it alone — the tracker issue raised alongside it was
+    withdrawn as sub-threshold, so §14 is the record, not a pointer to one. When
+    the repair lands, this test fails and points at the decision instead of
+    letting the change go unnoticed.
 
     Args:
         parse: One of the five parser callables.
@@ -970,7 +972,7 @@ def test_the_parser_has_no_bound_of_its_own_on_the_id_length(
     a ``try``/``except`` around the conversion would guard the *symptom* on
     default-configured interpreters and nothing at all elsewhere.
 
-    Recorded in ``TEST_SUITE.md`` §14 with the follow-up that owns the decision.
+    Recorded in ``TEST_SUITE.md`` §14, which owns the decision.
 
     Args:
         unbounded_int_digits: Fixture removing the conversion ceiling.


### PR DESCRIPTION
Follow-up to #88, and a direct consequence of a backlog decision taken after it merged.

## Context for the Product Owner

#88 recorded two defects it deliberately did **not** repair, and filed a tracker issue for each. Both have since been assessed as below the bar for a standalone ticket and withdrawn for deletion — the reasoning is on the issues themselves.

That leaves a small honesty problem in the code. The test module told its reader, in four places, that "its follow-up" or "the ticket that owns the decision" existed. Once those issues are gone, that is a promise pointing at nothing — and this repository has already been bitten once by a citation that could not be resolved from a clean checkout.

**Nothing about the defects changes.** They are still characterised, still pinned by five tests, and still fully described in `.system_design/TEST_SUITE.md` §14 — mechanism, measurements, and what a future fix should check. This PR only corrects who the record's *owner* is.

## What changed

Four docstrings in `tests/test_url_parser_identifiers.py`. §14 is now named as the record rather than as a pointer to one — which was always the durable half: it is committed, it is what the mutation-testing step reads, and unlike a ticket it cannot be deleted out from under a citation.

## Scope

Docstrings only. No test added, removed or renamed.

- `tests/test_url_parser_identifiers.py`: 149 passed (unchanged).
- Full gate selection: **1051 passed, 2 skipped, 1053 collected**.
- `--min-selected` deliberately **not** touched. The workflow attaches that update to a pull request that adds to or removes from the selection; this one does neither, and 1009 still holds against 1053.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H2WVNiG3yzp2QkJo4w9b9c
